### PR TITLE
Add reshuffle frequency simulation tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
 name = "cc"
 version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1340,22 @@ checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -2409,6 +2431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,6 +3137,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
+name = "reshuffle-sim"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "clap",
+ "dhat",
+ "flate2",
+ "libp2p-identity",
+ "network-scheduler",
+ "rand 0.9.1",
+ "semver",
+ "sqd-assignments 0.1.0",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,6 +3816,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["tools/compare_fb", "tools/clear_block_hash"]
+members = ["tools/compare_fb", "tools/clear_block_hash", "tools/reshuffle_sim"]
 
 [package]
 name = "network-scheduler"

--- a/tools/reshuffle_sim/Cargo.toml
+++ b/tools/reshuffle_sim/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "reshuffle-sim"
+version = "0.0.1"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.98"
+clap = { version = "4.5.38", features = ["derive", "env"] }
+dhat = "0.3"
+flate2 = "1.1.1"
+network-scheduler = { path = "../.." }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681", features = ["reader"] }
+libp2p-identity = { version = "0.2.10", features = ["peerid"] }
+semver = "1.0.26"
+bytesize = "2.3.1"
+rand = "0.9.1"

--- a/tools/reshuffle_sim/README.md
+++ b/tools/reshuffle_sim/README.md
@@ -1,0 +1,9 @@
+# Reshuffle Simulation
+
+Simulates chunk ingestion over multiple steps against a real assignment, runs the scheduler each step, and measures how much data movement (S3 downloads) the reshuffling causes.
+
+## Usage
+
+```sh
+cargo run -p reshuffle-sim -- -c config.yaml --chunks-per-step 1000 --steps 10 --report report.html input.fb.gz
+```

