### PR TITLE
feat: Reduce the size of the assignment by dropping the last block hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,9 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "flate2",
  "libp2p-identity",
+ "network-scheduler",
  "sqd-assignments 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "clear-block-hash"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "libp2p-identity",
+ "sqd-assignments 0.1.0",
+]
+
+[[package]]
 name = "clickhouse"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,6 +3640,7 @@ dependencies = [
  "flatbuffers 25.2.10",
  "hmac",
  "libp2p-identity",
+ "ouroboros",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_with = "3.12.0"
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681" }
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681", features = ["builder"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681", features = ["builder", "reader"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["tools/compare_fb"]
+members = ["tools/compare_fb", "tools/clear_block_hash"]
 
 [package]
 name = "network-scheduler"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,6 +150,9 @@ pub struct Config {
     /// with subdomain moved to the path-based routing
     #[serde(default)]
     pub storage_allow_insecure_scheme: bool,
+
+    #[serde(default)]
+    pub clear_last_block_hash: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,7 @@ pub struct Config {
     #[serde(default)]
     pub storage_allow_insecure_scheme: bool,
 
-    /// When provided the hash for the chunk will be set to empty string
+    /// When provided all the hashes except for the head of the dataset will be set to None
     #[serde(default)]
     pub clear_last_block_hash: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,6 +151,7 @@ pub struct Config {
     #[serde(default)]
     pub storage_allow_insecure_scheme: bool,
 
+    /// When provided the hash for the chunk will be set to empty string
     #[serde(default)]
     pub clear_last_block_hash: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod cli;
+pub mod cli_state;
+pub mod clickhouse;
+pub mod controller;
+pub mod metrics;
+pub mod parquet;
+pub mod pool;
+pub mod replication;
+pub mod scheduling;
+pub mod storage;
+#[cfg(test)]
+mod tests;
+pub mod types;
+pub mod upload;
+pub mod weight;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,12 @@
 use anyhow::Context;
 use clap::Parser;
 
-use crate::controller::{CacheAccess, Controller, WithAssignment};
-
-mod cli;
-mod cli_state;
-mod clickhouse;
-mod controller;
-mod metrics;
-mod parquet;
-mod pool;
-mod replication;
-mod scheduling;
-mod storage;
-#[cfg(test)]
-mod tests;
-mod types;
-mod upload;
-mod weight;
+use network_scheduler::controller::{CacheAccess, Controller, WithAssignment};
+use network_scheduler::{cli, metrics, storage, upload};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let _timer = crate::metrics::Timer::new("process");
+    let _timer = metrics::Timer::new("process");
 
     dotenv::dotenv().ok();
     let args = cli::Args::parse();
@@ -46,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_prod_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<WithAssignment> {
-    let db = clickhouse::ClickhouseClient::new(&args.clickhouse)
+    let db = network_scheduler::clickhouse::ClickhouseClient::new(&args.clickhouse)
         .await
         .context("Can't connect to ClickHouse")?;
 
@@ -70,8 +55,8 @@ async fn run_cli_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<W
         .as_ref()
         .context("CLI state file required for cli mode")?;
 
-    let cli_state =
-        cli_state::CliState::load(state_file).context("Failed to load CLI state file")?;
+    let cli_state = network_scheduler::cli_state::CliState::load(state_file)
+        .context("Failed to load CLI state file")?;
 
     let known_chunks = cli_state.to_chunks()?;
     let workers = cli_state.workers;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,34 +1,3 @@
 pub mod input;
 mod scheduling;
 mod utils;
-
-use std::collections::BTreeMap;
-use std::time::Duration;
-
-use crate::cli;
-
-pub fn test_config() -> cli::Config {
-    cli::Config {
-        datasets: BTreeMap::new(),
-        worker_inactive_timeout: Duration::from_secs(600),
-        ignore_reliability: false,
-        worker_storage_bytes: 0,
-        worker_stale_bytes: 0,
-        min_replication: 1,
-        saturation: 0.99,
-        network: "test".to_string(),
-        storage_domain: "test.io".to_string(),
-        network_state_name: "test.json".to_string(),
-        network_state_url: "https://test.io".to_string(),
-        scheduler_state_bucket: "test".to_string(),
-        cloudflare_storage_secret: "secret".to_string(),
-        min_supported_worker_version: "2.0.0".parse().unwrap(),
-        min_recommended_worker_version: "2.0.0".parse().unwrap(),
-        assignment_delay: Duration::from_secs(60),
-        assignment_ttl: Duration::from_secs(86400),
-        concurrent_dataset_downloads: 1,
-        strict_continuity_check: false,
-        storage_allow_insecure_scheme: false,
-        clear_last_block_hash: false,
-    }
-}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,34 @@
 pub mod input;
 mod scheduling;
 mod utils;
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use crate::cli;
+
+pub fn test_config() -> cli::Config {
+    cli::Config {
+        datasets: BTreeMap::new(),
+        worker_inactive_timeout: Duration::from_secs(600),
+        ignore_reliability: false,
+        worker_storage_bytes: 0,
+        worker_stale_bytes: 0,
+        min_replication: 1,
+        saturation: 0.99,
+        network: "test".to_string(),
+        storage_domain: "test.io".to_string(),
+        network_state_name: "test.json".to_string(),
+        network_state_url: "https://test.io".to_string(),
+        scheduler_state_bucket: "test".to_string(),
+        cloudflare_storage_secret: "secret".to_string(),
+        min_supported_worker_version: "2.0.0".parse().unwrap(),
+        min_recommended_worker_version: "2.0.0".parse().unwrap(),
+        assignment_delay: Duration::from_secs(60),
+        assignment_ttl: Duration::from_secs(86400),
+        concurrent_dataset_downloads: 1,
+        strict_continuity_check: false,
+        storage_allow_insecure_scheme: false,
+        clear_last_block_hash: false,
+    }
+}

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -120,14 +120,10 @@ impl Assignment {
                 .worker_indexes(&worker_ids)
                 .files(&chunk.files);
             if let Some(summary) = chunk.summary.as_ref() {
-                let hash = if config.clear_last_block_hash {
-                    ""
-                } else {
-                    &summary.last_block_hash
-                };
-                builder = builder
-                    .last_block_hash(hash)
-                    .last_block_timestamp(summary.last_block_timestamp);
+                if !config.clear_last_block_hash {
+                    builder = builder.last_block_hash(&summary.last_block_hash);
+                }
+                builder = builder.last_block_timestamp(summary.last_block_timestamp);
             }
             if let Err(e) = builder.finish() {
                 if config.strict_continuity_check {

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -189,10 +189,11 @@ mod tests {
             .to_peer_id()
     }
 
-    fn make_chunk(dataset: &str, id: &str, first: u64, last: u64, hash: &str) -> Chunk {
+    fn make_chunk(dataset: &str, first: u64, last: u64, hash: &str) -> Chunk {
+        let id = format!("{first:010}/{first:010}-{last:010}-{:08x}", first as u32);
         Chunk {
             dataset: Arc::new(dataset.to_string()),
-            id: id.to_string(),
+            id,
             size: 1000,
             blocks: first..=last,
             files: Arc::new(vec!["file.parquet".to_string()]),
@@ -221,11 +222,11 @@ mod tests {
     fn clear_last_block_hash_keeps_last_chunk_per_dataset() {
         let worker = make_worker();
         let chunks = vec![
-            make_chunk("s3://dataset-a", "0000000000/0000000000-0000000099-00000000", 0, 99, "hash_a1"),
-            make_chunk("s3://dataset-a", "0000000100/0000000100-0000000199-00000001", 100, 199, "hash_a2"),
-            make_chunk("s3://dataset-a", "0000000200/0000000200-0000000299-00000002", 200, 299, "hash_a3"),
-            make_chunk("s3://dataset-b", "0000000000/0000000000-0000000099-00000000", 0, 99, "hash_b1"),
-            make_chunk("s3://dataset-b", "0000000100/0000000100-0000000199-00000001", 100, 199, "hash_b2"),
+            make_chunk("s3://dataset-a", 0, 99, "hash_a1"),
+            make_chunk("s3://dataset-a", 100, 199, "hash_a2"),
+            make_chunk("s3://dataset-a", 200, 299, "hash_a3"),
+            make_chunk("s3://dataset-b", 0, 99, "hash_b1"),
+            make_chunk("s3://dataset-b", 100, 199, "hash_b2"),
         ];
 
         let assignment = Assignment {

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -120,8 +120,13 @@ impl Assignment {
                 .worker_indexes(&worker_ids)
                 .files(&chunk.files);
             if let Some(summary) = chunk.summary.as_ref() {
+                let hash = if config.clear_last_block_hash {
+                    ""
+                } else {
+                    &summary.last_block_hash
+                };
                 builder = builder
-                    .last_block_hash(&summary.last_block_hash)
+                    .last_block_hash(hash)
                     .last_block_timestamp(summary.last_block_timestamp);
             }
             if let Err(e) = builder.finish() {

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -178,10 +178,36 @@ impl Assignment {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
     use super::*;
     use crate::types::ChunkSummary;
+
+    fn test_config() -> cli::Config {
+        cli::Config {
+            datasets: BTreeMap::new(),
+            worker_inactive_timeout: Duration::from_secs(600),
+            ignore_reliability: false,
+            worker_storage_bytes: 0,
+            worker_stale_bytes: 0,
+            min_replication: 1,
+            saturation: 0.99,
+            network: "test".to_string(),
+            storage_domain: "test.io".to_string(),
+            network_state_name: "test.json".to_string(),
+            network_state_url: "https://test.io".to_string(),
+            scheduler_state_bucket: "test".to_string(),
+            cloudflare_storage_secret: "secret".to_string(),
+            min_supported_worker_version: "2.0.0".parse().unwrap(),
+            min_recommended_worker_version: "2.0.0".parse().unwrap(),
+            assignment_delay: Duration::from_secs(60),
+            assignment_ttl: Duration::from_secs(86400),
+            concurrent_dataset_downloads: 1,
+            strict_continuity_check: false,
+            storage_allow_insecure_scheme: false,
+            clear_last_block_hash: false,
+        }
+    }
 
     fn make_worker() -> PeerId {
         libp2p_identity::Keypair::generate_ed25519()
@@ -240,7 +266,7 @@ mod tests {
         }];
 
         // With clear_last_block_hash: only last chunk per dataset keeps the hash
-        let mut config = crate::tests::test_config();
+        let mut config = test_config();
         config.clear_last_block_hash = true;
         let fb_bytes = assignment.encode_fb(&chunks, &config, &workers, FbVersion::V1);
         let hashes = read_chunk_hashes(&fb_bytes);
@@ -252,7 +278,7 @@ mod tests {
         assert_eq!(hashes[4].1, Some("hash_b2".to_string()));
 
         // Without clear_last_block_hash: all hashes preserved
-        let mut config = crate::tests::test_config();
+        let mut config = test_config();
         config.clear_last_block_hash = false;
         let fb_bytes = assignment.encode_fb(&chunks, &config, &workers, FbVersion::V1);
         let hashes = read_chunk_hashes(&fb_bytes);

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -95,7 +95,8 @@ impl Assignment {
                 .check_continuity(config.strict_continuity_check);
 
         let mut prev_dataset = None;
-        for (chunk, worker_ids) in chunks.iter().zip(assigned_worker_ids) {
+        let mut iter = chunks.iter().zip(assigned_worker_ids).peekable();
+        while let Some((chunk, worker_ids)) = iter.next() {
             if prev_dataset
                 .as_ref()
                 .is_some_and(|prev| prev != &chunk.dataset)
@@ -104,6 +105,10 @@ impl Assignment {
                 assignment_builder.finish_dataset();
             }
             prev_dataset = Some(chunk.dataset.clone());
+
+            let is_last_in_dataset = iter
+                .peek()
+                .map_or(true, |(next, _)| next.dataset != chunk.dataset);
 
             let download_url = if config.storage_allow_insecure_scheme {
                 format!("http://{}/{}/", config.storage_domain, chunk.bucket())
@@ -120,7 +125,7 @@ impl Assignment {
                 .worker_indexes(&worker_ids)
                 .files(&chunk.files);
             if let Some(summary) = chunk.summary.as_ref() {
-                if !config.clear_last_block_hash {
+                if !config.clear_last_block_hash || is_last_in_dataset {
                     builder = builder.last_block_hash(&summary.last_block_hash);
                 }
                 builder = builder.last_block_timestamp(summary.last_block_timestamp);
@@ -168,5 +173,93 @@ impl Assignment {
             }
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::types::ChunkSummary;
+
+    fn make_worker() -> PeerId {
+        libp2p_identity::Keypair::generate_ed25519()
+            .public()
+            .to_peer_id()
+    }
+
+    fn make_chunk(dataset: &str, id: &str, first: u64, last: u64, hash: &str) -> Chunk {
+        Chunk {
+            dataset: Arc::new(dataset.to_string()),
+            id: id.to_string(),
+            size: 1000,
+            blocks: first..=last,
+            files: Arc::new(vec!["file.parquet".to_string()]),
+            summary: Some(ChunkSummary {
+                last_block_hash: hash.to_string(),
+                last_block_timestamp: 1000,
+            }),
+        }
+    }
+
+    fn read_chunk_hashes(fb_bytes: &[u8]) -> Vec<(String, Option<String>)> {
+        let fb = sqd_assignments::Assignment::from_owned_unchecked(fb_bytes.to_vec());
+        let mut result = Vec::new();
+        for dataset in fb.datasets() {
+            for chunk in dataset.chunks() {
+                result.push((
+                    chunk.id().to_string(),
+                    chunk.last_block_hash().map(|s| s.to_string()),
+                ));
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn clear_last_block_hash_keeps_last_chunk_per_dataset() {
+        let worker = make_worker();
+        let chunks = vec![
+            make_chunk("s3://dataset-a", "0000000000/0000000000-0000000099-00000000", 0, 99, "hash_a1"),
+            make_chunk("s3://dataset-a", "0000000100/0000000100-0000000199-00000001", 100, 199, "hash_a2"),
+            make_chunk("s3://dataset-a", "0000000200/0000000200-0000000299-00000002", 200, 299, "hash_a3"),
+            make_chunk("s3://dataset-b", "0000000000/0000000000-0000000099-00000000", 0, 99, "hash_b1"),
+            make_chunk("s3://dataset-b", "0000000100/0000000100-0000000199-00000001", 100, 199, "hash_b2"),
+        ];
+
+        let assignment = Assignment {
+            worker_chunks: BTreeMap::from([(worker, vec![0, 1, 2, 3, 4])]),
+            replication_by_weight: BTreeMap::new(),
+        };
+        let workers = vec![Worker {
+            id: worker,
+            status: WorkerStatus::Online,
+            version: None,
+        }];
+
+        // With clear_last_block_hash: only last chunk per dataset keeps the hash
+        let mut config = crate::tests::test_config();
+        config.clear_last_block_hash = true;
+        let fb_bytes = assignment.encode_fb(&chunks, &config, &workers, FbVersion::V1);
+        let hashes = read_chunk_hashes(&fb_bytes);
+
+        assert_eq!(hashes[0].1, None);
+        assert_eq!(hashes[1].1, None);
+        assert_eq!(hashes[2].1, Some("hash_a3".to_string()));
+        assert_eq!(hashes[3].1, None);
+        assert_eq!(hashes[4].1, Some("hash_b2".to_string()));
+
+        // Without clear_last_block_hash: all hashes preserved
+        let mut config = crate::tests::test_config();
+        config.clear_last_block_hash = false;
+        let fb_bytes = assignment.encode_fb(&chunks, &config, &workers, FbVersion::V1);
+        let hashes = read_chunk_hashes(&fb_bytes);
+
+        assert_eq!(hashes[0].1, Some("hash_a1".to_string()));
+        assert_eq!(hashes[1].1, Some("hash_a2".to_string()));
+        assert_eq!(hashes[2].1, Some("hash_a3".to_string()));
+        assert_eq!(hashes[3].1, Some("hash_b1".to_string()));
+        assert_eq!(hashes[4].1, Some("hash_b2".to_string()));
     }
 }

--- a/tools/clear_block_hash/Cargo.toml
+++ b/tools/clear_block_hash/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.38", features = ["derive", "env"] }
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681", features = ["reader", "builder"] }
+flate2 = "1.1.1"
+network-scheduler = { path = "../.." }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681", features = ["reader"] }
 libp2p-identity = { version = "0.2.10", features = ["peerid"] }

--- a/tools/clear_block_hash/Cargo.toml
+++ b/tools/clear_block_hash/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "clear-block-hash"
+version = "0.0.1"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.98"
+clap = { version = "4.5.38", features = ["derive", "env"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681", features = ["reader", "builder"] }
+libp2p-identity = { version = "0.2.10", features = ["peerid"] }

--- a/tools/clear_block_hash/src/main.rs
+++ b/tools/clear_block_hash/src/main.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use sqd_assignments::{Assignment, AssignmentBuilder};
+
+#[derive(Parser, Debug)]
+#[command(about = "Read an assignment and rewrite it with last_block_hash cleared on every chunk")]
+pub struct Args {
+    /// Input assignment file (flatbuffer)
+    #[arg(value_name = "INPUT")]
+    pub input: PathBuf,
+
+    /// Output assignment file
+    #[arg(value_name = "OUTPUT")]
+    pub output: PathBuf,
+
+    /// Cloudflare storage secret (required to generate encrypted worker headers)
+    #[arg(long, env = "CLOUDFLARE_STORAGE_SECRET")]
+    pub cloudflare_storage_secret: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let buf = std::fs::read(&args.input)?;
+    let assignment = Assignment::from_owned_unchecked(buf);
+
+    let mut builder = AssignmentBuilder::new(&args.cloudflare_storage_secret)
+        .check_continuity(false);
+
+    for dataset in assignment.datasets() {
+        let chunks: Vec<_> = dataset.chunks().iter().collect();
+        for (i, chunk) in chunks.iter().enumerate() {
+            let last_block = if i + 1 < chunks.len() {
+                chunks[i + 1].first_block() - 1
+            } else {
+                dataset.last_block()
+            };
+
+            let files: Vec<String> = chunk.files().iter().map(|f| f.filename().to_owned()).collect();
+            let worker_indexes: Vec<u16> = chunk.worker_indexes().iter().collect();
+
+            builder
+                .new_chunk()
+                .id(chunk.id())
+                .dataset_id(chunk.dataset_id())
+                .block_range(chunk.first_block()..=last_block)
+                .size(chunk.size())
+                .dataset_base_url(chunk.dataset_base_url())
+                .worker_indexes(&worker_indexes)
+                .files(&files)
+                .last_block_hash("")
+                .finish()?;
+        }
+        builder.finish_dataset();
+    }
+
+    let num_workers = assignment.workers().len();
+    for i in 0..num_workers {
+        let peer_id = assignment.get_worker_id(i as u16)?;
+        let worker = assignment
+            .get_worker(&peer_id)
+            .expect("Worker must exist in assignment");
+        builder.add_worker(peer_id, worker.status(), &[]);
+    }
+
+    let output = builder.finish();
+    std::fs::write(&args.output, &output)?;
+
+    eprintln!(
+        "Wrote {} bytes to {}",
+        output.len(),
+        args.output.display()
+    );
+
+    Ok(())
+}

--- a/tools/clear_block_hash/src/main.rs
+++ b/tools/clear_block_hash/src/main.rs
@@ -1,3 +1,7 @@
+/// A utility program to test the impact of last block hash in the assignment.
+/// To use run:
+/// cargo run -p clear-block-hash -- -c config.yaml input.fb output.fb
+
 use std::{
     collections::BTreeMap,
     io::{Read, Write},
@@ -25,7 +29,7 @@ pub struct Args {
     pub output: PathBuf,
 
     /// Scheduler config file (same one used to produce the assignment)
-    #[arg(long, short, default_value = "tools/clear_block_hash/config.yaml")]
+    #[arg(long, short)]
     pub config: PathBuf,
 }
 

--- a/tools/clear_block_hash/src/main.rs
+++ b/tools/clear_block_hash/src/main.rs
@@ -1,7 +1,17 @@
-use std::path::PathBuf;
+use std::{
+    collections::BTreeMap,
+    io::{Read, Write},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use clap::Parser;
-use sqd_assignments::{Assignment, AssignmentBuilder};
+use flate2::{Compression, read::GzDecoder, write::GzEncoder};
+use libp2p_identity::PeerId;
+use network_scheduler::types::{
+    Assignment, Chunk, ChunkIndex, ChunkSummary, FbVersion, Worker, WorkerStatus,
+};
+use sqd_assignments::Assignment as FbAssignment;
 
 #[derive(Parser, Debug)]
 #[command(about = "Read an assignment and rewrite it with last_block_hash cleared on every chunk")]
@@ -14,64 +24,124 @@ pub struct Args {
     #[arg(value_name = "OUTPUT")]
     pub output: PathBuf,
 
-    /// Cloudflare storage secret (required to generate encrypted worker headers)
-    #[arg(long, env = "CLOUDFLARE_STORAGE_SECRET")]
-    pub cloudflare_storage_secret: String,
+    /// Scheduler config file (same one used to produce the assignment)
+    #[arg(long, short, default_value = "tools/clear_block_hash/config.yaml")]
+    pub config: PathBuf,
 }
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    let mut config = network_scheduler::cli::Config::load(&args.config)?;
+    config.clear_last_block_hash = true;
 
-    let buf = std::fs::read(&args.input)?;
-    let assignment = Assignment::from_owned_unchecked(buf);
+    let raw = std::fs::read(&args.input)?;
+    let buf = if args.input.extension().is_some_and(|ext| ext == "gz") {
+        let mut decoder = GzDecoder::new(&raw[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed)?;
+        decompressed
+    } else {
+        raw
+    };
+    let fb = FbAssignment::from_owned_unchecked(buf);
 
-    let mut builder = AssignmentBuilder::new(&args.cloudflare_storage_secret)
-        .check_continuity(false);
+    let mut worker_ids: Vec<PeerId> = Vec::new();
+    for i in 0..fb.workers().len() {
+        worker_ids.push(fb.get_worker_id(i as u16)?);
+    }
 
-    for dataset in assignment.datasets() {
-        let chunks: Vec<_> = dataset.chunks().iter().collect();
-        for (i, chunk) in chunks.iter().enumerate() {
-            let last_block = if i + 1 < chunks.len() {
-                chunks[i + 1].first_block() - 1
+    let mut chunks: Vec<Chunk> = Vec::new();
+    let mut worker_chunks: BTreeMap<PeerId, Vec<ChunkIndex>> = BTreeMap::new();
+    let mut chunk_index: ChunkIndex = 0;
+
+    for dataset in fb.datasets() {
+        let fb_chunks: Vec<_> = dataset.chunks().iter().collect();
+        for (i, fb_chunk) in fb_chunks.iter().enumerate() {
+            let last_block = if i + 1 < fb_chunks.len() {
+                fb_chunks[i + 1].first_block() - 1
             } else {
                 dataset.last_block()
             };
 
-            let files: Vec<String> = chunk.files().iter().map(|f| f.filename().to_owned()).collect();
-            let worker_indexes: Vec<u16> = chunk.worker_indexes().iter().collect();
+            let dataset_id = fb_chunk.dataset_id().to_owned();
+            let files: Vec<String> = fb_chunk
+                .files()
+                .iter()
+                .map(|f| f.filename().to_owned())
+                .collect();
 
-            builder
-                .new_chunk()
-                .id(chunk.id())
-                .dataset_id(chunk.dataset_id())
-                .block_range(chunk.first_block()..=last_block)
-                .size(chunk.size())
-                .dataset_base_url(chunk.dataset_base_url())
-                .worker_indexes(&worker_indexes)
-                .files(&files)
-                .last_block_hash("")
-                .finish()?;
+            let summary = fb_chunk.last_block_hash().map(|hash| ChunkSummary {
+                last_block_hash: hash.to_owned(),
+                last_block_timestamp: fb_chunk.last_block_timestamp().unwrap_or(0),
+            });
+
+            let mut chunk = Chunk::new(
+                Arc::new(dataset_id),
+                fb_chunk.id().to_owned(),
+                fb_chunk.size(),
+                files,
+            )?;
+            chunk.blocks = fb_chunk.first_block()..=last_block;
+            chunk.summary = summary;
+            chunks.push(chunk);
+
+            for wi in fb_chunk.worker_indexes().iter() {
+                let peer_id = worker_ids[wi as usize];
+                worker_chunks.entry(peer_id).or_default().push(chunk_index);
+            }
+            chunk_index += 1;
+            if chunk_index % 50_000 == 0 {
+                eprintln!("Processed {} chunks...", chunk_index);
+            }
         }
-        builder.finish_dataset();
     }
 
-    let num_workers = assignment.workers().len();
-    for i in 0..num_workers {
-        let peer_id = assignment.get_worker_id(i as u16)?;
-        let worker = assignment
-            .get_worker(&peer_id)
-            .expect("Worker must exist in assignment");
-        builder.add_worker(peer_id, worker.status(), &[]);
+    let workers: Vec<Worker> = fb
+        .workers()
+        .iter()
+        .enumerate()
+        .map(|(i, _)| {
+            let peer_id = worker_ids[i];
+            let w = fb.get_worker(&peer_id).expect("Worker must exist");
+            let status = match w.status() {
+                sqd_assignments::WorkerStatus::Ok => WorkerStatus::Online,
+                sqd_assignments::WorkerStatus::Unreliable => WorkerStatus::Offline,
+                sqd_assignments::WorkerStatus::UnsupportedVersion => {
+                    WorkerStatus::UnsupportedVersion
+                }
+                _ => WorkerStatus::Offline,
+            };
+            Worker {
+                id: peer_id,
+                status,
+                version: None,
+            }
+        })
+        .collect();
+
+    for chunks in worker_chunks.values_mut() {
+        chunks.sort_unstable();
     }
 
-    let output = builder.finish();
-    std::fs::write(&args.output, &output)?;
+    let assignment = Assignment {
+        worker_chunks,
+        replication_by_weight: BTreeMap::new(),
+    };
 
+    let fb_bytes = assignment.encode_fb(&chunks, &config, &workers, FbVersion::V1);
+    std::fs::write(&args.output, &fb_bytes)?;
     eprintln!(
         "Wrote {} bytes to {}",
-        output.len(),
+        fb_bytes.len(),
         args.output.display()
     );
+
+    let gz_path = args.output.with_extension("fb.gz");
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(&fb_bytes)?;
+    let compressed = encoder.finish()?;
+    std::fs::write(&gz_path, &compressed)?;
+    eprintln!("Wrote {} bytes to {}", compressed.len(), gz_path.display());
 
     Ok(())
 }

--- a/tools/clear_block_hash/src/main.rs
+++ b/tools/clear_block_hash/src/main.rs
@@ -1,7 +1,6 @@
 /// A utility program to test the impact of last block hash in the assignment.
 /// To use run:
 /// cargo run -p clear-block-hash -- -c config.yaml input.fb output.fb
-
 use std::{
     collections::BTreeMap,
     io::{Read, Write},


### PR DESCRIPTION
Closes: [NET-585](https://linear.app/sqd-ai/issue/NET-585/feat-reduce-the-size-of-the-assignment-by-dropping-the-last-block-hash)

## What is this PR about?

`last_block_hash` is stored per chunk in the assignment to verify chunk continuity. However, given the current hash format, it occupies a significant amount of space. This PR adds a `clear_last_block_hash` config option that skips generating the hash. This requires `strict_continuity_check` to be disabled, but reduces the assignment size substantially.

Example (mainnet, May 2026):

| | Flatbuffer | Gzipped |
|---|---|---|
| With hash | 1.09 GB | 545 MB |
| Without hash | 819 MB | 321 MB |
| Reduction | **27%** | **41%** |

**Updated**: conditional last_block_hash call:
722 MB Flatbuffer
319 MB Gzipped

## How does it work?

- `clear_last_block_hash: bool` added to the scheduler config. When `true`, `encode_fb` writes actual hashes only for the last chunks in the dataset.
- `src/lib.rs` extracted so tools can depend on the main crate.
- A `clear-block-hash` CLI utility is included for rewriting existing assignments with the hash cleared, useful for evaluating the impact before enabling in production.

### Running the tool

```bash
cargo run -p clear-block-hash -- -c path/to/config.yaml input.fb output.fb
```