### PR TITLE
ci: Run tests with coverage and upload to codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,16 @@ jobs:
           lfs: true
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
-        run: cargo test --all-features
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run tests with coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
 
   fmt:
     name: Rustfmt

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.89.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools-preview"]
 profile = "minimal"


### PR DESCRIPTION
Replace `cargo test` in the CI test job with `cargo llvm-cov`, emit lcov.info, and upload it to Codecov so per-file coverage is browsable from app.codecov.io and linked from each workflow run. Adds `llvm-tools-preview` to the toolchain file so the same command works locally.