--- a/tools/reshuffle_sim/src/baseline.rs
+++ b/tools/reshuffle_sim/src/baseline.rs
@@ -1,0 +1,176 @@
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    io::Read,
+    path::PathBuf,
+    sync::Arc,
+};
+
+use flate2::read::GzDecoder;
+use libp2p_identity::PeerId;
+use network_scheduler::types::{BlockNumber, Chunk, Worker, WorkerStatus};
+use semver::Version;
+use sqd_assignments::Assignment as FbAssignment;
+
+use crate::{ChunkEntry, ChunkIndex};
+
+pub struct DatasetInfo {
+    pub dataset_id: Arc<String>,
+    pub chunk_count: u32,
+    pub last_block: BlockNumber,
+    pub avg_block_span: u64,
+    pub avg_chunk_size: u32,
+}
+
+pub struct Baseline {
+    pub chunks: Vec<Chunk>,
+    pub workers: Vec<Worker>,
+    pub chunk_index: ChunkIndex,
+    pub datasets: Vec<DatasetInfo>,
+}
+
+fn read_flatbuffer(path: &PathBuf) -> anyhow::Result<Vec<u8>> {
+    let raw = std::fs::read(path)?;
+    if path.extension().is_some_and(|ext| ext == "gz") || path.to_string_lossy().ends_with(".fb.gz")
+    {
+        let mut decoder = GzDecoder::new(&raw[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed)?;
+        Ok(decompressed)
+    } else {
+        Ok(raw)
+    }
+}
+
+fn extract_peer_ids(fb: &FbAssignment) -> anyhow::Result<Vec<PeerId>> {
+    (0..fb.workers().len())
+        .map(|i| fb.get_worker_id(i as u16))
+        .collect()
+}
+
+fn extract_workers(fb: &FbAssignment, worker_version: &Version) -> anyhow::Result<Vec<Worker>> {
+    let worker_peer_ids = extract_peer_ids(fb)?;
+
+    let workers = fb
+        .workers()
+        .iter()
+        .enumerate()
+        .map(|(i, _)| {
+            let peer_id = worker_peer_ids[i];
+            let fb_worker = fb.get_worker(&peer_id).expect("Worker must exist");
+            let status = match fb_worker.status() {
+                sqd_assignments::WorkerStatus::Ok => WorkerStatus::Online,
+                sqd_assignments::WorkerStatus::Unreliable => WorkerStatus::Offline,
+                sqd_assignments::WorkerStatus::UnsupportedVersion => {
+                    WorkerStatus::UnsupportedVersion
+                }
+                _ => WorkerStatus::Offline,
+            };
+            Worker {
+                id: peer_id,
+                status,
+                version: Some(worker_version.clone()),
+            }
+        })
+        .collect();
+
+    Ok(workers)
+}
+
+/// Reconstructs chunks and their worker ownership from the flatbuffer.
+/// Each chunk's last_block is inferred from the next chunk's first_block within the same dataset.
+fn extract_chunks_and_index(fb: &FbAssignment) -> anyhow::Result<(Vec<Chunk>, ChunkIndex)> {
+    let worker_peer_ids = extract_peer_ids(fb)?;
+
+    let mut chunks = Vec::new();
+    let mut chunk_index = HashMap::new();
+    let mut dataset_pool: HashMap<String, Arc<String>> = HashMap::new();
+
+    for dataset in fb.datasets() {
+        let fb_chunks: Vec<_> = dataset.chunks().iter().collect();
+        for (i, fb_chunk) in fb_chunks.iter().enumerate() {
+            let first_block = fb_chunk.first_block();
+            let last_block = if i + 1 < fb_chunks.len() {
+                fb_chunks[i + 1].first_block() - 1
+            } else {
+                dataset.last_block()
+            };
+
+            let dataset_arc = dataset_pool
+                .entry(fb_chunk.dataset_id().to_owned())
+                .or_insert_with_key(|k| Arc::new(k.clone()))
+                .clone();
+            let chunk_id_arc = Arc::new(fb_chunk.id().to_owned());
+            let size = fb_chunk.size();
+
+            chunks.push(Chunk {
+                dataset: dataset_arc.clone(),
+                id: (*chunk_id_arc).clone(),
+                size,
+                blocks: first_block..=last_block,
+                files: Arc::new(vec![]),
+                summary: None,
+            });
+
+            let owners: HashSet<PeerId> = fb_chunk
+                .worker_indexes()
+                .iter()
+                .map(|wi| worker_peer_ids[wi as usize])
+                .collect();
+            chunk_index.insert((dataset_arc, chunk_id_arc), ChunkEntry { owners, size });
+        }
+    }
+
+    Ok((chunks, chunk_index))
+}
+
+/// Aggregates per-dataset statistics needed for proportional chunk generation:
+/// chunk count, highest block number, average block span, and average chunk size.
+fn compute_dataset_stats(chunks: &[Chunk]) -> Vec<DatasetInfo> {
+    let mut stats: BTreeMap<Arc<String>, (u32, BlockNumber, u64, u64)> = BTreeMap::new();
+
+    for chunk in chunks {
+        let first = *chunk.blocks.start();
+        let last = *chunk.blocks.end();
+        let entry = stats.entry(chunk.dataset.clone()).or_insert((0, 0, 0, 0));
+        entry.0 += 1;
+        entry.1 = entry.1.max(last);
+        entry.2 += last - first + 1;
+        entry.3 += chunk.size as u64;
+    }
+
+    stats
+        .into_iter()
+        .map(
+            |(dataset_id, (count, last_block, total_block_span, total_bytes))| DatasetInfo {
+                dataset_id,
+                chunk_count: count,
+                last_block,
+                avg_block_span: total_block_span / count.max(1) as u64,
+                avg_chunk_size: (total_bytes / count.max(1) as u64) as u32,
+            },
+        )
+        .collect()
+}
+
+pub fn load_baseline(path: &PathBuf, worker_version: &Version) -> anyhow::Result<Baseline> {
+    let buf = read_flatbuffer(path)?;
+    let fb = FbAssignment::from_owned_unchecked(buf);
+
+    let workers = extract_workers(&fb, worker_version)?;
+    let (chunks, chunk_index) = extract_chunks_and_index(&fb)?;
+    let datasets = compute_dataset_stats(&chunks);
+
+    eprintln!(
+        "Loaded {} chunks across {} datasets, {} workers",
+        chunks.len(),
+        datasets.len(),
+        workers.len()
+    );
+
+    Ok(Baseline {
+        chunks,
+        workers,
+        chunk_index,
+        datasets,
+    })
+}

--- a/tools/reshuffle_sim/src/main.rs
+++ b/tools/reshuffle_sim/src/main.rs
@@ -1,0 +1,127 @@
+/// Simulates chunk ingestion over multiple steps and measures reshuffling impact.
+///
+/// Reads a real assignment (flatbuffer), generates new chunks at the head of each
+/// dataset proportionally to existing sizes, then runs the scheduler and diffs
+/// against the original assignment.
+///
+/// Usage:
+///   cargo run -p reshuffle-sim -- -c config.yaml --chunks-per-step 1000 --steps 10 input.fb.gz
+mod baseline;
+mod report;
+mod simulation;
+mod util;
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use anyhow::Context;
+use clap::Parser;
+use libp2p_identity::PeerId;
+use network_scheduler::{cli::Config, scheduling::SchedulingConfig, types::Chunk};
+use rand::prelude::*;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+type ChunkId = (Arc<String>, Arc<String>);
+type ChunkIndex = HashMap<ChunkId, ChunkEntry>;
+
+pub struct ChunkEntry {
+    pub owners: HashSet<PeerId>,
+    pub size: u32,
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "Simulate chunk ingestion and measure reshuffling")]
+struct Args {
+    /// Input assignment file (flatbuffer, optionally .gz)
+    #[arg(value_name = "INPUT")]
+    input: PathBuf,
+
+    /// Scheduler config file
+    #[arg(long, short)]
+    config: PathBuf,
+
+    /// Number of new chunks to generate per step
+    #[arg(long, default_value = "1000")]
+    chunks_per_step: u32,
+
+    /// Number of simulation steps
+    #[arg(long, default_value = "10")]
+    steps: u32,
+
+    /// Random seed for reproducibility
+    #[arg(long, default_value = "42")]
+    seed: u64,
+
+    /// Write an HTML report with charts to this path
+    #[arg(long, default_missing_value = "report.html", num_args = 0..=1)]
+    report: Option<PathBuf>,
+
+    /// Enable dhat heap profiling for this run (writes dhat-heap.json on exit).
+    /// View with https://nnethercote.github.io/dh_view/dh_view.html
+    #[arg(long)]
+    dhat: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let _profiler = args.dhat.then(dhat::Profiler::new_heap);
+    let config = Config::load(&args.config).context("Failed to load config")?;
+
+    eprintln!("Loading baseline assignment from {:?}", args.input);
+    let mut baseline = baseline::load_baseline(&args.input, &config.min_supported_worker_version)?;
+
+    let scheduling_config = SchedulingConfig {
+        worker_capacity: config.worker_storage_bytes,
+        saturation: config.saturation,
+        min_replication: config.min_replication,
+        ignore_reliability: config.ignore_reliability,
+    };
+
+    let mut rng = StdRng::seed_from_u64(args.seed);
+    let mut accumulated_new_chunks: Vec<Chunk> = Vec::new();
+    let mut previous_index = baseline.chunk_index;
+    let mut all_metrics = Vec::new();
+
+    util::print_header();
+
+    for step in 1..=args.steps {
+        let step_chunks =
+            simulation::generate_new_chunks(&mut baseline.datasets, args.chunks_per_step, &mut rng);
+        let new_count = step_chunks.len() as u32;
+        accumulated_new_chunks.extend(step_chunks);
+
+        let (filtered_chunks, assignment) = simulation::schedule_combined_chunks(
+            &baseline.chunks,
+            &accumulated_new_chunks,
+            &baseline.workers,
+            &config.datasets,
+            &scheduling_config,
+        )?;
+
+        let (metrics, current_index) = simulation::measure_reshuffle(
+            &previous_index,
+            &filtered_chunks,
+            &assignment,
+            step,
+            new_count,
+            baseline.workers.len(),
+            scheduling_config.worker_capacity,
+        );
+
+        util::print_step(&metrics);
+        all_metrics.push(metrics);
+
+        previous_index = current_index;
+    }
+
+    if let Some(report_path) = &args.report {
+        report::generate_html(&all_metrics, report_path)?;
+    }
+
+    Ok(())
+}

