### PR TITLE
Fix behavior if many unreliable workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,7 +2408,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "network-scheduler"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-scheduler"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
If there are not enough reliable workers, we should just ignore reliability and schedule to all existing workers