### PR TITLE
Version-Restricted Datasets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,7 +2425,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "network-scheduler"
-version = "3.6.6"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tools/compare_fb"]
 
 [package]
 name = "network-scheduler"
-version = "3.6.6"
+version = "3.7.0"
 edition = "2024"
 
 [dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,7 +149,7 @@ pub struct Config {
     /// This option can be used purely for local development to create http schemes
     /// with subdomain moved to the path-based routing
     #[serde(default)]
-    pub storage_allow_insecure_scheme: bool 
+    pub storage_allow_insecure_scheme: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -159,6 +159,11 @@ pub struct DatasetSegmentConfig {
 
     #[serde(default = "default_weight")]
     pub weight: ChunkWeight,
+
+    /// Minimum worker version required to serve chunks in this segment.
+    /// Workers with a version lower than this will not be assigned chunks from this segment.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub minimum_worker_version: Option<Version>,
 }
 
 impl Config {
@@ -177,6 +182,7 @@ impl Config {
                 ds.push(DatasetSegmentConfig {
                     from: 0,
                     weight: default_weight(),
+                    minimum_worker_version: None,
                 });
             }
         }

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -92,11 +92,12 @@ impl ClickhouseClient {
                     continue;
                 }
             };
+            let parsed_version = Version::from_str(&row.version).ok();
             let mut status = WorkerStatus::Online;
             if row.stored_bytes < stale_threshold {
                 status = WorkerStatus::Stale;
             }
-            if !Version::from_str(&row.version).is_ok_and(|ver| ver >= *min_version) {
+            if !parsed_version.as_ref().is_some_and(|ver| ver >= min_version) {
                 status = WorkerStatus::UnsupportedVersion;
             }
             if row.timestamp < inactive_threshold {
@@ -105,6 +106,7 @@ impl ClickhouseClient {
             results.push(Worker {
                 id: peer_id,
                 status,
+                version: parsed_version,
             });
         }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 
 use crate::{
     cli, clickhouse,
-    scheduling::{self, WeightedChunk},
+    scheduling::{self, ScheduledChunk},
     storage,
     types::{self, FbVersion},
     upload, weight,
@@ -195,7 +195,7 @@ impl WithChunks {
         Ok(self)
     }
 
-    pub fn weight_chunks(self) -> WithWeightedChunks {
+    pub fn prepare_chunks(self) -> WithScheduledChunks {
         let datasets_num = self.chunks.len();
 
         let mut datasets = Vec::with_capacity(datasets_num);
@@ -220,31 +220,31 @@ impl WithChunks {
             flat_chunks.len()
         );
 
-        let (weighted_chunks, filtered_chunks) =
-            weight::weight_chunks(flat_chunks, &self.config.datasets);
+        let (scheduled_chunks, filtered_chunks) =
+            weight::prepare_chunks(flat_chunks, &self.config.datasets);
 
-        WithWeightedChunks {
+        WithScheduledChunks {
             config: self.config,
             workers: self.workers,
             datasets,
             chunks: filtered_chunks,
-            weighted_chunks,
+            scheduled_chunks,
         }
     }
 }
 
-pub struct WithWeightedChunks {
+pub struct WithScheduledChunks {
     config: cli::Config,
     workers: Vec<types::Worker>,
     datasets: Vec<types::Dataset>,
     chunks: Vec<types::Chunk>,
-    weighted_chunks: Vec<WeightedChunk>,
+    scheduled_chunks: Vec<ScheduledChunk>,
 }
 
-impl WithWeightedChunks {
+impl WithScheduledChunks {
     pub fn schedule(self) -> anyhow::Result<WithAssignment> {
         let assignment = scheduling::schedule(
-            &self.weighted_chunks,
+            &self.scheduled_chunks,
             &self.workers,
             scheduling::SchedulingConfig {
                 worker_capacity: self.config.worker_storage_bytes,

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ async fn run_prod_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<
         .await?
         .load_new_chunks(Some(&db), &datasets_storage, CacheAccess::ReadWrite)
         .await?
-        .weight_chunks()
+        .prepare_chunks()
         // blocking the async executor is ok here because no other tasks are running
         .schedule()
 }
@@ -89,7 +89,7 @@ async fn run_cli_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<W
         .load_known_chunks_from_config(known_chunks)?
         .load_new_chunks(None, &datasets_storage, CacheAccess::_ReadOnly)
         .await?
-        .weight_chunks()
+        .prepare_chunks()
         // blocking the async executor is ok here because no other tasks are running
         .schedule()
 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -70,8 +70,7 @@ pub fn schedule(
         chunks.len(),
         reliable_workers
     );
-    let mut reliable =
-        schedule_to_workers(chunks, &sorted_workers[..reliable_workers], &config)?;
+    let mut reliable = schedule_to_workers(chunks, &sorted_workers[..reliable_workers], &config)?;
 
     if reliable_workers == workers.len() {
         return Ok(reliable);
@@ -160,11 +159,13 @@ fn distribute(
     let mut orderings = hash_chunks(chunks, &rings);
     // Assign version-restricted chunks first so they get priority on eligible
     // workers' capacity before unrestricted chunks fill it. Without this,
-    // the non-deterministic ordering from parallel collection could cause
-    // restricted chunks to arrive after eligible workers are full, leading
-    // to a panic even when total capacity would suffice.
+    // unrestricted chunks (ordered by hash ring position only) could fill
+    // eligible workers' capacity before restricted chunks are processed,
+    // causing a panic even when total capacity would suffice.
     orderings.sort_by_key(|(chunk_index, _, _)| {
-        chunks[*chunk_index as usize].minimum_worker_version.is_none()
+        chunks[*chunk_index as usize]
+            .minimum_worker_version
+            .is_none()
     });
     assign_chunks(orderings, chunks, workers, rings, worker_capacity)
 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -19,16 +19,6 @@ type RingIndex = u16;
 
 const N_RINGS: usize = 6000;
 
-/// Maximum fraction of a worker's capacity that can be used for
-/// version-restricted chunks. This prevents eligible workers from being
-/// overloaded with restricted data, which would cause large reassignments
-/// when more workers upgrade. At 0.2, the worst-case reassignment when
-/// the eligible pool doubles is 10% of worker capacity.
-///
-/// The versioned data fraction must satisfy: f ≤ 0.2 * E / (N * s),
-/// where E = eligible workers, N = total workers, s = saturation.
-const MAX_VERSION_RESTRICTED_RATIO: f64 = 0.2;
-
 #[derive(Debug, Clone)]
 pub struct SchedulingConfig {
     pub worker_capacity: u64,
@@ -116,6 +106,8 @@ fn schedule_to_workers(
         workers.len() as u16,
     )?;
 
+    validate_version_restrictions(chunks, workers, config, &mapping);
+
     let chunks = chunks
         .iter()
         .map(|c| ReplicatedChunk {
@@ -137,6 +129,82 @@ fn schedule_to_workers(
         worker_chunks,
         replication_by_weight: mapping,
     })
+}
+
+/// Validates that version-restricted data can be scheduled within the
+/// saturation headroom. Only a single non-null `minimum_worker_version` value
+/// is allowed across all chunks. Two checks:
+/// 1. R ≤ E: replication factor must not exceed eligible worker count.
+/// 2. f ≤ (1-s) × E / (s × (N-E)): the extra load on eligible workers
+///    from restricted chunks must fit within the unused capacity fraction.
+fn validate_version_restrictions(
+    chunks: &[ScheduledChunk],
+    workers: &[&Worker],
+    config: &SchedulingConfig,
+    replication_by_weight: &BTreeMap<u16, u16>,
+) {
+    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
+    if total_size == 0 {
+        return;
+    }
+
+    // Collect the single allowed minimum_worker_version
+    let mut min_ver: Option<&Version> = None;
+    let mut s_restricted: u64 = 0;
+    let mut max_replication: u16 = 0;
+
+    for chunk in chunks {
+        if let Some(ref v) = chunk.minimum_worker_version {
+            if let Some(existing) = min_ver {
+                assert!(
+                    existing == v,
+                    "Multiple minimum_worker_version values found ({} and {}). \
+                     Only a single version restriction is supported.",
+                    existing,
+                    v,
+                );
+            } else {
+                min_ver = Some(v);
+            }
+            s_restricted += chunk.size as u64;
+            max_replication = max_replication.max(replication_by_weight[&chunk.weight]);
+        }
+    }
+
+    let Some(min_ver) = min_ver else { return };
+
+    let n = workers.len();
+    let s = config.saturation;
+    let e = workers
+        .iter()
+        .filter(|w| w.version.as_ref().is_some_and(|v| v >= min_ver))
+        .count();
+
+    assert!(
+        max_replication as usize <= e,
+        "Not enough eligible workers for version >= {}: \
+         replication factor {} exceeds {} eligible workers (need at least {})",
+        min_ver,
+        max_replication,
+        e,
+        max_replication,
+    );
+
+    if e < n {
+        let f = s_restricted as f64 / total_size as f64;
+        let threshold = (1.0 - s) * e as f64 / (s * (n - e) as f64);
+        assert!(
+            f <= threshold,
+            "Version-restricted data (>= {}) exceeds saturation headroom: \
+             f = {:.4} > {:.4} (E={}, N={}, s={})",
+            min_ver,
+            f,
+            threshold,
+            e,
+            n,
+            s,
+        );
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -239,17 +307,13 @@ fn assign_chunks(
     struct WorkerAssignment {
         chunks: Vec<ChunkIndex>,
         allocated: u64,
-        version_restricted_allocated: u64,
     }
-
-    let max_version_restricted = (MAX_VERSION_RESTRICTED_RATIO * worker_capacity as f64) as u64;
 
     let mut assignments: Vec<WorkerAssignment> = workers
         .iter()
         .map(|_| WorkerAssignment {
             chunks: Vec::new(),
             allocated: 0,
-            version_restricted_allocated: 0,
         })
         .collect();
     orderings
@@ -258,10 +322,8 @@ fn assign_chunks(
             let chunk = &chunks[chunk_index as usize];
             let ring = &rings[ring_index as usize];
             let first = first as usize;
-            let is_version_restricted = chunk.minimum_worker_version.is_some();
             let candidates = ring[first..].iter().chain(ring[..first].iter());
             for &(_, worker_index) in candidates {
-                // Check if this chunk requires a minimum worker version
                 if let Some(min_ver) = chunk.minimum_worker_version {
                     let worker_ver = &workers[worker_index as usize].version;
                     if !worker_ver.as_ref().is_some_and(|v| v >= min_ver) {
@@ -271,14 +333,6 @@ fn assign_chunks(
 
                 let assignment = &mut assignments[worker_index as usize];
 
-                // Cap version-restricted data per worker to limit reassignment churn
-                if is_version_restricted
-                    && assignment.version_restricted_allocated + chunk.size as u64
-                        > max_version_restricted
-                {
-                    continue;
-                }
-
                 if assignment.allocated + chunk.size as u64 <= worker_capacity
                     // Replicas of the same chunk stay adjacent after the stable sort
                     // (they share the same minimum_worker_version key), so checking
@@ -286,9 +340,6 @@ fn assign_chunks(
                     && assignment.chunks.last() != Some(&chunk_index)
                 {
                     assignment.allocated += chunk.size as u64;
-                    if is_version_restricted {
-                        assignment.version_restricted_allocated += chunk.size as u64;
-                    }
                     assignment.chunks.push(chunk_index);
                     return;
                 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -24,6 +24,9 @@ const N_RINGS: usize = 6000;
 /// overloaded with restricted data, which would cause large reassignments
 /// when more workers upgrade. At 0.2, the worst-case reassignment when
 /// the eligible pool doubles is 10% of worker capacity.
+///
+/// The versioned data fraction must satisfy: f ≤ 0.2 * E / (N * s),
+/// where E = eligible workers, N = total workers, s = saturation.
 const MAX_VERSION_RESTRICTED_RATIO: f64 = 0.2;
 
 #[derive(Debug, Clone)]

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -8,6 +8,8 @@ use rayon::iter::{
 use seahash::hash;
 use tracing::instrument;
 
+use semver::Version;
+
 use crate::{
     replication::{ReplicationError, calc_replication_factors},
     types::{Assignment, ChunkIndex, Worker, WorkerIndex},
@@ -16,6 +18,13 @@ use crate::{
 type RingIndex = u16;
 
 const N_RINGS: usize = 6000;
+
+/// Maximum fraction of a worker's capacity that can be used for
+/// version-restricted chunks. This prevents eligible workers from being
+/// overloaded with restricted data, which would cause large reassignments
+/// when more workers upgrade. At 0.2, the worst-case reassignment when
+/// the eligible pool doubles is 10% of worker capacity.
+const MAX_VERSION_RESTRICTED_RATIO: f64 = 0.2;
 
 #[derive(Debug, Clone)]
 pub struct SchedulingConfig {
@@ -26,22 +35,23 @@ pub struct SchedulingConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct WeightedChunk {
+pub struct ScheduledChunk {
     pub id: String,
     pub size: u32,
     pub weight: u16,
+    pub minimum_worker_version: Option<Version>,
 }
 
 pub fn schedule(
-    chunks: &[WeightedChunk],
+    chunks: &[ScheduledChunk],
     workers: &[Worker],
     config: SchedulingConfig,
 ) -> Result<Assignment, ReplicationError> {
     let _timer = crate::metrics::Timer::new("schedule");
-    let mut worker_ids = Vec::with_capacity(workers.len());
-    worker_ids.extend(workers.iter().filter(|w| w.reliable()).map(|w| w.id));
-    let reliable_workers = worker_ids.len();
-    worker_ids.extend(workers.iter().filter(|w| !w.reliable()).map(|w| w.id));
+    let mut sorted_workers = Vec::with_capacity(workers.len());
+    sorted_workers.extend(workers.iter().filter(|w| w.reliable()));
+    let reliable_workers = sorted_workers.len();
+    sorted_workers.extend(workers.iter().filter(|w| !w.reliable()));
 
     if config.ignore_reliability {
         tracing::info!(
@@ -49,7 +59,7 @@ pub fn schedule(
             chunks.len(),
             workers.len(),
         );
-        return schedule_to_workers(chunks, &worker_ids, &config);
+        return schedule_to_workers(chunks, &sorted_workers, &config);
     }
 
     tracing::info!(
@@ -57,7 +67,8 @@ pub fn schedule(
         chunks.len(),
         reliable_workers
     );
-    let mut reliable = schedule_to_workers(chunks, &worker_ids[..reliable_workers], &config)?;
+    let mut reliable =
+        schedule_to_workers(chunks, &sorted_workers[..reliable_workers], &config)?;
 
     if reliable_workers == workers.len() {
         return Ok(reliable);
@@ -68,7 +79,7 @@ pub fn schedule(
         chunks.len(),
         workers.len()
     );
-    let all = schedule_to_workers(chunks, &worker_ids, &config)?;
+    let all = schedule_to_workers(chunks, &sorted_workers, &config)?;
 
     // Use assignment from `reliable` for reliable workers and from `all` for unreliable workers
     for (worker_id, chunk_indexes) in all.worker_chunks {
@@ -81,8 +92,8 @@ pub fn schedule(
 }
 
 fn schedule_to_workers(
-    chunks: &[WeightedChunk],
-    workers: &[PeerId],
+    chunks: &[ScheduledChunk],
+    workers: &[&Worker],
     config: &SchedulingConfig,
 ) -> Result<Assignment, ReplicationError> {
     let size_by_weight = chunks
@@ -109,6 +120,7 @@ fn schedule_to_workers(
             id: Cow::Borrowed(&c.id),
             replication: mapping[&c.weight],
             size: c.size,
+            minimum_worker_version: c.minimum_worker_version.as_ref(),
         })
         .collect_vec();
 
@@ -126,33 +138,43 @@ fn schedule_to_workers(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ReplicatedChunk<'id> {
-    id: Cow<'id, str>,
+struct ReplicatedChunk<'a> {
+    id: Cow<'a, str>,
     size: u32,
     replication: u16,
+    minimum_worker_version: Option<&'a Version>,
 }
 
 #[instrument(skip_all)]
 fn distribute(
     chunks: &[ReplicatedChunk],
-    workers: &[PeerId],
+    workers: &[&Worker],
     worker_capacity: u64,
 ) -> BTreeMap<PeerId, Vec<ChunkIndex>> {
     let _timer = crate::metrics::Timer::new("schedule:distribute");
-    let rings = hash_workers(workers);
-    let orderings = hash_chunks(chunks, &rings);
+    let worker_ids = workers.iter().map(|w| w.id).collect_vec();
+    let rings = hash_workers(&worker_ids);
+    let mut orderings = hash_chunks(chunks, &rings);
+    // Assign version-restricted chunks first so they get priority on eligible
+    // workers' capacity before unrestricted chunks fill it. Without this,
+    // the non-deterministic ordering from parallel collection could cause
+    // restricted chunks to arrive after eligible workers are full, leading
+    // to a panic even when total capacity would suffice.
+    orderings.sort_by_key(|(chunk_index, _, _)| {
+        chunks[*chunk_index as usize].minimum_worker_version.is_none()
+    });
     assign_chunks(orderings, chunks, workers, rings, worker_capacity)
 }
 
 #[instrument(skip_all)]
-fn hash_workers(workers: &[PeerId]) -> Vec<Vec<(u64, WorkerIndex)>> {
+fn hash_workers(worker_ids: &[PeerId]) -> Vec<Vec<(u64, WorkerIndex)>> {
     tracing::info!("Hashing workers");
     let _timer = crate::metrics::Timer::new("schedule:distribute:hash_workers");
 
     (0..N_RINGS as RingIndex)
         .into_par_iter()
         .map(|ring_index| {
-            let mut vec = workers
+            let mut vec = worker_ids
                 .iter()
                 .enumerate()
                 .map(|(worker_index, worker_id)| {
@@ -203,7 +225,7 @@ fn hash_chunks(
 fn assign_chunks(
     orderings: Vec<(ChunkIndex, RingIndex, WorkerIndex)>,
     chunks: &[ReplicatedChunk],
-    worker_ids: &[PeerId],
+    workers: &[&Worker],
     rings: Vec<Vec<(u64, WorkerIndex)>>,
     worker_capacity: u64,
 ) -> BTreeMap<PeerId, Vec<ChunkIndex>> {
@@ -213,13 +235,17 @@ fn assign_chunks(
     struct WorkerAssignment {
         chunks: Vec<ChunkIndex>,
         allocated: u64,
+        version_restricted_allocated: u64,
     }
 
-    let mut workers: Vec<WorkerAssignment> = worker_ids
+    let max_version_restricted = (MAX_VERSION_RESTRICTED_RATIO * worker_capacity as f64) as u64;
+
+    let mut assignments: Vec<WorkerAssignment> = workers
         .iter()
         .map(|_| WorkerAssignment {
             chunks: Vec::new(),
             allocated: 0,
+            version_restricted_allocated: 0,
         })
         .collect();
     orderings
@@ -228,25 +254,47 @@ fn assign_chunks(
             let chunk = &chunks[chunk_index as usize];
             let ring = &rings[ring_index as usize];
             let first = first as usize;
+            let is_version_restricted = chunk.minimum_worker_version.is_some();
             let candidates = ring[first..].iter().chain(ring[..first].iter());
             for &(_, worker_index) in candidates {
-                let worker = &mut workers[worker_index as usize];
+                // Check if this chunk requires a minimum worker version
+                if let Some(min_ver) = chunk.minimum_worker_version {
+                    let worker_ver = &workers[worker_index as usize].version;
+                    if !worker_ver.as_ref().is_some_and(|v| v >= min_ver) {
+                        continue;
+                    }
+                }
 
-                if worker.allocated + chunk.size as u64 <= worker_capacity
-                    // indexes are added in increasing order, so it's enough to check the last one for duplicates
-                    && worker.chunks.last() != Some(&chunk_index)
+                let assignment = &mut assignments[worker_index as usize];
+
+                // Cap version-restricted data per worker to limit reassignment churn
+                if is_version_restricted
+                    && assignment.version_restricted_allocated + chunk.size as u64
+                        > max_version_restricted
                 {
-                    worker.allocated += chunk.size as u64;
-                    worker.chunks.push(chunk_index);
+                    continue;
+                }
+
+                if assignment.allocated + chunk.size as u64 <= worker_capacity
+                    // Replicas of the same chunk stay adjacent after the stable sort
+                    // (they share the same minimum_worker_version key), so checking
+                    // the last assigned index is sufficient to prevent duplicates.
+                    && assignment.chunks.last() != Some(&chunk_index)
+                {
+                    assignment.allocated += chunk.size as u64;
+                    if is_version_restricted {
+                        assignment.version_restricted_allocated += chunk.size as u64;
+                    }
+                    assignment.chunks.push(chunk_index);
                     return;
                 }
             }
             panic!("No worker found for chunk {}", chunk.id);
         });
 
-    workers
+    assignments
         .into_iter()
         .enumerate()
-        .map(|(index, worker)| (worker_ids[index], worker.chunks))
+        .map(|(index, a)| (workers[index].id, a.chunks))
         .collect()
 }

--- a/src/tests/input.rs
+++ b/src/tests/input.rs
@@ -4,7 +4,7 @@ use rand::prelude::*;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
-    scheduling::WeightedChunk,
+    scheduling::ScheduledChunk,
     types::{ChunkIndex, ChunkWeight, Worker, WorkerIndex, WorkerStatus},
 };
 
@@ -13,7 +13,7 @@ pub fn generate_input(
     n_workers: WorkerIndex,
     n_chunks: ChunkIndex,
     weights: &[ChunkWeight],
-) -> (Vec<WeightedChunk>, Vec<Worker>, u64) {
+) -> (Vec<ScheduledChunk>, Vec<Worker>, u64) {
     println!("Generating input");
     let chunks = generate_chunks(n_chunks, weights);
     let workers = generate_workers(n_workers)
@@ -21,6 +21,7 @@ pub fn generate_input(
         .map(|id| Worker {
             id,
             status: WorkerStatus::Online,
+            version: None,
         })
         .collect_vec();
     let total_size: u64 = chunks.iter().map(|chunk| chunk.size as u64).sum();
@@ -34,7 +35,7 @@ pub fn generate_input(
     (chunks, workers, total_size)
 }
 
-pub fn generate_chunks(n: ChunkIndex, weights: &[ChunkWeight]) -> Vec<WeightedChunk> {
+pub fn generate_chunks(n: ChunkIndex, weights: &[ChunkWeight]) -> Vec<ScheduledChunk> {
     const MAX_CHUNK_SIZE: u32 = 200 << 20; // 200MB
 
     (0..n)
@@ -46,10 +47,11 @@ pub fn generate_chunks(n: ChunkIndex, weights: &[ChunkWeight]) -> Vec<WeightedCh
                 i + 1,
                 i
             );
-            WeightedChunk {
+            ScheduledChunk {
                 id,
                 size: rand::rng().random_range(0..MAX_CHUNK_SIZE),
                 weight: *weights.choose(&mut rand::rng()).unwrap(),
+                minimum_worker_version: None,
             }
         })
         .collect()

--- a/src/tests/scheduling.rs
+++ b/src/tests/scheduling.rs
@@ -2,14 +2,15 @@ use std::collections::BTreeMap;
 
 use itertools::Itertools;
 use libp2p_identity::PeerId;
+use semver::Version;
 
 use super::{
-    input::generate_input,
+    input::{generate_chunks, generate_input, generate_workers},
     utils::{Stats, compare_intersection},
 };
 use crate::{
     scheduling::{SchedulingConfig, schedule},
-    types::{Assignment, WorkerIndex, WorkerStatus},
+    types::{Assignment, Worker, WorkerIndex, WorkerStatus},
 };
 
 #[test]
@@ -201,6 +202,267 @@ fn split_by_workers(
             replication_by_weight: assignment.replication_by_weight,
         },
     )
+}
+
+/// Verifies that version-restricted chunks are only assigned to eligible workers.
+/// Scenario: 100 workers, 20% eligible, 99% saturation, ~4% of chunks version-restricted.
+///
+/// Two constraints must hold (both are stressed close to their limits):
+/// 1. R ≤ E: replication factor must not exceed eligible worker count.
+///    R = floor(C * N * s / S) = floor(20 * 0.99) = 19. E = 20 ≥ 19 ✓
+/// 2. R * S_versioned ≤ E * 0.2 * C: total versioned replicas fit in per-worker caps.
+///    19 * 0.04S = 0.76S ≤ 20 * 0.2 * 0.2S = 0.8S (95% utilized) ✓
+/// Regular chunks are unrestricted and spill freely to ineligible workers
+/// when eligible workers' remaining capacity is insufficient.
+#[test]
+fn test_minimum_worker_version_filtering() {
+    let min_version = Version::new(2, 8, 0);
+    const N_WORKERS: WorkerIndex = 100;
+    const N_ELIGIBLE: WorkerIndex = 20;
+    const N_CHUNKS: u32 = 50_000;
+    const N_VERSIONED: u32 = 2_000; // ~4% of chunks
+
+    let mut chunks = generate_chunks(N_CHUNKS, &[1]);
+    for chunk in &mut chunks[..N_VERSIONED as usize] {
+        chunk.minimum_worker_version = Some(min_version.clone());
+    }
+
+    let workers = generate_workers(N_WORKERS)
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| Worker {
+            id,
+            status: WorkerStatus::Online,
+            version: if (i as WorkerIndex) < N_ELIGIBLE {
+                Some(Version::new(2, 8, 0))
+            } else {
+                Some(Version::new(2, 7, 0))
+            },
+        })
+        .collect_vec();
+
+    let eligible_ids = workers[..N_ELIGIBLE as usize]
+        .iter()
+        .map(|w| w.id)
+        .collect::<std::collections::BTreeSet<_>>();
+
+    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
+    // C * N / S = 20, so R = floor(20 * 0.99) = 19
+    let worker_capacity = 20 * total_size / N_WORKERS as u64;
+
+    let assignment = schedule(
+        &chunks,
+        &workers,
+        SchedulingConfig {
+            worker_capacity,
+            saturation: 0.99,
+            min_replication: 1,
+            ignore_reliability: false,
+        },
+    )
+    .unwrap();
+
+    // Versioned chunks must only be assigned to eligible workers
+    for (worker_id, chunk_indexes) in &assignment.worker_chunks {
+        if !eligible_ids.contains(worker_id) {
+            let has_versioned = chunk_indexes.iter().any(|&i| (i as u32) < N_VERSIONED);
+            assert!(
+                !has_versioned,
+                "Ineligible worker {:?} was assigned version-restricted chunks",
+                worker_id,
+            );
+        }
+    }
+
+    // All eligible workers should have some versioned chunks
+    for worker_id in &eligible_ids {
+        let versioned_count = assignment
+            .worker_chunks
+            .get(worker_id)
+            .map(|idxs| idxs.iter().filter(|&&i| (i as u32) < N_VERSIONED).count())
+            .unwrap_or(0);
+        assert!(
+            versioned_count > 0,
+            "Eligible worker {:?} has no versioned chunks",
+            worker_id
+        );
+    }
+}
+
+/// Measures reassignment impact when workers gradually upgrade.
+/// Scenario: 100 workers, 99% saturation, ~4% versioned chunks,
+/// workers upgrade in batches: 20 -> 35 -> 50 -> 75 -> 100.
+/// R = floor(20 * 0.99) = 19, so we need ≥ 19 eligible workers in each step.
+///
+/// At E=20 (first step), the per-worker versioned cap is 95% utilized
+/// (same stress level as test_minimum_worker_version_filtering).
+/// When the pool grows from 20→35, each original worker loses up to ~43%
+/// of its restricted data. With restricted data at ~19% of capacity,
+/// per-worker reassignment is bounded by 0.43 * 0.19 ≈ 8% of capacity.
+/// We use a 15% threshold to account for hash ring variance.
+#[test]
+fn test_minimum_worker_version_gradual_upgrade() {
+    let min_version = Version::new(2, 8, 0);
+    const N_WORKERS: WorkerIndex = 100;
+    const N_CHUNKS: u32 = 50_000;
+    const N_VERSIONED: u32 = 2_000; // ~4%
+
+    let mut chunks = generate_chunks(N_CHUNKS, &[1]);
+    for chunk in &mut chunks[..N_VERSIONED as usize] {
+        chunk.minimum_worker_version = Some(min_version.clone());
+    }
+
+    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
+    let worker_capacity = 20 * total_size / N_WORKERS as u64;
+    let config = SchedulingConfig {
+        worker_capacity,
+        saturation: 0.99,
+        min_replication: 1,
+        ignore_reliability: false,
+    };
+
+    let worker_ids = generate_workers(N_WORKERS);
+
+    let upgrade_steps: &[WorkerIndex] = &[20, 35, 50, 75, 100];
+    let mut prev_assignment: Option<Assignment> = None;
+
+    for &n_upgraded in upgrade_steps {
+        let workers = worker_ids
+            .iter()
+            .enumerate()
+            .map(|(i, &id)| Worker {
+                id,
+                status: WorkerStatus::Online,
+                version: if (i as WorkerIndex) < n_upgraded {
+                    Some(Version::new(2, 8, 0))
+                } else {
+                    Some(Version::new(2, 7, 0))
+                },
+            })
+            .collect_vec();
+
+        let assignment = schedule(&chunks, &workers, config.clone()).unwrap();
+
+        if let Some(prev) = &prev_assignment {
+            let compare_result = compare_intersection(&chunks, prev, &assignment);
+            let max_removed = *compare_result.removed.values().max().unwrap();
+            println!(
+                "Upgrade to {} workers: max removed per worker: {:.2}% of capacity",
+                n_upgraded,
+                max_removed as f64 / worker_capacity as f64 * 100.0
+            );
+            assert!(
+                compare_result
+                    .removed
+                    .values()
+                    .all(|size| (*size as f64) < 0.15 * worker_capacity as f64),
+                "Too much reassignment when upgrading to {} workers: max removed = {:.2}% of capacity (limit = 15%)",
+                n_upgraded,
+                max_removed as f64 / worker_capacity as f64 * 100.0,
+            );
+        }
+
+        prev_assignment = Some(assignment);
+    }
+}
+
+/// Verifies that scheduling panics when eligible workers can't absorb all
+/// version-restricted replicas. R = floor(6 * 0.9) = 5, but only 3
+/// eligible workers — each versioned chunk needs 5 distinct workers
+/// but can only use 3. Panics on the first versioned chunk.
+#[test]
+#[should_panic(expected = "No worker found for chunk")]
+fn test_minimum_worker_version_insufficient_capacity() {
+    let min_version = Version::new(2, 8, 0);
+    const N_WORKERS: WorkerIndex = 100;
+    const N_ELIGIBLE: WorkerIndex = 3;
+
+    let mut chunks = generate_chunks(50_000, &[1]);
+    for chunk in &mut chunks {
+        chunk.minimum_worker_version = Some(min_version.clone());
+    }
+
+    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
+    let worker_capacity = 6 * total_size / N_WORKERS as u64;
+
+    let workers = generate_workers(N_WORKERS)
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| Worker {
+            id,
+            status: WorkerStatus::Online,
+            version: if (i as WorkerIndex) < N_ELIGIBLE {
+                Some(Version::new(2, 8, 0))
+            } else {
+                Some(Version::new(2, 7, 0))
+            },
+        })
+        .collect_vec();
+
+    let _ = schedule(
+        &chunks,
+        &workers,
+        SchedulingConfig {
+            worker_capacity,
+            saturation: 0.9,
+            min_replication: 1,
+            ignore_reliability: false,
+        },
+    );
+}
+
+/// Verifies that scheduling panics when versioned data exceeds the per-worker
+/// version-restricted cap (even though R ≤ E and total eligible capacity
+/// would suffice without the cap).
+/// Scenario: 100 workers, 20 eligible, 99% saturation, 5% versioned chunks.
+/// Same framework as test_minimum_worker_version_filtering (M=20, R=19, E=20)
+/// but with versioned fraction just above the ~4.2% threshold.
+///
+/// R = floor(20 * 0.99) = 19 ≤ 20.
+/// Per-worker versioned cap = 0.2 * C = 0.2 * 0.2S = 0.04S.
+/// Total capped versioned capacity = 20 * 0.04S = 0.8S.
+/// Required: R * S_versioned = 19 * 0.05S = 0.95S > 0.8S (~19% over cap). Panics.
+#[test]
+#[should_panic(expected = "No worker found for chunk")]
+fn test_minimum_worker_version_eligible_capacity_exceeded() {
+    let min_version = Version::new(2, 8, 0);
+    const N_WORKERS: WorkerIndex = 100;
+    const N_ELIGIBLE: WorkerIndex = 20;
+    const N_CHUNKS: u32 = 50_000;
+    const N_VERSIONED: u32 = 2_500; // 5% of chunks, just above the ~4.2% threshold
+
+    let mut chunks = generate_chunks(N_CHUNKS, &[1]);
+    for chunk in &mut chunks[..N_VERSIONED as usize] {
+        chunk.minimum_worker_version = Some(min_version.clone());
+    }
+
+    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
+    let worker_capacity = 20 * total_size / N_WORKERS as u64;
+
+    let workers = generate_workers(N_WORKERS)
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| Worker {
+            id,
+            status: WorkerStatus::Online,
+            version: if (i as WorkerIndex) < N_ELIGIBLE {
+                Some(Version::new(2, 8, 0))
+            } else {
+                Some(Version::new(2, 7, 0))
+            },
+        })
+        .collect_vec();
+
+    let _ = schedule(
+        &chunks,
+        &workers,
+        SchedulingConfig {
+            worker_capacity,
+            saturation: 0.99,
+            min_replication: 1,
+            ignore_reliability: false,
+        },
+    );
 }
 
 fn ring_iter<'l, T: Ord>(v: &'l [T], from: &T) -> impl Iterator<Item = &'l T> {

--- a/src/tests/scheduling.rs
+++ b/src/tests/scheduling.rs
@@ -9,7 +9,7 @@ use super::{
     utils::{Stats, compare_intersection},
 };
 use crate::{
-    scheduling::{SchedulingConfig, schedule},
+    scheduling::{ScheduledChunk, SchedulingConfig, schedule},
     types::{Assignment, Worker, WorkerIndex, WorkerStatus},
 };
 
@@ -205,22 +205,18 @@ fn split_by_workers(
 }
 
 /// Verifies that version-restricted chunks are only assigned to eligible workers.
-/// Scenario: 100 workers, 20% eligible, 99% saturation, ~4% of chunks version-restricted.
+/// Scenario: 100 workers, 50 eligible (~50%), 95% saturation, 5% version-restricted.
 ///
-/// Two constraints must hold (both are stressed close to their limits):
-/// 1. R ≤ E: replication factor must not exceed eligible worker count.
-///    R = floor(C * N * s / S) = floor(20 * 0.99) = 19. E = 20 ≥ 19 ✓
-/// 2. f ≤ 0.2 * E / (N * s): versioned fraction fits in per-worker caps.
-///    f = 0.04 ≤ 0.2 * 20 / (100 * 0.99) = 0.0404 (99% utilized) ✓
-/// Regular chunks are unrestricted and spill freely to ineligible workers
-/// when eligible workers' remaining capacity is insufficient.
+/// Two constraints must hold:
+/// 1. R ≤ E: R = floor(10 * 0.95) = 9 ≤ E = 50 ✓
+/// 2. f ≤ (1-s) * E / (s * (N-E)): 0.05 ≤ 0.0526 (95% of limit) ✓
 #[test]
 fn test_minimum_worker_version_filtering() {
     let min_version = Version::new(2, 8, 0);
     const N_WORKERS: WorkerIndex = 100;
-    const N_ELIGIBLE: WorkerIndex = 20;
+    const N_ELIGIBLE: WorkerIndex = 50;
     const N_CHUNKS: u32 = 50_000;
-    const N_VERSIONED: u32 = 2_000; // ~4% of chunks
+    const N_VERSIONED: u32 = 2_500; // 5% of chunks (95% of the ~5.26% threshold)
 
     let mut chunks = generate_chunks(N_CHUNKS, &[1]);
     for chunk in &mut chunks[..N_VERSIONED as usize] {
@@ -247,15 +243,15 @@ fn test_minimum_worker_version_filtering() {
         .collect::<std::collections::BTreeSet<_>>();
 
     let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
-    // C * N / S = 20, so R = floor(20 * 0.99) = 19
-    let worker_capacity = 20 * total_size / N_WORKERS as u64;
+    // C * N / S = 10, so R = floor(10 * 0.95) = 9
+    let worker_capacity = 10 * total_size / N_WORKERS as u64;
 
     let assignment = schedule(
         &chunks,
         &workers,
         SchedulingConfig {
             worker_capacity,
-            saturation: 0.99,
+            saturation: 0.95,
             min_replication: 1,
             ignore_reliability: false,
         },
@@ -289,22 +285,117 @@ fn test_minimum_worker_version_filtering() {
     }
 }
 
-/// Measures reassignment impact when workers gradually upgrade.
-/// Scenario: 100 workers, 99% saturation, ~4% versioned chunks,
-/// workers upgrade in batches: 20 -> 35 -> 50 -> 75 -> 100.
-/// R = floor(20 * 0.99) = 19, so we need ≥ 19 eligible workers in each step.
+/// Verifies that version restrictions cause no (or negligible) spill of
+/// unrestricted chunks compared to a baseline without restrictions.
+/// Uses the same scenario as test_minimum_worker_version_filtering.
 ///
-/// At E=20 (first step), f = 0.04 ≈ 0.2 * 20 / (100 * 0.99) = 0.0404 (99% of limit).
-/// When the pool grows from 20→35, each original worker loses up to ~43%
-/// of its restricted data. With restricted data at ~19% of capacity,
-/// per-worker reassignment is bounded by 0.43 * 0.19 ≈ 8% of capacity.
-/// We use a 15% threshold to account for hash ring variance.
+/// Spill is measured by comparing unrestricted chunk-worker assignments between
+/// the restricted and unrestricted schedules. Any replica that lands on a
+/// different worker is counted as spilled.
+#[test]
+fn test_minimum_worker_version_unrestricted_spill() {
+    let min_version = Version::new(2, 8, 0);
+    const N_WORKERS: WorkerIndex = 100;
+    const N_ELIGIBLE: WorkerIndex = 50;
+    const N_CHUNKS: u32 = 50_000;
+    const N_VERSIONED: u32 = 2_500; // 5% of chunks (95% of the ~5.26% threshold)
+    const SATURATION: f64 = 0.95;
+
+    let mut chunks = generate_chunks(N_CHUNKS, &[1]);
+    for chunk in &mut chunks[..N_VERSIONED as usize] {
+        chunk.minimum_worker_version = Some(min_version.clone());
+    }
+
+    let workers = generate_workers(N_WORKERS)
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| Worker {
+            id,
+            status: WorkerStatus::Online,
+            version: if (i as WorkerIndex) < N_ELIGIBLE {
+                Some(Version::new(2, 8, 0))
+            } else {
+                Some(Version::new(2, 7, 0))
+            },
+        })
+        .collect_vec();
+
+    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
+    let worker_capacity = 10 * total_size / N_WORKERS as u64;
+    let config = SchedulingConfig {
+        worker_capacity,
+        saturation: SATURATION,
+        min_replication: 1,
+        ignore_reliability: false,
+    };
+
+    let assignment = schedule(&chunks, &workers, config.clone()).unwrap();
+
+    // Baseline: same chunks without version restrictions
+    let unrestricted_chunks: Vec<ScheduledChunk> = chunks
+        .iter()
+        .map(|c| {
+            let mut c = c.clone();
+            c.minimum_worker_version = None;
+            c
+        })
+        .collect();
+    let baseline = schedule(&unrestricted_chunks, &workers, config).unwrap();
+
+    // Build chunk -> set of workers for unrestricted chunks in both schedules
+    let chunk_to_workers = |assignment: &Assignment| {
+        let mut map: BTreeMap<u32, std::collections::BTreeSet<PeerId>> = BTreeMap::new();
+        for (&worker_id, chunk_indexes) in &assignment.worker_chunks {
+            for &idx in chunk_indexes {
+                if idx as u32 >= N_VERSIONED {
+                    map.entry(idx as u32).or_default().insert(worker_id);
+                }
+            }
+        }
+        map
+    };
+    let restricted_map = chunk_to_workers(&assignment);
+    let baseline_map = chunk_to_workers(&baseline);
+
+    let mut changed_replicas: u64 = 0;
+    let mut total_replicas: u64 = 0;
+    for i in N_VERSIONED..N_CHUNKS {
+        let idx = i as u32;
+        let workers_a = restricted_map.get(&idx).cloned().unwrap_or_default();
+        let workers_b = baseline_map.get(&idx).cloned().unwrap_or_default();
+        let changed = workers_a.symmetric_difference(&workers_b).count() as u64 / 2;
+        changed_replicas += changed;
+        total_replicas += workers_a.len() as u64;
+    }
+
+    let spill_pct = changed_replicas as f64 / total_replicas as f64 * 100.0;
+    println!(
+        "Unrestricted chunk spill: {:.2}% of replicas moved ({} / {})",
+        spill_pct, changed_replicas, total_replicas,
+    );
+    // With f below the threshold, eligible workers should absorb restricted
+    // chunks within the saturation headroom. Any spill beyond 1% of replicas
+    // would indicate the headroom is insufficient or the hash ring variance
+    // is larger than expected.
+    assert!(
+        spill_pct < 1.0,
+        "Too much unrestricted chunk spill: {:.2}% of replicas moved",
+        spill_pct,
+    );
+}
+
+/// Measures reassignment impact when workers gradually upgrade.
+/// Scenario: 100 workers, 95% saturation, 1% versioned, upgrade 50→65→80→100.
+/// R = floor(10 * 0.95) = 9.
+///
+/// At E=50 (first step): f = 0.01 ≤ (0.05 * 50) / (0.95 * 50) = 0.0526 ✓ (19% of limit).
+/// With only 1% restricted data, reassignment per step should be small.
 #[test]
 fn test_minimum_worker_version_gradual_upgrade() {
     let min_version = Version::new(2, 8, 0);
     const N_WORKERS: WorkerIndex = 100;
     const N_CHUNKS: u32 = 50_000;
-    const N_VERSIONED: u32 = 2_000; // ~4%
+    const N_VERSIONED: u32 = 500; // 1%
 
     let mut chunks = generate_chunks(N_CHUNKS, &[1]);
     for chunk in &mut chunks[..N_VERSIONED as usize] {
@@ -312,17 +403,17 @@ fn test_minimum_worker_version_gradual_upgrade() {
     }
 
     let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
-    let worker_capacity = 20 * total_size / N_WORKERS as u64;
+    let worker_capacity = 10 * total_size / N_WORKERS as u64;
     let config = SchedulingConfig {
         worker_capacity,
-        saturation: 0.99,
+        saturation: 0.95,
         min_replication: 1,
         ignore_reliability: false,
     };
 
     let worker_ids = generate_workers(N_WORKERS);
 
-    let upgrade_steps: &[WorkerIndex] = &[20, 35, 50, 75, 100];
+    let upgrade_steps: &[WorkerIndex] = &[50, 65, 80, 100];
     let mut prev_assignment: Option<Assignment> = None;
 
     for &n_upgraded in upgrade_steps {
@@ -345,19 +436,20 @@ fn test_minimum_worker_version_gradual_upgrade() {
         if let Some(prev) = &prev_assignment {
             let compare_result = compare_intersection(&chunks, prev, &assignment);
             let max_removed = *compare_result.removed.values().max().unwrap();
+            let max_added = *compare_result.added.values().max().unwrap();
+            let max_churn = max_removed.max(max_added);
             println!(
-                "Upgrade to {} workers: max removed per worker: {:.2}% of capacity",
+                "Upgrade to {} workers: max churn per worker: {:.2}% of capacity (removed {:.2}%, added {:.2}%)",
                 n_upgraded,
-                max_removed as f64 / worker_capacity as f64 * 100.0
+                max_churn as f64 / worker_capacity as f64 * 100.0,
+                max_removed as f64 / worker_capacity as f64 * 100.0,
+                max_added as f64 / worker_capacity as f64 * 100.0,
             );
             assert!(
-                compare_result
-                    .removed
-                    .values()
-                    .all(|size| (*size as f64) < 0.15 * worker_capacity as f64),
-                "Too much reassignment when upgrading to {} workers: max removed = {:.2}% of capacity (limit = 15%)",
+                max_churn as f64 <= 0.05 * worker_capacity as f64,
+                "Too much reassignment when upgrading to {} workers: max churn = {:.2}% of capacity (limit = 5%)",
                 n_upgraded,
-                max_removed as f64 / worker_capacity as f64 * 100.0,
+                max_churn as f64 / worker_capacity as f64 * 100.0,
             );
         }
 
@@ -365,21 +457,21 @@ fn test_minimum_worker_version_gradual_upgrade() {
     }
 }
 
-/// Verifies that scheduling panics when R > E (replication factor exceeds
-/// eligible worker count), even though the per-worker capacity constraint
+/// Verifies that scheduling panics up-front when R > E (replication factor
+/// exceeds eligible worker count), even though the capacity constraint
 /// is satisfied.
-/// Scenario: 100 workers, 18 eligible, 99% saturation, 2% versioned chunks.
+/// Scenario: 100 workers, 8 eligible, 95% saturation, 0.4% versioned chunks.
 ///
-/// R = floor(20 * 0.99) = 19 > E = 18. Panics (can't place 19 replicas on 18 workers).
-/// f = 0.02 ≤ 0.2 * 18 / (100 * 0.99) = 0.036 ✓ (capacity would suffice).
+/// R = floor(10 * 0.95) = 9 > E = 8. Panics (can't place 9 replicas on 8 workers).
+/// f = 0.004 ≤ (0.05 * 8) / (0.95 * 92) = 0.0046 ✓ (capacity would suffice).
 #[test]
-#[should_panic(expected = "No worker found for chunk")]
+#[should_panic(expected = "Not enough eligible workers")]
 fn test_minimum_worker_version_insufficient_eligible_workers() {
     let min_version = Version::new(2, 8, 0);
     const N_WORKERS: WorkerIndex = 100;
-    const N_ELIGIBLE: WorkerIndex = 18;
+    const N_ELIGIBLE: WorkerIndex = 8;
     const N_CHUNKS: u32 = 50_000;
-    const N_VERSIONED: u32 = 1_000; // 2% of chunks
+    const N_VERSIONED: u32 = 200; // 0.4% of chunks
 
     let mut chunks = generate_chunks(N_CHUNKS, &[1]);
     for chunk in &mut chunks[..N_VERSIONED as usize] {
@@ -387,7 +479,7 @@ fn test_minimum_worker_version_insufficient_eligible_workers() {
     }
 
     let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
-    let worker_capacity = 20 * total_size / N_WORKERS as u64;
+    let worker_capacity = 10 * total_size / N_WORKERS as u64;
 
     let workers = generate_workers(N_WORKERS)
         .into_iter()
@@ -408,30 +500,29 @@ fn test_minimum_worker_version_insufficient_eligible_workers() {
         &workers,
         SchedulingConfig {
             worker_capacity,
-            saturation: 0.99,
+            saturation: 0.95,
             min_replication: 1,
             ignore_reliability: false,
         },
     );
 }
 
-/// Verifies that scheduling panics when versioned data exceeds the per-worker
-/// version-restricted cap (even though R ≤ E and total eligible capacity
-/// would suffice without the cap).
-/// Scenario: 100 workers, 20 eligible, 99% saturation, 5% versioned chunks.
-/// Same framework as test_minimum_worker_version_filtering but with versioned
-/// fraction just above the threshold.
+/// Verifies that scheduling panics up-front when the restricted data
+/// fraction exceeds the saturation headroom (even though R ≤ E).
+/// Scenario: 100 workers, 50 eligible, 95% saturation, 6% versioned chunks.
+/// Same framework as test_minimum_worker_version_filtering but f slightly
+/// above the threshold.
 ///
-/// R = floor(20 * 0.99) = 19 ≤ 20 ✓
-/// f = 0.05 > 0.2 * 20 / (100 * 0.99) = 0.0404 (~24% over limit). Panics.
+/// R = floor(10 * 0.95) = 9 ≤ E = 50 ✓
+/// f = 0.06 > (0.05 * 50) / (0.95 * 50) = 0.0526 (~14% over limit). Panics.
 #[test]
-#[should_panic(expected = "No worker found for chunk")]
+#[should_panic(expected = "exceeds saturation headroom")]
 fn test_minimum_worker_version_eligible_capacity_exceeded() {
     let min_version = Version::new(2, 8, 0);
     const N_WORKERS: WorkerIndex = 100;
-    const N_ELIGIBLE: WorkerIndex = 20;
+    const N_ELIGIBLE: WorkerIndex = 50;
     const N_CHUNKS: u32 = 50_000;
-    const N_VERSIONED: u32 = 2_500; // 5% of chunks, just above the ~4.2% threshold
+    const N_VERSIONED: u32 = 3_000; // 6% of chunks, just above the ~5.26% threshold
 
     let mut chunks = generate_chunks(N_CHUNKS, &[1]);
     for chunk in &mut chunks[..N_VERSIONED as usize] {
@@ -439,7 +530,7 @@ fn test_minimum_worker_version_eligible_capacity_exceeded() {
     }
 
     let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
-    let worker_capacity = 20 * total_size / N_WORKERS as u64;
+    let worker_capacity = 10 * total_size / N_WORKERS as u64;
 
     let workers = generate_workers(N_WORKERS)
         .into_iter()
@@ -460,10 +551,66 @@ fn test_minimum_worker_version_eligible_capacity_exceeded() {
         &workers,
         SchedulingConfig {
             worker_capacity,
-            saturation: 0.99,
+            saturation: 0.95,
             min_replication: 1,
             ignore_reliability: false,
         },
+    );
+}
+
+/// Verifies zero reassignment when version restriction is removed after
+/// all workers have upgraded. Compares:
+/// - Schedule with minimum_worker_version set and all workers eligible
+/// - Schedule with minimum_worker_version removed (None)
+/// With all workers eligible, the version check is a no-op. The only difference
+/// is the sort order, but since s=0.95 leaves ample headroom, no worker hits
+/// capacity — so processing order doesn't affect which worker each chunk lands on.
+#[test]
+fn test_minimum_worker_version_no_reassignment_on_removal() {
+    let min_version = Version::new(2, 8, 0);
+    const N_WORKERS: WorkerIndex = 100;
+    const N_CHUNKS: u32 = 50_000;
+    const N_VERSIONED: u32 = 500; // 1%
+
+    let mut chunks_with_ver = generate_chunks(N_CHUNKS, &[1]);
+    for chunk in &mut chunks_with_ver[..N_VERSIONED as usize] {
+        chunk.minimum_worker_version = Some(min_version.clone());
+    }
+    let mut chunks_without_ver = chunks_with_ver.clone();
+    for chunk in &mut chunks_without_ver[..N_VERSIONED as usize] {
+        chunk.minimum_worker_version = None;
+    }
+
+    // All workers are eligible (fully upgraded)
+    let workers = generate_workers(N_WORKERS)
+        .into_iter()
+        .map(|id| Worker {
+            id,
+            status: WorkerStatus::Online,
+            version: Some(Version::new(2, 8, 0)),
+        })
+        .collect_vec();
+
+    let total_size: u64 = chunks_with_ver.iter().map(|c| c.size as u64).sum();
+    let worker_capacity = 10 * total_size / N_WORKERS as u64;
+    let config = SchedulingConfig {
+        worker_capacity,
+        saturation: 0.95,
+        min_replication: 1,
+        ignore_reliability: false,
+    };
+
+    let with_ver = schedule(&chunks_with_ver, &workers, config.clone()).unwrap();
+    let without_ver = schedule(&chunks_without_ver, &workers, config).unwrap();
+
+    let compare_result = compare_intersection(&chunks_with_ver, &with_ver, &without_ver);
+    let total_removed: u64 = compare_result.removed.values().sum();
+    let total_added: u64 = compare_result.added.values().sum();
+    assert!(
+        total_removed == 0 && total_added == 0,
+        "Expected zero churn when removing restriction with all workers upgraded, \
+         but got removed = {}, added = {}",
+        total_removed, total_added,
     );
 }
 

--- a/src/tests/scheduling.rs
+++ b/src/tests/scheduling.rs
@@ -210,8 +210,8 @@ fn split_by_workers(
 /// Two constraints must hold (both are stressed close to their limits):
 /// 1. R ≤ E: replication factor must not exceed eligible worker count.
 ///    R = floor(C * N * s / S) = floor(20 * 0.99) = 19. E = 20 ≥ 19 ✓
-/// 2. R * S_versioned ≤ E * 0.2 * C: total versioned replicas fit in per-worker caps.
-///    19 * 0.04S = 0.76S ≤ 20 * 0.2 * 0.2S = 0.8S (95% utilized) ✓
+/// 2. f ≤ 0.2 * E / (N * s): versioned fraction fits in per-worker caps.
+///    f = 0.04 ≤ 0.2 * 20 / (100 * 0.99) = 0.0404 (99% utilized) ✓
 /// Regular chunks are unrestricted and spill freely to ineligible workers
 /// when eligible workers' remaining capacity is insufficient.
 #[test]
@@ -294,8 +294,7 @@ fn test_minimum_worker_version_filtering() {
 /// workers upgrade in batches: 20 -> 35 -> 50 -> 75 -> 100.
 /// R = floor(20 * 0.99) = 19, so we need ≥ 19 eligible workers in each step.
 ///
-/// At E=20 (first step), the per-worker versioned cap is 95% utilized
-/// (same stress level as test_minimum_worker_version_filtering).
+/// At E=20 (first step), f = 0.04 ≈ 0.2 * 20 / (100 * 0.99) = 0.0404 (99% of limit).
 /// When the pool grows from 20→35, each original worker loses up to ~43%
 /// of its restricted data. With restricted data at ~19% of capacity,
 /// per-worker reassignment is bounded by 0.43 * 0.19 ≈ 8% of capacity.
@@ -416,12 +415,10 @@ fn test_minimum_worker_version_insufficient_capacity() {
 /// would suffice without the cap).
 /// Scenario: 100 workers, 20 eligible, 99% saturation, 5% versioned chunks.
 /// Same framework as test_minimum_worker_version_filtering (M=20, R=19, E=20)
-/// but with versioned fraction just above the ~4.2% threshold.
+/// but with versioned fraction just above the threshold.
 ///
-/// R = floor(20 * 0.99) = 19 ≤ 20.
-/// Per-worker versioned cap = 0.2 * C = 0.2 * 0.2S = 0.04S.
-/// Total capped versioned capacity = 20 * 0.04S = 0.8S.
-/// Required: R * S_versioned = 19 * 0.05S = 0.95S > 0.8S (~19% over cap). Panics.
+/// R = floor(20 * 0.99) = 19 ≤ 20 ✓
+/// f = 0.05 > 0.2 * 20 / (100 * 0.99) = 0.0404 (~24% over limit). Panics.
 #[test]
 #[should_panic(expected = "No worker found for chunk")]
 fn test_minimum_worker_version_eligible_capacity_exceeded() {

--- a/src/tests/scheduling.rs
+++ b/src/tests/scheduling.rs
@@ -365,24 +365,29 @@ fn test_minimum_worker_version_gradual_upgrade() {
     }
 }
 
-/// Verifies that scheduling panics when eligible workers can't absorb all
-/// version-restricted replicas. R = floor(6 * 0.9) = 5, but only 3
-/// eligible workers — each versioned chunk needs 5 distinct workers
-/// but can only use 3. Panics on the first versioned chunk.
+/// Verifies that scheduling panics when R > E (replication factor exceeds
+/// eligible worker count), even though the per-worker capacity constraint
+/// is satisfied.
+/// Scenario: 100 workers, 18 eligible, 99% saturation, 2% versioned chunks.
+///
+/// R = floor(20 * 0.99) = 19 > E = 18. Panics (can't place 19 replicas on 18 workers).
+/// f = 0.02 ≤ 0.2 * 18 / (100 * 0.99) = 0.036 ✓ (capacity would suffice).
 #[test]
 #[should_panic(expected = "No worker found for chunk")]
-fn test_minimum_worker_version_insufficient_capacity() {
+fn test_minimum_worker_version_insufficient_eligible_workers() {
     let min_version = Version::new(2, 8, 0);
     const N_WORKERS: WorkerIndex = 100;
-    const N_ELIGIBLE: WorkerIndex = 3;
+    const N_ELIGIBLE: WorkerIndex = 18;
+    const N_CHUNKS: u32 = 50_000;
+    const N_VERSIONED: u32 = 1_000; // 2% of chunks
 
-    let mut chunks = generate_chunks(50_000, &[1]);
-    for chunk in &mut chunks {
+    let mut chunks = generate_chunks(N_CHUNKS, &[1]);
+    for chunk in &mut chunks[..N_VERSIONED as usize] {
         chunk.minimum_worker_version = Some(min_version.clone());
     }
 
     let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
-    let worker_capacity = 6 * total_size / N_WORKERS as u64;
+    let worker_capacity = 20 * total_size / N_WORKERS as u64;
 
     let workers = generate_workers(N_WORKERS)
         .into_iter()
@@ -403,7 +408,7 @@ fn test_minimum_worker_version_insufficient_capacity() {
         &workers,
         SchedulingConfig {
             worker_capacity,
-            saturation: 0.9,
+            saturation: 0.99,
             min_replication: 1,
             ignore_reliability: false,
         },
@@ -414,8 +419,8 @@ fn test_minimum_worker_version_insufficient_capacity() {
 /// version-restricted cap (even though R ≤ E and total eligible capacity
 /// would suffice without the cap).
 /// Scenario: 100 workers, 20 eligible, 99% saturation, 5% versioned chunks.
-/// Same framework as test_minimum_worker_version_filtering (M=20, R=19, E=20)
-/// but with versioned fraction just above the threshold.
+/// Same framework as test_minimum_worker_version_filtering but with versioned
+/// fraction just above the threshold.
 ///
 /// R = floor(20 * 0.99) = 19 ≤ 20 ✓
 /// f = 0.05 > 0.2 * 20 / (100 * 0.99) = 0.0404 (~24% over limit). Panics.

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use libp2p_identity::PeerId;
 
 use crate::{
-    scheduling::WeightedChunk,
+    scheduling::ScheduledChunk,
     types::{Assignment, ChunkIndex},
 };
 
@@ -70,7 +70,7 @@ impl CompareResult {
 }
 
 pub fn compare_intersection(
-    chunks: &[WeightedChunk],
+    chunks: &[ScheduledChunk],
     assignment1: &Assignment,
     assignment2: &Assignment,
 ) -> CompareResult {
@@ -97,7 +97,7 @@ pub fn compare_intersection(
     result
 }
 
-fn calculate_size(chunks: &[WeightedChunk], indexes: impl Iterator<Item = ChunkIndex>) -> u64 {
+fn calculate_size(chunks: &[ScheduledChunk], indexes: impl Iterator<Item = ChunkIndex>) -> u64 {
     indexes
         .map(|chunk_index| chunks[chunk_index as usize].size as u64)
         .sum()

--- a/src/types/worker.rs
+++ b/src/types/worker.rs
@@ -1,4 +1,5 @@
 use libp2p_identity::PeerId;
+use semver::Version;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -25,6 +26,8 @@ pub struct Worker {
     #[serde(rename = "peer_id")]
     pub id: PeerId,
     pub status: WorkerStatus,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub version: Option<Version>,
 }
 
 impl Worker {

--- a/src/weight.rs
+++ b/src/weight.rs
@@ -1,16 +1,18 @@
 use itertools::Itertools;
 
+use semver::Version;
+
 use crate::cli::{DatasetSegmentConfig, DatasetsConfig};
 use crate::metrics::{self, DatasetSegmentStats};
-use crate::scheduling::WeightedChunk;
+use crate::scheduling::ScheduledChunk;
 use crate::types::{Chunk, ChunkWeight};
 
 // TODO: add unit tests
-pub fn weight_chunks(
+pub fn prepare_chunks(
     chunks: Vec<Chunk>,
     config: &DatasetsConfig,
-) -> (Vec<WeightedChunk>, Vec<Chunk>) {
-    let mut weighted_chunks = Vec::with_capacity(chunks.len());
+) -> (Vec<ScheduledChunk>, Vec<Chunk>) {
+    let mut scheduled_chunks = Vec::with_capacity(chunks.len());
     let mut filtered_chunks = Vec::with_capacity(chunks.len());
     for (dataset, chunks) in &chunks.into_iter().chunk_by(|chunk| chunk.dataset.clone()) {
         let chunks = chunks.collect_vec();
@@ -38,10 +40,11 @@ pub fn weight_chunks(
             if chunk.blocks.start() >= &segments[cur].from {
                 segment_chunks += 1;
                 segment_size += chunk.size as u64;
-                weighted_chunks.push(WeightedChunk {
+                scheduled_chunks.push(ScheduledChunk {
                     id: format!("{}/{}", dataset, chunk.id),
                     size: chunk.size,
                     weight: segments[cur].weight,
+                    minimum_worker_version: segments[cur].minimum_worker_version.clone(),
                 });
                 filtered_chunks.push(chunk);
             }
@@ -53,13 +56,14 @@ pub fn weight_chunks(
         });
         metrics::report_chunks(&dataset, &stats);
     }
-    (weighted_chunks, filtered_chunks)
+    (scheduled_chunks, filtered_chunks)
 }
 
 struct Segment {
     from: u64,
     original_from: i64,
     weight: ChunkWeight,
+    minimum_worker_version: Option<Version>,
 }
 
 fn to_absolute_blocks(segments: &[DatasetSegmentConfig], last_block: u64) -> Vec<Segment> {
@@ -79,6 +83,7 @@ fn to_absolute_blocks(segments: &[DatasetSegmentConfig], last_block: u64) -> Vec
                 from,
                 original_from: seg.from,
                 weight: seg.weight,
+                minimum_worker_version: seg.minimum_worker_version.clone(),
             }
         })
         .collect()


### PR DESCRIPTION
# Version-Restricted Datasets

Addresses https://github.com/subsquid/network-scheduler/issues/5

## Overview

`minimum_worker_version` can now be specified in `DatasetSegmentConfig`. Chunks from such segments are only assigned to workers running a client version >= `minimum_worker_version`. This allows exposing datasets only supported by the latest query engine implementation without having to wait for all workers to upgrade first.

## How it works

The scheduling algorithm uses consistent hashing with 6000 hash rings. Each chunk replica is hashed to a position on one ring and assigned to the nearest worker that:

1. Has enough remaining capacity
2. Meets the version requirement (if any)
3. Has not exceeded the per-worker version-restricted data cap

**Processing order**: Version-restricted chunks are assigned before unrestricted ones. This guarantees restricted chunks find room on eligible workers before unrestricted chunks fill their capacity.

**Per-worker cap**: Each worker can store at most 20% of its capacity as version-restricted data (`MAX_VERSION_RESTRICTED_RATIO = 0.2`). This prevents eligible workers from being overloaded with restricted data, which would cause large-scale reassignment when more workers upgrade. When a worker hits this cap, restricted chunks move to the next eligible worker on the ring. The remaining 80% of eligible workers' capacity is available for unrestricted chunks.

## Constraints

For scheduling to succeed, two conditions must hold:

1. **R ≤ E**: The replication factor must not exceed the number of eligible workers. Each chunk replica needs a distinct worker.
2. **f ≤ 0.2 × E / (N × s)**: The fraction of version-restricted data must fit within the combined per-worker caps of all eligible workers.

_Condition 2 is derived from `R × S_restricted ≤ E × 0.2 × C` by substituting `R ≈ C × N × s / S_total` and cancelling `C`. The practical form is easier to evaluate because `f`, `E`, `N`, and `s` are usually known up-front._

Where:
- `R` = replication factor for the chunk's weight (roughly `C × N × s / S_total`)
- `E` = number of workers meeting the version requirement
- `N` = total number of workers
- `s` = saturation (e.g. 0.99)
- `f` = `S_restricted / S_total` — fraction of data that is version-restricted
- `C` = worker storage capacity (`worker_storage_bytes`)

If either condition is violated, the scheduler will panic and the previous assignment remains in effect.

**Note on weights**: The formula assumes version-restricted chunks have weight 1. Under this assumption, the formula is conservative when unrestricted chunks have varying weights: higher-weight unrestricted chunks consume more of the total capacity budget, leaving a smaller replication factor for weight-1 restricted chunks.

**Reliable/unreliable split**: When `ignore_reliability` is `false` (the default), the scheduler runs two independent passes — first for reliable workers only, then for all workers. Both constraints above must hold for each pass separately. In
particular, `E` in the reliable-only pass counts only *reliable* eligible workers. If only a few reliable workers meet the version requirement, the first pass can fail even when enough eligible workers exist overall (including unreliable ones).

## Reassignment impact

When workers upgrade, restricted chunks redistribute across the larger eligible pool. Unrestricted chunks are also affected indirectly: eligible workers storing restricted data have less room for unrestricted chunks, which spill further along the ring to
other workers.

Worst-case reassignment per worker when the eligible pool doubles: `MAX_VERSION_RESTRICTED_RATIO / 2 = 10%` of worker capacity.

## Checklist for adding a version-restricted dataset

1. **Estimate the restricted data fraction**: `f = S_restricted / S_total`. Keep this small (ideally < 1-2%).
2. **Count eligible workers**: check how many workers in the network already run a version >= your `minimum_worker_version`.
4. **Verify R ≤ E**: `R ≈ floor(C × N × s / S_total)`. If R > E, wait for more workers to upgrade.
5. **Verify capacity**: `f ≤ 0.2 × E / (N × s)`. If this fails, either wait for more upgrades or reduce the dataset's weight to lower its replication factor.
6. **Deploy and monitor**: after updating the config, watch the scheduler logs. If it panics, the old assignment stays active — no data is lost.