--- a/tools/reshuffle_sim/src/report.rs
+++ b/tools/reshuffle_sim/src/report.rs
@@ -1,0 +1,114 @@
+use std::fmt::Write;
+use std::path::Path;
+
+use bytesize::ByteSize;
+
+use crate::simulation::ReshuffleMetrics;
+
+const TEMPLATE: &str = include_str!("../templates/report.html");
+
+pub fn generate_html(metrics: &[ReshuffleMetrics], path: &Path) -> anyhow::Result<()> {
+    let html = TEMPLATE
+        .replacen("__DATA__", &build_data_json(metrics), 1)
+        .replacen("__TABLE_ROWS__", &build_table_rows(metrics), 1);
+
+    std::fs::write(path, html)?;
+    eprintln!("Report written to {}", path.display());
+    Ok(())
+}
+
+fn build_data_json(metrics: &[ReshuffleMetrics]) -> String {
+    let steps: Vec<u32> = metrics.iter().map(|m| m.step).collect();
+    let new_chunks: Vec<u32> = metrics.iter().map(|m| m.new_chunks_in_step).collect();
+    let total_chunks: Vec<usize> = metrics.iter().map(|m| m.total_chunks).collect();
+    let new_chunk_bytes: Vec<u64> = metrics
+        .iter()
+        .map(|m| m.data_movement.new_chunk_bytes)
+        .collect();
+    let shuffled_bytes: Vec<u64> = metrics
+        .iter()
+        .map(|m| m.data_movement.shuffled_bytes)
+        .collect();
+    let shuffled_count: Vec<u32> = metrics
+        .iter()
+        .map(|m| m.data_movement.shuffled_count)
+        .collect();
+    let increased_repl: Vec<u64> = metrics
+        .iter()
+        .map(|m| m.data_movement.increased_replication_bytes)
+        .collect();
+    let decreased_repl: Vec<u64> = metrics
+        .iter()
+        .map(|m| m.data_movement.decreased_replication_bytes)
+        .collect();
+    let total_download: Vec<u64> = metrics
+        .iter()
+        .map(|m| m.data_movement.total_download())
+        .collect();
+    let free_capacity: Vec<u64> = metrics.iter().map(|m| m.free_capacity()).collect();
+    let used_pct: Vec<f64> = metrics.iter().map(|m| m.used_pct()).collect();
+    let workers_receiving_new: Vec<usize> = metrics
+        .iter()
+        .map(|m| m.data_movement.workers_receiving_new)
+        .collect();
+    let workers_losing: Vec<usize> = metrics
+        .iter()
+        .map(|m| m.data_movement.workers_losing)
+        .collect();
+    let workers_shuffled: Vec<usize> = metrics
+        .iter()
+        .map(|m| m.data_movement.workers_shuffled)
+        .collect();
+
+    format!(
+        r#"{{
+"steps":{steps:?},
+"newChunks":{new_chunks:?},
+"totalChunks":{total_chunks:?},
+"newChunkBytes":{new_chunk_bytes:?},
+"shuffledBytes":{shuffled_bytes:?},
+"shuffledCount":{shuffled_count:?},
+"increasedRepl":{increased_repl:?},
+"decreasedRepl":{decreased_repl:?},
+"totalDownload":{total_download:?},
+"freeCapacity":{free_capacity:?},
+"usedPct":{used_pct:?},
+"workersReceivingNew":{workers_receiving_new:?},
+"workersLosing":{workers_losing:?},
+"workersShuffled":{workers_shuffled:?}
+}}"#,
+    )
+}
+
+fn build_table_rows(metrics: &[ReshuffleMetrics]) -> String {
+    let mut out = String::new();
+    for m in metrics {
+        let dm = &m.data_movement;
+        let _ = write!(
+            out,
+            "<tr>\
+             <td>{}</td><td>{}</td><td>{}</td><td>{}</td>\
+             <td>{}</td><td>{}</td><td>{}</td>\
+             <td>{}</td><td>{}</td><td>{}</td>\
+             <td>{}</td><td>{:.1}%</td>\
+             <td>{}</td><td>{}</td><td>{}</td>\
+             </tr>\n",
+            m.step,
+            m.new_chunks_in_step,
+            m.total_chunks,
+            m.replication_summary(),
+            ByteSize(dm.new_chunk_bytes),
+            dm.shuffled_count,
+            ByteSize(dm.shuffled_bytes),
+            ByteSize(dm.increased_replication_bytes),
+            ByteSize(dm.decreased_replication_bytes),
+            ByteSize(dm.total_download()),
+            ByteSize(m.free_capacity()),
+            m.used_pct(),
+            dm.workers_receiving_new,
+            dm.workers_losing,
+            dm.workers_shuffled,
+        );
+    }
+    out
+}

--- a/tools/reshuffle_sim/src/simulation.rs
+++ b/tools/reshuffle_sim/src/simulation.rs
@@ -1,0 +1,302 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
+
+use anyhow::Context;
+use libp2p_identity::PeerId;
+use network_scheduler::{
+    scheduling::{SchedulingConfig, schedule},
+    types::{Chunk, Worker},
+    weight::prepare_chunks,
+};
+use rand::prelude::*;
+
+use crate::{ChunkEntry, ChunkIndex, baseline::DatasetInfo};
+
+pub struct ReshuffleMetrics {
+    pub step: u32,
+    pub new_chunks_in_step: u32,
+    pub total_chunks: usize,
+    pub replication_by_weight: BTreeMap<u16, u16>,
+    pub data_movement: DataMovement,
+    pub total_capacity_bytes: u64,
+    pub used_capacity_bytes: u64,
+}
+
+pub struct DataMovement {
+    pub new_chunk_bytes: u64,
+    pub shuffled_bytes: u64,
+    pub shuffled_count: u32,
+    pub increased_replication_bytes: u64,
+    pub decreased_replication_bytes: u64,
+    pub workers_receiving_new: usize,
+    pub workers_losing: usize,
+    pub workers_shuffled: usize,
+}
+
+impl DataMovement {
+    pub fn total_download(&self) -> u64 {
+        self.new_chunk_bytes + self.shuffled_bytes + self.increased_replication_bytes
+    }
+}
+
+impl ReshuffleMetrics {
+    pub fn free_capacity(&self) -> u64 {
+        self.total_capacity_bytes
+            .saturating_sub(self.used_capacity_bytes)
+    }
+
+    pub fn used_pct(&self) -> f64 {
+        if self.total_capacity_bytes > 0 {
+            self.used_capacity_bytes as f64 / self.total_capacity_bytes as f64 * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    pub fn replication_summary(&self) -> String {
+        self.replication_by_weight
+            .iter()
+            .map(|(weight, factor)| format!("{weight}:{factor}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+// --- Chunk generation ---
+
+fn build_cumulative_distribution(datasets: &[DatasetInfo]) -> Vec<(usize, f64)> {
+    let total: f64 = datasets.iter().map(|d| d.chunk_count as f64).sum();
+    let mut cumulative = Vec::with_capacity(datasets.len());
+    let mut acc = 0.0;
+    for (i, ds) in datasets.iter().enumerate() {
+        acc += ds.chunk_count as f64 / total;
+        cumulative.push((i, acc));
+    }
+    cumulative
+}
+
+fn sample_dataset_index(cumulative: &[(usize, f64)], rng: &mut impl Rng) -> usize {
+    let r: f64 = rng.random();
+    cumulative
+        .iter()
+        .find(|(_, threshold)| r <= *threshold)
+        .map(|(i, _)| *i)
+        .unwrap_or(cumulative.len() - 1)
+}
+
+/// Creates synthetic chunks at the head (latest blocks) of each dataset.
+/// Datasets are sampled proportionally to their existing chunk counts —
+/// a dataset with 60% of total chunks receives ~60% of new chunks.
+/// Each generated chunk extends the dataset's block range using its average block span and size.
+pub fn generate_new_chunks(
+    datasets: &mut Vec<DatasetInfo>,
+    chunks_to_generate: u32,
+    rng: &mut impl Rng,
+) -> Vec<Chunk> {
+    let cumulative_distribution = build_cumulative_distribution(datasets);
+    let mut new_chunks = Vec::with_capacity(chunks_to_generate as usize);
+
+    for _ in 0..chunks_to_generate {
+        let dataset_index = sample_dataset_index(&cumulative_distribution, rng);
+        let dataset = &mut datasets[dataset_index];
+
+        let first_block = dataset.last_block + 1;
+        let last_block = first_block + dataset.avg_block_span - 1;
+        let chunk_id = format!(
+            "{:010}/{:010}-{:010}-{:08x}",
+            first_block, first_block, last_block, first_block as u32
+        );
+
+        new_chunks.push(Chunk {
+            dataset: dataset.dataset_id.clone(),
+            id: chunk_id,
+            size: dataset.avg_chunk_size,
+            blocks: first_block..=last_block,
+            files: Arc::new(vec![]),
+            summary: None,
+        });
+
+        dataset.last_block = last_block;
+        dataset.chunk_count += 1;
+    }
+
+    new_chunks
+}
+
+// --- Scheduling ---
+
+/// Merges existing and new chunks, assigns weights via the config's dataset segments,
+/// and runs the full scheduling algorithm. Chunks are sorted by dataset then block number
+/// so that `prepare_chunks` can resolve relative segment boundaries (e.g. `from: -10000000`)
+/// against the updated last_block of each dataset.
+pub fn schedule_combined_chunks(
+    existing_chunks: &[Chunk],
+    new_chunks: &[Chunk],
+    workers: &[Worker],
+    datasets_config: &network_scheduler::cli::DatasetsConfig,
+    scheduling_config: &SchedulingConfig,
+) -> anyhow::Result<(Vec<Chunk>, network_scheduler::types::Assignment)> {
+    let mut combined: Vec<Chunk> = existing_chunks.to_vec();
+    combined.extend_from_slice(new_chunks);
+    combined.sort_by(|a, b| {
+        a.dataset
+            .cmp(&b.dataset)
+            .then(a.blocks.start().cmp(b.blocks.start()))
+    });
+
+    let (scheduled_chunks, filtered_chunks) = prepare_chunks(combined, datasets_config);
+    let assignment = schedule(&scheduled_chunks, workers, scheduling_config.clone())
+        .context("Scheduling failed")?;
+
+    Ok((filtered_chunks, assignment))
+}
+
+// --- Assignment diffing ---
+
+fn build_chunk_index(
+    chunks: &[Chunk],
+    assignment: &network_scheduler::types::Assignment,
+) -> ChunkIndex {
+    let keys: Vec<(Arc<String>, Arc<String>)> = chunks
+        .iter()
+        .map(|c| (c.dataset.clone(), Arc::new(c.id.clone())))
+        .collect();
+
+    let mut index: ChunkIndex = keys
+        .iter()
+        .enumerate()
+        .map(|(i, key)| {
+            (
+                key.clone(),
+                ChunkEntry {
+                    owners: HashSet::new(),
+                    size: chunks[i].size,
+                },
+            )
+        })
+        .collect();
+
+    for (worker, chunk_indexes) in &assignment.worker_chunks {
+        for &ci in chunk_indexes {
+            index
+                .get_mut(&keys[ci as usize])
+                .unwrap()
+                .owners
+                .insert(*worker);
+        }
+    }
+
+    index
+}
+
+/// Classifies data movement between two assignments by cause.
+/// For each chunk in the current assignment:
+/// - New chunk (not in previous): all replicas count as new_chunk_bytes.
+/// - Existing chunk: workers gained/lost are classified as shuffle (1:1 swap)
+///   or replication change (net gain/loss of replicas).
+fn compute_data_movement(previous: &ChunkIndex, current: &ChunkIndex) -> DataMovement {
+    let mut result = DataMovement {
+        new_chunk_bytes: 0,
+        shuffled_bytes: 0,
+        shuffled_count: 0,
+        increased_replication_bytes: 0,
+        decreased_replication_bytes: 0,
+        workers_receiving_new: 0,
+        workers_losing: 0,
+        workers_shuffled: 0,
+    };
+
+    let mut workers_receiving_new: HashSet<PeerId> = HashSet::new();
+    let mut workers_losing: HashSet<PeerId> = HashSet::new();
+    let mut workers_shuffled: HashSet<PeerId> = HashSet::new();
+
+    for (chunk_id, entry) in current {
+        let size = entry.size as u64;
+
+        if let Some(prev_entry) = previous.get(chunk_id) {
+            let gained: usize = entry.owners.difference(&prev_entry.owners).count();
+            let lost: usize = prev_entry.owners.difference(&entry.owners).count();
+
+            let shuffled = gained.min(lost);
+            let replication_increase = gained.saturating_sub(lost);
+            let replication_decrease = lost.saturating_sub(gained);
+
+            if shuffled > 0 {
+                result.shuffled_count += 1;
+                result.shuffled_bytes += size * shuffled as u64;
+            }
+            result.increased_replication_bytes += size * replication_increase as u64;
+            result.decreased_replication_bytes += size * replication_decrease as u64;
+
+            if gained > 0 {
+                for w in entry.owners.difference(&prev_entry.owners) {
+                    workers_shuffled.insert(*w);
+                }
+            }
+            for w in prev_entry.owners.difference(&entry.owners) {
+                workers_losing.insert(*w);
+            }
+        } else {
+            result.new_chunk_bytes += size * entry.owners.len() as u64;
+            for w in &entry.owners {
+                workers_receiving_new.insert(*w);
+            }
+        }
+    }
+
+    for (chunk_id, prev_entry) in previous {
+        if !current.contains_key(chunk_id) {
+            let size = prev_entry.size as u64;
+            result.decreased_replication_bytes += size * prev_entry.owners.len() as u64;
+            for w in &prev_entry.owners {
+                workers_losing.insert(*w);
+            }
+        }
+    }
+
+    result.workers_receiving_new = workers_receiving_new.len();
+    result.workers_losing = workers_losing.len();
+    result.workers_shuffled = workers_shuffled.len();
+
+    result
+}
+
+/// Computes all reshuffle metrics for a single simulation step.
+/// All comparisons are against the previous step (incremental).
+/// Returns the current chunk owners for use as the next step's previous.
+pub fn measure_reshuffle(
+    previous: &ChunkIndex,
+    chunks: &[Chunk],
+    assignment: &network_scheduler::types::Assignment,
+    step: u32,
+    new_chunks_in_step: u32,
+    num_workers: usize,
+    worker_capacity: u64,
+) -> (ReshuffleMetrics, ChunkIndex) {
+    let current = build_chunk_index(chunks, assignment);
+
+    let data_movement = compute_data_movement(previous, &current);
+
+    let used_capacity_bytes: u64 = assignment
+        .worker_chunks
+        .values()
+        .flat_map(|indexes| indexes.iter())
+        .map(|&i| chunks[i as usize].size as u64)
+        .sum();
+
+    let total_capacity_bytes = num_workers as u64 * worker_capacity;
+
+    let metrics = ReshuffleMetrics {
+        step,
+        new_chunks_in_step,
+        total_chunks: chunks.len(),
+        replication_by_weight: assignment.replication_by_weight.clone(),
+        data_movement,
+        total_capacity_bytes,
+        used_capacity_bytes,
+    };
+
+    (metrics, current)
+}

--- a/tools/reshuffle_sim/src/util.rs
+++ b/tools/reshuffle_sim/src/util.rs
@@ -1,0 +1,47 @@
+use bytesize::ByteSize;
+
+use crate::simulation::ReshuffleMetrics;
+
+pub fn print_header() {
+    println!(
+        "{:>5} | {:>12} | {:>14} | {:>30} | {:>12} | {:>17} | {:>14} | {:>14} | {:>12} | {:>12} | {:>6} | {:>10} | {:>10} | {:>10}",
+        "Step",
+        "New chunks",
+        "Total chunks",
+        "Replication",
+        "New DL",
+        "Shuffled",
+        "Shuffle DL",
+        "Repl DL change",
+        "Total DL(*)",
+        "Free cap",
+        "Used%",
+        "W new",
+        "W lost",
+        "W shuffled"
+    );
+    println!("{}", "-".repeat(230));
+}
+
+pub fn print_step(metrics: &ReshuffleMetrics) {
+    let dm = &metrics.data_movement;
+
+    println!(
+        "{:>5} | {:>12} | {:>14} | {:>30} | {:>12} | {:>17} | {:>14} | {:>6}+ / {:<5}- | {:>12} | {:>12} | {:>6.1}% | {:>10} | {:>10} | {:>10}",
+        metrics.step,
+        metrics.new_chunks_in_step,
+        metrics.total_chunks,
+        metrics.replication_summary(),
+        ByteSize(dm.new_chunk_bytes),
+        format!("{} chunks", dm.shuffled_count),
+        ByteSize(dm.shuffled_bytes),
+        ByteSize(dm.increased_replication_bytes),
+        ByteSize(dm.decreased_replication_bytes),
+        ByteSize(dm.total_download()),
+        ByteSize(metrics.free_capacity()),
+        metrics.used_pct(),
+        dm.workers_receiving_new,
+        dm.workers_losing,
+        dm.workers_shuffled,
+    );
+}

--- a/tools/reshuffle_sim/templates/report.html
+++ b/tools/reshuffle_sim/templates/report.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Reshuffle Simulation Report</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; margin: 0; padding: 20px; background: #f5f5f5; }
+  h1 { text-align: center; color: #333; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; max-width: 1400px; margin: 0 auto; }
+  .card { background: white; border-radius: 8px; padding: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  .card.wide { grid-column: 1 / -1; }
+  canvas { width: 100% !important; }
+  table { border-collapse: collapse; width: 100%; font-size: 13px; }
+  th, td { border: 1px solid #ddd; padding: 6px 10px; text-align: right; }
+  th { background: #f0f0f0; position: sticky; top: 0; }
+  td:first-child, th:first-child { text-align: center; }
+</style>
+</head>
+<body>
+<h1>Reshuffle Simulation Report</h1>
+<div class="grid">
+
+<div class="card">
+  <canvas id="chunksChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="dataBreakdownChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="shuffledChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="replicationChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="workersChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="shuffledCountChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="totalDownloadChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="capacityChart"></canvas>
+</div>
+
+<div class="card wide">
+<h3 style="margin-top:0">Raw Data</h3>
+<div style="overflow-x:auto">
+<table>
+<tr>
+  <th>Step</th><th>New chunks</th><th>Total chunks</th><th>Replication factor</th>
+  <th>New chunks download (all replicas)</th><th>Shuffled chunks</th><th>Shuffled chunks download (all replicas)</th>
+  <th>Replication increase download</th><th>Replication decrease freed</th><th>Total S3 download (all replicas)</th>
+  <th>Free capacity</th><th>Used %</th>
+  <th>Workers receiving new</th><th>Workers losing</th><th>Workers receiving shuffled</th>
+</tr>
+__TABLE_ROWS__
+</table>
+</div>
+</div>
+
+</div>
+
+<script type="application/json" id="data">__DATA__</script>
+<script>
+const D = JSON.parse(document.getElementById('data').textContent);
+
+function formatBytes(b) {
+  if (b === 0) return '0 B';
+  const units = ['B','KB','MB','GB','TB'];
+  const i = Math.floor(Math.log(b)/Math.log(1024));
+  return (b/Math.pow(1024,i)).toFixed(1) + ' ' + units[i];
+}
+
+const bytesTooltip = { callbacks: { label: function(ctx) { return ctx.dataset.label + ': ' + formatBytes(ctx.raw); } } };
+const bytesScale = { beginAtZero: true, ticks: { callback: function(v) { return formatBytes(v); } } };
+const stepLabels = D.steps.map(s => 'Step ' + s);
+
+new Chart(document.getElementById('chunksChart'), {
+  type: 'bar',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'New chunks', data: D.newChunks, backgroundColor: 'rgba(54,162,235,0.7)' },
+      { label: 'Total chunks', data: D.totalChunks, type: 'line', borderColor: '#ff6384', backgroundColor: 'transparent', yAxisID: 'y1' }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'Chunk Counts' } },
+    scales: {
+      y: { beginAtZero: true, title: { display: true, text: 'New per step' } },
+      y1: { position: 'right', title: { display: true, text: 'Total' }, grid: { drawOnChartArea: false } }
+    }
+  }
+});
+
+new Chart(document.getElementById('dataBreakdownChart'), {
+  type: 'bar',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'New chunks download (all replicas)', data: D.newChunkBytes, backgroundColor: 'rgba(54,162,235,0.7)' },
+      { label: 'Shuffled chunks download (all replicas)', data: D.shuffledBytes, backgroundColor: 'rgba(255,99,132,0.7)' },
+      { label: 'Replication increase download', data: D.increasedRepl, backgroundColor: 'rgba(255,206,86,0.7)' }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'S3 Download Breakdown (chunk size × number of downloading workers)' }, tooltip: bytesTooltip },
+    scales: { y: bytesScale }
+  }
+});
+
+new Chart(document.getElementById('shuffledChart'), {
+  type: 'bar',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'Shuffled chunks download (all replicas)', data: D.shuffledBytes, backgroundColor: 'rgba(255,99,132,0.7)' }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'Shuffled Chunks Download (all replicas, existing chunks moved to different workers)' }, tooltip: bytesTooltip },
+    scales: { y: bytesScale }
+  }
+});
+
+new Chart(document.getElementById('replicationChart'), {
+  type: 'bar',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'Replication increase download', data: D.increasedRepl, backgroundColor: 'rgba(75,192,192,0.7)' },
+      { label: 'Replication decrease freed', data: D.decreasedRepl, backgroundColor: 'rgba(255,159,64,0.7)' }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'Replication Changes (download from gained replicas / freed from lost replicas)' }, tooltip: bytesTooltip },
+    scales: { y: bytesScale }
+  }
+});
+
+new Chart(document.getElementById('workersChart'), {
+  type: 'bar',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'Receiving new chunks', data: D.workersReceivingNew, backgroundColor: 'rgba(54,162,235,0.7)' },
+      { label: 'Losing chunks', data: D.workersLosing, backgroundColor: 'rgba(255,99,132,0.7)' },
+      { label: 'Receiving shuffled chunks', data: D.workersShuffled, backgroundColor: 'rgba(255,206,86,0.7)' }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'Workers Affected by Category' } },
+    scales: { y: { beginAtZero: true } }
+  }
+});
+
+new Chart(document.getElementById('shuffledCountChart'), {
+  type: 'line',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'Chunks shuffled', data: D.shuffledCount, borderColor: '#ff6384', backgroundColor: 'rgba(255,99,132,0.1)', fill: true }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'Existing Chunks Reshuffled (count)' } },
+    scales: { y: { beginAtZero: true } }
+  }
+});
+
+new Chart(document.getElementById('totalDownloadChart'), {
+  type: 'bar',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'Total S3 download (all replicas)', data: D.totalDownload, backgroundColor: 'rgba(153,102,255,0.7)' }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'Total S3 Download per Step (all replicas: new + shuffled + replication increase)' }, tooltip: bytesTooltip },
+    scales: { y: bytesScale }
+  }
+});
+
+new Chart(document.getElementById('capacityChart'), {
+  type: 'bar',
+  data: {
+    labels: stepLabels,
+    datasets: [
+      { label: 'Free capacity', data: D.freeCapacity, backgroundColor: 'rgba(75,192,192,0.7)', yAxisID: 'y' },
+      { label: 'Used %', data: D.usedPct, type: 'line', borderColor: '#ff6384', backgroundColor: 'transparent', yAxisID: 'y1' }
+    ]
+  },
+  options: {
+    plugins: { title: { display: true, text: 'Remaining Free Capacity Across All Workers' }, tooltip: {
+      callbacks: { label: function(ctx) {
+        if (ctx.dataset.yAxisID === 'y1') return ctx.dataset.label + ': ' + ctx.raw.toFixed(1) + '%';
+        return ctx.dataset.label + ': ' + formatBytes(ctx.raw);
+      } }
+    } },
+    scales: {
+      y: { ...bytesScale, title: { display: true, text: 'Free capacity' } },
+      y1: { position: 'right', min: 0, max: 100, title: { display: true, text: 'Used %' }, grid: { drawOnChartArea: false }, ticks: { callback: function(v) { return v + '%'; } } }
+    }
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a tool that simulates chunk ingestion over multiple steps, runs the scheduler, and measures reshuffling impact. Reports data movement breakdown (new chunks, shuffled, replication changes) with total S3 download volume per step. Outputs a console table and optional HTML report with charts.