### PR TITLE
feat: Distribute chunks with replication back-off instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,12 +941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
 
 [[package]]
-name = "claims"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba18ee93d577a8428902687bcc2b6b45a56b1981a1f6d779731c86cc4c5db18"
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,12 +2412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,7 +2492,6 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "chrono",
- "claims",
  "clap",
  "clickhouse",
  "dotenv",
@@ -2514,7 +2501,6 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "libp2p-identity",
- "maplit",
  "multihash",
  "parking_lot",
  "parquet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -768,6 +768,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,9 +790,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -924,6 +939,12 @@ name = "cityhash-rs"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
+
+[[package]]
+name = "claims"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba18ee93d577a8428902687bcc2b6b45a56b1981a1f6d779731c86cc4c5db18"
 
 [[package]]
 name = "clang-sys"
@@ -1527,7 +1548,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "rustc_version",
 ]
 
@@ -2397,6 +2418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2504,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "chrono",
+ "claims",
  "clap",
  "clickhouse",
  "dotenv",
@@ -2486,10 +2514,12 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "libp2p-identity",
+ "maplit",
  "multihash",
  "parking_lot",
  "parquet",
  "prometheus-client",
+ "proptest",
  "rand 0.9.1",
  "rayon",
  "seahash",
@@ -2932,6 +2962,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3055,12 @@ checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -3091,6 +3146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,7 +3180,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3244,7 +3308,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3257,7 +3321,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3361,6 +3425,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,7 +3523,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3460,7 +3536,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -4151,6 +4227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,6 +4324,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -4570,7 +4661,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,8 @@ tokio = { version = "1.45.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "parking_lot"] }
 secrecy = { version = "0.10.3", features = ["serde"] }
+
+[dev-dependencies]
+claims = "0.8"
+maplit = "1.0.2"
+proptest = "1.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,4 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "parking_lo
 secrecy = { version = "0.10.3", features = ["serde"] }
 
 [dev-dependencies]
-claims = "0.8"
-maplit = "1.0.2"
 proptest = "1.11"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -247,6 +247,7 @@ impl WithScheduledChunks {
                     size: chunk.size,
                     weight: *weight,
                     minimum_worker_version: mwv.as_ref(),
+                    hashes: Vec::new(),
                 })
                 .collect();
 

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -210,16 +210,16 @@ fn validate_version_restrictions(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ReplicatedChunk<'a> {
-    dataset: &'a str,
-    chunk_id: &'a str,
-    size: u32,
-    replication: u16,
-    minimum_worker_version: Option<&'a Version>,
+pub(crate) struct ReplicatedChunk<'a> {
+    pub(crate) dataset: &'a str,
+    pub(crate) chunk_id: &'a str,
+    pub(crate) size: u32,
+    pub(crate) replication: u16,
+    pub(crate) minimum_worker_version: Option<&'a Version>,
 }
 
 #[instrument(skip_all)]
-fn distribute(
+pub(crate) fn distribute(
     chunks: &[ReplicatedChunk],
     workers: &[&Worker],
     worker_capacity: u64,

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -35,6 +35,9 @@ pub struct ScheduledChunk<'a> {
     pub size: u32,
     pub weight: ChunkWeight,
     pub minimum_worker_version: Option<&'a Version>,
+    /// Hashes locating each of the chunk's replicas on the ring, indexed by tag.
+    /// Filled by [`schedule`] (see [`hash_chunks`]) — leave empty when constructing.
+    pub hashes: Vec<u64>,
 }
 
 pub fn schedule(
@@ -47,10 +50,16 @@ pub fn schedule(
     // Order workers reliable-first, schedule the reliable subset, then (unless
     // reliability is ignored) overlay a pass over all workers so unreliable workers
     // also get chunks.
-    let mut sorted = Vec::with_capacity(workers.len());
-    sorted.extend(workers.iter().filter(|w| w.reliable()));
-    let reliable = sorted.len();
-    sorted.extend(workers.iter().filter(|w| !w.reliable()));
+    let mut sorted_workers = Vec::with_capacity(workers.len());
+    sorted_workers.extend(workers.iter().filter(|w| w.reliable()));
+    let reliable_workers = sorted_workers.len();
+    sorted_workers.extend(workers.iter().filter(|w| !w.reliable()));
+
+    // Hash every chunk's replica ring positions once up front; both placement passes
+    // share them. The all-workers caps bound the per-pass caps (capacity only grows
+    // with worker count), so the hash vectors are long enough for either pass.
+    let caps = replication_cap(chunks, workers.len(), &config)?;
+    let chunks = hash_chunks(chunks, &caps, config.min_replication);
 
     if config.ignore_reliability {
         tracing::info!(
@@ -58,16 +67,17 @@ pub fn schedule(
             chunks.len(),
             workers.len()
         );
-        return schedule_to_workers(chunks, &sorted, &config);
+        return schedule_to_workers(&chunks, &sorted_workers, &config);
     }
 
     tracing::info!(
         "Scheduling {} chunks to {} reliable workers",
         chunks.len(),
-        reliable
+        reliable_workers
     );
-    let mut assignment = schedule_to_workers(chunks, &sorted[..reliable], &config)?;
-    if reliable == workers.len() {
+    let mut assignment =
+        schedule_to_workers(&chunks, &sorted_workers[..reliable_workers], &config)?;
+    if reliable_workers == workers.len() {
         return Ok(assignment);
     }
 
@@ -76,7 +86,7 @@ pub fn schedule(
         chunks.len(),
         workers.len()
     );
-    let all = schedule_to_workers(chunks, &sorted, &config)?;
+    let all = schedule_to_workers(&chunks, &sorted_workers, &config)?;
     // Reliable workers keep their assignment; unreliable ones take theirs from `all`.
     for (worker_id, chunk_indexes) in all.worker_chunks {
         assignment
@@ -135,9 +145,9 @@ fn replication_cap(
 }
 
 /// Expand `chunks` into `ReplicatedChunk`s, taking each chunk's replication factor from
-/// `replication_by_weight`.
+/// `replication_by_weight` and propagating its precomputed replica hashes.
 fn to_replicated<'a>(
-    chunks: &[ScheduledChunk<'a>],
+    chunks: &'a [ScheduledChunk<'a>],
     replication_by_weight: &BTreeMap<ChunkWeight, ReplicationFactor>,
 ) -> Vec<ReplicatedChunk<'a>> {
     chunks
@@ -148,6 +158,7 @@ fn to_replicated<'a>(
             replication: replication_by_weight[&c.weight],
             size: c.size,
             minimum_worker_version: c.minimum_worker_version,
+            hashes: &c.hashes,
         })
         .collect()
 }
@@ -159,6 +170,8 @@ pub(crate) struct ReplicatedChunk<'a> {
     pub(crate) size: u32,
     pub(crate) replication: ReplicationFactor,
     pub(crate) minimum_worker_version: Option<&'a Version>,
+    /// Replica hashes by tag, borrowed from the [`ScheduledChunk`].
+    pub(crate) hashes: &'a [u64],
 }
 
 #[instrument(skip_all)]
@@ -188,17 +201,41 @@ fn hash_workers(worker_ids: &[PeerId]) -> Vec<Vec<(u64, WorkerIndex)>> {
         .collect()
 }
 
-/// Hash of a chunk's `tag`-th replica, locating it on the ring.
-fn replica_hash(chunk: &ReplicatedChunk, tag: ReplicationFactor) -> u64 {
-    let buffer = [
-        chunk.dataset.as_bytes(),
-        b"/",
-        chunk.chunk_id.as_bytes(),
-        b":",
-        &tag.to_le_bytes(),
-    ]
-    .concat();
-    hash(&buffer)
+/// Clone of `chunks` with every replica hash precomputed: tags
+/// `0..max(min_replication, cap)`, where the cap comes from the chunk's weight.
+#[instrument(skip_all)]
+fn hash_chunks<'a>(
+    chunks: &[ScheduledChunk<'a>],
+    caps: &BTreeMap<ChunkWeight, ReplicationFactor>,
+    min_replication: ReplicationFactor,
+) -> Vec<ScheduledChunk<'a>> {
+    let _timer = crate::metrics::Timer::new("schedule:hash_chunks");
+
+    chunks
+        .into_par_iter()
+        .map(|chunk| {
+            let mut buffer = [
+                chunk.dataset.as_bytes(),
+                b"/",
+                chunk.chunk_id.as_bytes(),
+                b":",
+            ]
+            .concat();
+            let prefix = buffer.len();
+            let tags = min_replication.max(caps[&chunk.weight]);
+            let hashes = (0..tags)
+                .map(|tag| {
+                    buffer.truncate(prefix);
+                    buffer.extend_from_slice(&tag.to_le_bytes());
+                    hash(&buffer)
+                })
+                .collect();
+            ScheduledChunk {
+                hashes,
+                ..chunk.clone()
+            }
+        })
+        .collect()
 }
 
 /// The guaranteed replication per weight: the fewest replicas actually placed among the
@@ -337,7 +374,7 @@ impl<'a> Placement<'a> {
     /// capacity, walking the chunk's hash ring from its home. Returns whether it landed.
     fn place(&mut self, chunk_index: usize, tag: ReplicationFactor) -> bool {
         let chunk = &self.chunks[chunk_index];
-        let chunk_hash = replica_hash(chunk, tag);
+        let chunk_hash = chunk.hashes[tag as usize];
         let ring = &self.rings[chunk_hash as usize % N_RINGS];
         let first = ring.partition_point(|(x, _)| *x < chunk_hash);
 

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeMap;
 
 use itertools::Itertools;
 use libp2p_identity::PeerId;
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use seahash::hash;
 use tracing::instrument;
 
@@ -12,18 +10,21 @@ use semver::Version;
 
 use crate::{
     replication::{ReplicationError, calc_replication_factors},
-    types::{Assignment, ChunkIndex, Worker, WorkerIndex},
+    types::{Assignment, ChunkIndex, ChunkWeight, ReplicationFactor, Worker, WorkerIndex},
 };
 
 type RingIndex = u16;
 
 const N_RINGS: usize = 6000;
 
+/// Chunk indices assigned to each worker.
+type WorkerChunks = BTreeMap<PeerId, Vec<ChunkIndex>>;
+
 #[derive(Debug, Clone)]
 pub struct SchedulingConfig {
     pub worker_capacity: u64,
     pub saturation: f64,
-    pub min_replication: u16,
+    pub min_replication: ReplicationFactor,
     pub ignore_reliability: bool,
 }
 
@@ -32,7 +33,7 @@ pub struct ScheduledChunk<'a> {
     pub dataset: &'a str,
     pub chunk_id: &'a str,
     pub size: u32,
-    pub weight: u16,
+    pub weight: ChunkWeight,
     pub minimum_worker_version: Option<&'a Version>,
 }
 
@@ -42,29 +43,32 @@ pub fn schedule(
     config: SchedulingConfig,
 ) -> Result<Assignment, ReplicationError> {
     let _timer = crate::metrics::Timer::new("schedule");
-    let mut sorted_workers = Vec::with_capacity(workers.len());
-    sorted_workers.extend(workers.iter().filter(|w| w.reliable()));
-    let reliable_workers = sorted_workers.len();
-    sorted_workers.extend(workers.iter().filter(|w| !w.reliable()));
+
+    // Order workers reliable-first, schedule the reliable subset, then (unless
+    // reliability is ignored) overlay a pass over all workers so unreliable workers
+    // also get chunks.
+    let mut sorted = Vec::with_capacity(workers.len());
+    sorted.extend(workers.iter().filter(|w| w.reliable()));
+    let reliable = sorted.len();
+    sorted.extend(workers.iter().filter(|w| !w.reliable()));
 
     if config.ignore_reliability {
         tracing::info!(
             "Scheduling {} chunks to {} workers",
             chunks.len(),
-            workers.len(),
+            workers.len()
         );
-        return schedule_to_workers(chunks, &sorted_workers, &config);
+        return schedule_to_workers(chunks, &sorted, &config);
     }
 
     tracing::info!(
         "Scheduling {} chunks to {} reliable workers",
         chunks.len(),
-        reliable_workers
+        reliable
     );
-    let mut reliable = schedule_to_workers(chunks, &sorted_workers[..reliable_workers], &config)?;
-
-    if reliable_workers == workers.len() {
-        return Ok(reliable);
+    let mut assignment = schedule_to_workers(chunks, &sorted[..reliable], &config)?;
+    if reliable == workers.len() {
+        return Ok(assignment);
     }
 
     tracing::info!(
@@ -72,16 +76,15 @@ pub fn schedule(
         chunks.len(),
         workers.len()
     );
-    let all = schedule_to_workers(chunks, &sorted_workers, &config)?;
-
-    // Use assignment from `reliable` for reliable workers and from `all` for unreliable workers
+    let all = schedule_to_workers(chunks, &sorted, &config)?;
+    // Reliable workers keep their assignment; unreliable ones take theirs from `all`.
     for (worker_id, chunk_indexes) in all.worker_chunks {
-        reliable
+        assignment
             .worker_chunks
             .entry(worker_id)
             .or_insert(chunk_indexes);
     }
-    Ok(reliable)
+    Ok(assignment)
 }
 
 fn schedule_to_workers(
@@ -89,6 +92,30 @@ fn schedule_to_workers(
     workers: &[&Worker],
     config: &SchedulingConfig,
 ) -> Result<Assignment, ReplicationError> {
+    // The byte-budget replication is a cap; `distribute` places what fits and reports
+    // the factor actually achieved.
+    let caps = replication_cap(chunks, workers.len(), config)?;
+    let replicated = to_replicated(chunks, &caps);
+    let (worker_chunks, achieved) = distribute(
+        &replicated,
+        workers,
+        config.worker_capacity,
+        config.min_replication,
+    )?;
+    tracing::info!("Replication caps by weight: {caps:?}");
+    Ok(Assignment {
+        worker_chunks,
+        replication_by_weight: min_replication_by_weight(chunks, &achieved),
+    })
+}
+
+/// Per-weight replication derived from the saturated byte budget (always at least
+/// `config.min_replication`).
+fn replication_cap(
+    chunks: &[ScheduledChunk<'_>],
+    n_workers: usize,
+    config: &SchedulingConfig,
+) -> Result<BTreeMap<ChunkWeight, ReplicationFactor>, ReplicationError> {
     let size_by_weight = chunks
         .iter()
         .map(|chunk| (chunk.weight, chunk.size as u64))
@@ -96,117 +123,32 @@ fn schedule_to_workers(
         .sum()
         .into_iter()
         .collect();
-
     let total_capacity =
-        (config.worker_capacity as f64 * workers.len() as f64 * config.saturation) as u64;
-
-    let mapping = calc_replication_factors(
+        (config.worker_capacity as f64 * n_workers as f64 * config.saturation) as u64;
+    calc_replication_factors(
         size_by_weight,
         total_capacity,
         config.min_replication,
-        workers.len() as u16,
-    )?;
+        n_workers as ReplicationFactor,
+    )
+}
 
-    validate_version_restrictions(chunks, workers, config, &mapping);
-
-    let chunks = chunks
+/// Expand `chunks` into `ReplicatedChunk`s, taking each chunk's replication factor from
+/// `replication_by_weight`.
+fn to_replicated<'a>(
+    chunks: &[ScheduledChunk<'a>],
+    replication_by_weight: &BTreeMap<ChunkWeight, ReplicationFactor>,
+) -> Vec<ReplicatedChunk<'a>> {
+    chunks
         .iter()
         .map(|c| ReplicatedChunk {
             dataset: c.dataset,
             chunk_id: c.chunk_id,
-            replication: mapping[&c.weight],
+            replication: replication_by_weight[&c.weight],
             size: c.size,
             minimum_worker_version: c.minimum_worker_version,
         })
-        .collect_vec();
-
-    tracing::info!(
-        "Replication factors by weight: {:?}, total vchunks: {}",
-        mapping,
-        chunks.iter().map(|c| c.replication as u64).sum::<u64>()
-    );
-
-    let worker_chunks = distribute(&chunks, workers, config.worker_capacity);
-    Ok(Assignment {
-        worker_chunks,
-        replication_by_weight: mapping,
-    })
-}
-
-/// Validates that version-restricted data can be scheduled within the
-/// saturation headroom. Only a single non-null `minimum_worker_version` value
-/// is allowed across all chunks. Two checks:
-/// 1. R ≤ E: replication factor must not exceed eligible worker count.
-/// 2. f ≤ (1-s) × E / (s × (N-E)): the extra load on eligible workers
-///    from restricted chunks must fit within the unused capacity fraction.
-fn validate_version_restrictions(
-    chunks: &[ScheduledChunk<'_>],
-    workers: &[&Worker],
-    config: &SchedulingConfig,
-    replication_by_weight: &BTreeMap<u16, u16>,
-) {
-    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
-    if total_size == 0 {
-        return;
-    }
-
-    // Collect the single allowed minimum_worker_version
-    let mut min_ver: Option<&Version> = None;
-    let mut s_restricted: u64 = 0;
-    let mut max_replication: u16 = 0;
-
-    for chunk in chunks {
-        if let Some(v) = chunk.minimum_worker_version {
-            if let Some(existing) = min_ver {
-                assert!(
-                    existing == v,
-                    "Multiple minimum_worker_version values found ({} and {}). \
-                     Only a single version restriction is supported.",
-                    existing,
-                    v,
-                );
-            } else {
-                min_ver = Some(v);
-            }
-            s_restricted += chunk.size as u64;
-            max_replication = max_replication.max(replication_by_weight[&chunk.weight]);
-        }
-    }
-
-    let Some(min_ver) = min_ver else { return };
-
-    let n = workers.len();
-    let s = config.saturation;
-    let e = workers
-        .iter()
-        .filter(|w| w.version.as_ref().is_some_and(|v| v >= min_ver))
-        .count();
-
-    assert!(
-        max_replication as usize <= e,
-        "Not enough eligible workers for version >= {}: \
-         replication factor {} exceeds {} eligible workers (need at least {})",
-        min_ver,
-        max_replication,
-        e,
-        max_replication,
-    );
-
-    if e < n {
-        let f = s_restricted as f64 / total_size as f64;
-        let threshold = (1.0 - s) * e as f64 / (s * (n - e) as f64);
-        assert!(
-            f <= threshold,
-            "Version-restricted data (>= {}) exceeds saturation headroom: \
-             f = {:.4} > {:.4} (E={}, N={}, s={})",
-            min_ver,
-            f,
-            threshold,
-            e,
-            n,
-            s,
-        );
-    }
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -214,31 +156,8 @@ pub(crate) struct ReplicatedChunk<'a> {
     pub(crate) dataset: &'a str,
     pub(crate) chunk_id: &'a str,
     pub(crate) size: u32,
-    pub(crate) replication: u16,
+    pub(crate) replication: ReplicationFactor,
     pub(crate) minimum_worker_version: Option<&'a Version>,
-}
-
-#[instrument(skip_all)]
-pub(crate) fn distribute(
-    chunks: &[ReplicatedChunk],
-    workers: &[&Worker],
-    worker_capacity: u64,
-) -> BTreeMap<PeerId, Vec<ChunkIndex>> {
-    let _timer = crate::metrics::Timer::new("schedule:distribute");
-    let worker_ids = workers.iter().map(|w| w.id).collect_vec();
-    let rings = hash_workers(&worker_ids);
-    let mut orderings = hash_chunks(chunks, &rings);
-    // Assign version-restricted chunks first so they get priority on eligible
-    // workers' capacity before unrestricted chunks fill it. Without this,
-    // unrestricted chunks (ordered by hash ring position only) could fill
-    // eligible workers' capacity before restricted chunks are processed,
-    // causing a panic even when total capacity would suffice.
-    orderings.sort_by_key(|(chunk_index, _, _)| {
-        chunks[*chunk_index as usize]
-            .minimum_worker_version
-            .is_none()
-    });
-    assign_chunks(orderings, chunks, workers, rings, worker_capacity)
 }
 
 #[instrument(skip_all)]
@@ -268,101 +187,200 @@ fn hash_workers(worker_ids: &[PeerId]) -> Vec<Vec<(u64, WorkerIndex)>> {
         .collect()
 }
 
-#[instrument(skip_all)]
-fn hash_chunks(
-    chunks: &[ReplicatedChunk],
-    rings: &[Vec<(u64, u16)>],
-) -> Vec<(ChunkIndex, RingIndex, WorkerIndex)> {
-    tracing::info!("Hashing chunks");
-    let _timer = crate::metrics::Timer::new("schedule:distribute:hash_chunks");
-
-    chunks
-        .par_iter()
-        .enumerate()
-        .flat_map_iter(|(chunk_index, chunk)| {
-            (0..chunk.replication).map(move |tag| {
-                let buffer = [
-                    chunk.dataset.as_bytes(),
-                    b"/",
-                    chunk.chunk_id.as_bytes(),
-                    b":",
-                    &tag.to_le_bytes(),
-                ]
-                .concat();
-                let chunk_hash = hash(&buffer);
-                let ring_index = chunk_hash as usize % N_RINGS;
-                let ring = &rings[ring_index];
-                let first = ring.partition_point(|(x, _)| *x < chunk_hash);
-                (
-                    chunk_index as ChunkIndex,
-                    ring_index as RingIndex,
-                    first as WorkerIndex,
-                )
-            })
-        })
-        .collect()
+/// Hash of a chunk's `tag`-th replica, locating it on the ring.
+fn replica_hash(chunk: &ReplicatedChunk, tag: ReplicationFactor) -> u64 {
+    let buffer = [
+        chunk.dataset.as_bytes(),
+        b"/",
+        chunk.chunk_id.as_bytes(),
+        b":",
+        &tag.to_le_bytes(),
+    ]
+    .concat();
+    hash(&buffer)
 }
 
+/// The guaranteed replication per weight: the fewest replicas actually placed among the
+/// chunks of each weight.
+fn min_replication_by_weight(
+    chunks: &[ScheduledChunk<'_>],
+    achieved: &[ReplicationFactor],
+) -> BTreeMap<ChunkWeight, ReplicationFactor> {
+    let mut by_weight: BTreeMap<ChunkWeight, ReplicationFactor> = BTreeMap::new();
+    for (chunk, &got) in chunks.iter().zip(achieved) {
+        by_weight
+            .entry(chunk.weight)
+            .and_modify(|min| *min = (*min).min(got))
+            .or_insert(got);
+    }
+    by_weight
+}
+
+/// Multi-step scatter with a dynamically discovered replication factor. Returns the
+/// placement (`worker -> chunk indices`) and the replication actually achieved for each
+/// chunk (indexed like `chunks`).
+///
+/// `chunks[i].replication` is the cap (upper bound) for chunk `i`. Placement runs in
+/// three phases, each replica walking the chunk's hash ring from its home:
+/// 1. restricted chunks up to `min_replication` — they can only land on eligible
+///    workers, which are scarce, so they claim that capacity first;
+/// 2. unrestricted chunks up to `min_replication`;
+/// 3. both kinds (restricted first) from `min_replication` up to each chunk's cap.
+///
+/// Phases 1 and 2 are mandatory: a replica that can't be placed there means the data
+/// doesn't fit at the required minimum (`NotEnoughCapacity`). Phase 3 is best-effort, so
+/// an unreachable cap just yields a lower achieved factor instead of a panic.
 #[instrument(skip_all)]
-fn assign_chunks(
-    orderings: Vec<(ChunkIndex, RingIndex, WorkerIndex)>,
+pub(crate) fn distribute(
     chunks: &[ReplicatedChunk],
     workers: &[&Worker],
-    rings: Vec<Vec<(u64, WorkerIndex)>>,
     worker_capacity: u64,
-) -> BTreeMap<PeerId, Vec<ChunkIndex>> {
-    tracing::info!("Assigning chunks");
-    let _timer = crate::metrics::Timer::new("schedule:distribute:assign_chunks");
+    min_replication: ReplicationFactor,
+) -> Result<(WorkerChunks, Vec<ReplicationFactor>), ReplicationError> {
+    let _timer = crate::metrics::Timer::new("schedule:distribute");
+    let worker_ids = workers.iter().map(|w| w.id).collect_vec();
+    let rings = hash_workers(&worker_ids);
+    let mut placement = Placement::new(chunks, workers, &rings, worker_capacity);
 
-    struct WorkerAssignment {
-        chunks: Vec<ChunkIndex>,
-        allocated: u64,
+    // `partition` keeps each group in input order, so placement stays deterministic.
+    let (restricted, unrestricted): (Vec<usize>, Vec<usize>) =
+        (0..chunks.len()).partition(|&i| chunks[i].minimum_worker_version.is_some());
+
+    placement.ensure_minimum(&restricted, min_replication)?;
+    placement.ensure_minimum(&unrestricted, min_replication)?;
+
+    let order = restricted.into_iter().chain(unrestricted).collect_vec();
+    placement.fill_to_cap(&order, min_replication);
+
+    let achieved = placement.achieved_replication();
+    Ok((placement.into_worker_chunks(), achieved))
+}
+
+/// Mutable state for [`distribute`].
+struct Placement<'a> {
+    chunks: &'a [ReplicatedChunk<'a>],
+    workers: &'a [&'a Worker],
+    rings: &'a [Vec<(u64, WorkerIndex)>],
+    worker_capacity: u64,
+    /// Bytes assigned to each worker.
+    allocated: Vec<u64>,
+    /// Chunks assigned to each worker — the result.
+    worker_chunks: Vec<Vec<ChunkIndex>>,
+    /// Workers holding each chunk — the inverse of `worker_chunks`, used to keep two
+    /// replicas of a chunk off the same worker.
+    chunk_workers: Vec<Vec<WorkerIndex>>,
+}
+
+impl<'a> Placement<'a> {
+    fn new(
+        chunks: &'a [ReplicatedChunk<'a>],
+        workers: &'a [&'a Worker],
+        rings: &'a [Vec<(u64, WorkerIndex)>],
+        worker_capacity: u64,
+    ) -> Self {
+        Self {
+            chunks,
+            workers,
+            rings,
+            worker_capacity,
+            allocated: vec![0; workers.len()],
+            worker_chunks: vec![Vec::new(); workers.len()],
+            chunk_workers: vec![Vec::new(); chunks.len()],
+        }
     }
 
-    let mut assignments: Vec<WorkerAssignment> = workers
-        .iter()
-        .map(|_| WorkerAssignment {
-            chunks: Vec::new(),
-            allocated: 0,
-        })
-        .collect();
-    orderings
-        .into_iter()
-        .for_each(|(chunk_index, ring_index, first)| {
-            let chunk = &chunks[chunk_index as usize];
-            let ring = &rings[ring_index as usize];
-            let first = first as usize;
-            let candidates = ring[first..].iter().chain(ring[..first].iter());
-            for &(_, worker_index) in candidates {
-                if let Some(min_ver) = chunk.minimum_worker_version {
-                    let worker_ver = &workers[worker_index as usize].version;
-                    if worker_ver.as_ref().is_none_or(|v| v < min_ver) {
-                        continue;
-                    }
-                }
-
-                let assignment = &mut assignments[worker_index as usize];
-
-                if assignment.allocated + chunk.size as u64 <= worker_capacity
-                    // Replicas of the same chunk stay adjacent after the stable sort
-                    // (they share the same minimum_worker_version key), so checking
-                    // the last assigned index is sufficient to prevent duplicates.
-                    && assignment.chunks.last() != Some(&chunk_index)
-                {
-                    assignment.allocated += chunk.size as u64;
-                    assignment.chunks.push(chunk_index);
-                    return;
+    /// Place `min_replication` replicas of every chunk in `subset`, failing if any of
+    /// them can't be placed.
+    fn ensure_minimum(
+        &mut self,
+        subset: &[usize],
+        min_replication: ReplicationFactor,
+    ) -> Result<(), ReplicationError> {
+        for tag in 0..min_replication {
+            for &chunk_index in subset {
+                if !self.place(chunk_index, tag) {
+                    return Err(ReplicationError::NotEnoughCapacity);
                 }
             }
-            panic!(
-                "No worker found for chunk {}/{}",
-                chunk.dataset, chunk.chunk_id
-            );
-        });
+        }
+        Ok(())
+    }
 
-    assignments
-        .into_iter()
-        .enumerate()
-        .map(|(index, a)| (workers[index].id, a.chunks))
-        .collect()
+    /// Add replicas from `from_tag` up to each chunk's cap, in `order`, best-effort. A
+    /// chunk leaves the rounds once it reaches its cap or fails to place — a phase-3
+    /// failure can't succeed at a higher tag (capacity only shrinks, the chunk's worker
+    /// set is fixed), so retrying is pure waste and dropping it keeps the result identical.
+    fn fill_to_cap(&mut self, order: &[usize], from_tag: ReplicationFactor) {
+        let max_cap = order
+            .iter()
+            .map(|&i| self.chunks[i].replication)
+            .max()
+            .unwrap_or(0);
+        // Chunks still below their cap (`cap > tag` holds at each round's start).
+        let mut active: Vec<usize> = order
+            .iter()
+            .copied()
+            .filter(|&i| self.chunks[i].replication > from_tag)
+            .collect();
+        for tag in from_tag..max_cap {
+            active.retain(|&chunk_index| {
+                self.place(chunk_index, tag) && self.chunks[chunk_index].replication > tag + 1
+            });
+            if active.is_empty() {
+                break;
+            }
+        }
+    }
+
+    /// Place the `tag`-th replica of `chunk_index` on the first eligible worker with free
+    /// capacity, walking the chunk's hash ring from its home. Returns whether it landed.
+    fn place(&mut self, chunk_index: usize, tag: ReplicationFactor) -> bool {
+        let chunk = &self.chunks[chunk_index];
+        let chunk_hash = replica_hash(chunk, tag);
+        let ring = &self.rings[chunk_hash as usize % N_RINGS];
+        let first = ring.partition_point(|(x, _)| *x < chunk_hash);
+
+        for &(_, worker) in ring[first..].iter().chain(&ring[..first]) {
+            let w = worker as usize;
+            let eligible = chunk
+                .minimum_worker_version
+                .is_none_or(|min| self.workers[w].version.as_ref().is_some_and(|v| v >= min));
+            if !eligible || self.chunk_workers[chunk_index].contains(&worker) {
+                continue;
+            }
+            if self.allocated[w] + chunk.size as u64 <= self.worker_capacity {
+                self.allocated[w] += chunk.size as u64;
+                self.worker_chunks[w].push(chunk_index as ChunkIndex);
+                self.chunk_workers[chunk_index].push(worker);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// The replication actually achieved for each chunk (indexed like `chunks`): the
+    /// number of distinct workers it ended up on.
+    fn achieved_replication(&self) -> Vec<ReplicationFactor> {
+        self.chunk_workers
+            .iter()
+            .map(|w| w.len() as ReplicationFactor)
+            .collect()
+    }
+
+    /// Consume the state into the final `worker -> sorted chunk indices` map.
+    fn into_worker_chunks(self) -> WorkerChunks {
+        let Placement {
+            workers,
+            worker_chunks,
+            ..
+        } = self;
+        worker_chunks
+            .into_iter()
+            .enumerate()
+            .map(|(i, mut indices)| {
+                indices.sort_unstable();
+                (workers[i].id, indices)
+            })
+            .collect()
+    }
 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -102,10 +102,11 @@ fn schedule_to_workers(
         config.worker_capacity,
         config.min_replication,
     )?;
-    tracing::info!("Replication caps by weight: {caps:?}");
+    let replication_by_weight = min_replication_by_weight(chunks, &achieved);
+    tracing::info!("Replication by weight: caps {caps:?}, achieved {replication_by_weight:?}");
     Ok(Assignment {
         worker_chunks,
-        replication_by_weight: min_replication_by_weight(chunks, &achieved),
+        replication_by_weight,
     })
 }
 

--- a/src/tests/input.rs
+++ b/src/tests/input.rs
@@ -31,6 +31,7 @@ impl TestChunks {
                 size: e.size,
                 weight: e.weight,
                 minimum_worker_version: e.minimum_worker_version.as_ref(),
+                hashes: Vec::new(),
             })
             .collect()
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod input;
 mod scheduling;
+mod scheduling_proptests;
 mod utils;

--- a/src/tests/scheduling.rs
+++ b/src/tests/scheduling.rs
@@ -431,6 +431,7 @@ fn test_minimum_worker_version_unrestricted_spill() {
             size: e.size,
             weight: e.weight,
             minimum_worker_version: None,
+            hashes: Vec::new(),
         })
         .collect();
     let baseline = schedule(&unrestricted_chunks, &workers, config).unwrap();
@@ -697,6 +698,7 @@ fn test_minimum_worker_version_no_reassignment_on_removal() {
             size: e.size,
             weight: e.weight,
             minimum_worker_version: None,
+            hashes: Vec::new(),
         })
         .collect();
 

--- a/src/tests/scheduling.rs
+++ b/src/tests/scheduling.rs
@@ -9,6 +9,7 @@ use super::{
     utils::{Stats, compare_intersection},
 };
 use crate::{
+    replication::ReplicationError,
     scheduling::{ScheduledChunk, SchedulingConfig, schedule},
     types::{Assignment, Worker, WorkerIndex, WorkerStatus},
 };
@@ -291,6 +292,88 @@ fn test_minimum_worker_version_filtering() {
     }
 }
 
+/// `schedule` must give every version-restricted chunk at least
+/// `min_replication` replicas, all on eligible workers — even when eligible workers
+/// are scarce and unrestricted chunks compete for their capacity. The multi-step
+/// ordering places the restricted minimum *first*, so unrestricted data can't starve
+/// it (the failure mode a per-round interleaving would have).
+///
+/// Scenario: 100 workers, only 20 eligible, 10% of chunks restricted, min_replication 3.
+#[test]
+fn test_restricted_chunks_reach_min_replication() {
+    let min_version = Version::new(2, 8, 0);
+    const N_WORKERS: WorkerIndex = 100;
+    const N_ELIGIBLE: WorkerIndex = 20;
+    const N_CHUNKS: u32 = 10_000;
+    const N_VERSIONED: u32 = 1_000; // 10% restricted
+    const MIN_REPLICATION: u16 = 3;
+
+    let mut test_data = generate_chunks(N_CHUNKS, &[1]);
+    for entry in &mut test_data.entries[..N_VERSIONED as usize] {
+        entry.minimum_worker_version = Some(min_version.clone());
+    }
+    let chunks = test_data.as_scheduled();
+
+    let workers = generate_workers(N_WORKERS)
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| Worker {
+            id,
+            status: WorkerStatus::Online,
+            version: Some(if (i as WorkerIndex) < N_ELIGIBLE {
+                Version::new(2, 8, 0)
+            } else {
+                Version::new(2, 7, 0)
+            }),
+        })
+        .collect_vec();
+
+    let eligible_ids = workers[..N_ELIGIBLE as usize]
+        .iter()
+        .map(|w| w.id)
+        .collect::<std::collections::BTreeSet<_>>();
+
+    // Capacity tuned so the byte-budget factor is small while eligible workers can
+    // comfortably hold the restricted minimum alongside some unrestricted data.
+    let total_size: u64 = chunks.iter().map(|c| c.size as u64).sum();
+    let worker_capacity = total_size / N_ELIGIBLE as u64;
+
+    let assignment = schedule(
+        &chunks,
+        &workers,
+        SchedulingConfig {
+            worker_capacity,
+            saturation: 0.9,
+            min_replication: MIN_REPLICATION,
+            ignore_reliability: false,
+        },
+    )
+    .unwrap();
+
+    // Restricted chunks are indices 0..N_VERSIONED; count their replicas and make sure
+    // each one only landed on eligible workers.
+    let mut replicas = vec![0u16; N_VERSIONED as usize];
+    for (worker_id, chunk_indexes) in &assignment.worker_chunks {
+        let eligible = eligible_ids.contains(worker_id);
+        for &i in chunk_indexes {
+            if i < N_VERSIONED {
+                assert!(
+                    eligible,
+                    "restricted chunk {i} placed on ineligible worker {worker_id:?}",
+                );
+                replicas[i as usize] += 1;
+            }
+        }
+    }
+
+    for (i, &count) in replicas.iter().enumerate() {
+        assert!(
+            count >= MIN_REPLICATION,
+            "restricted chunk {i} got only {count} replicas, expected >= {MIN_REPLICATION}",
+        );
+    }
+}
+
 /// Verifies that version restrictions cause no (or negligible) spill of
 /// unrestricted chunks compared to a baseline without restrictions.
 /// Uses the same scenario as test_minimum_worker_version_filtering.
@@ -468,21 +551,19 @@ fn test_minimum_worker_version_gradual_upgrade() {
     }
 }
 
-/// Verifies that scheduling panics up-front when R > E (replication factor
-/// exceeds eligible worker count), even though the capacity constraint
-/// is satisfied.
-/// Scenario: 100 workers, 8 eligible, 95% saturation, 0.4% versioned chunks.
-///
-/// R = floor(10 * 0.95) = 9 > E = 8. Panics (can't place 9 replicas on 8 workers).
-/// f = 0.004 ≤ (0.05 * 8) / (0.95 * 92) = 0.0046 ✓ (capacity would suffice).
+/// With fewer eligible workers than the required `min_replication`, a
+/// version-restricted chunk's minimum replicas can't all be placed (a worker holds at
+/// most one replica of a chunk). Scheduling reports `NotEnoughCapacity` instead of
+/// over-replicating onto fewer workers or panicking.
+/// Scenario: 100 workers, 8 eligible, `min_replication = 9`, 0.4% versioned chunks.
 #[test]
-#[should_panic(expected = "Not enough eligible workers")]
 fn test_minimum_worker_version_insufficient_eligible_workers() {
     let min_version = Version::new(2, 8, 0);
     const N_WORKERS: WorkerIndex = 100;
     const N_ELIGIBLE: WorkerIndex = 8;
     const N_CHUNKS: u32 = 50_000;
     const N_VERSIONED: u32 = 200; // 0.4% of chunks
+    const MIN_REPLICATION: u16 = 9; // one more than the 8 eligible workers
 
     let mut test_data = generate_chunks(N_CHUNKS, &[1]);
     for entry in &mut test_data.entries[..N_VERSIONED as usize] {
@@ -507,34 +588,35 @@ fn test_minimum_worker_version_insufficient_eligible_workers() {
         })
         .collect_vec();
 
-    let _ = schedule(
+    let result = schedule(
         &chunks,
         &workers,
         SchedulingConfig {
             worker_capacity,
             saturation: 0.95,
-            min_replication: 1,
+            min_replication: MIN_REPLICATION,
             ignore_reliability: false,
         },
     );
+    assert!(
+        matches!(result, Err(ReplicationError::NotEnoughCapacity)),
+        "expected NotEnoughCapacity (can't place {MIN_REPLICATION} replicas on {N_ELIGIBLE} \
+         eligible workers), got {result:?}",
+    );
 }
 
-/// Verifies that scheduling panics up-front when the restricted data
-/// fraction exceeds the saturation headroom (even though R ≤ E).
+/// A dense restricted fraction (6%) that the old scheduler rejected up front as
+/// "exceeds saturation headroom" is now simply placed: there's enough hard capacity on
+/// the eligible workers, so `schedule` succeeds and every restricted chunk lands only on
+/// eligible workers.
 /// Scenario: 100 workers, 50 eligible, 95% saturation, 6% versioned chunks.
-/// Same framework as test_minimum_worker_version_filtering but f slightly
-/// above the threshold.
-///
-/// R = floor(10 * 0.95) = 9 ≤ E = 50 ✓
-/// f = 0.06 > (0.05 * 50) / (0.95 * 50) = 0.0526 (~14% over limit). Panics.
 #[test]
-#[should_panic(expected = "exceeds saturation headroom")]
-fn test_minimum_worker_version_eligible_capacity_exceeded() {
+fn test_minimum_worker_version_dense_restricted_data_is_placed() {
     let min_version = Version::new(2, 8, 0);
     const N_WORKERS: WorkerIndex = 100;
     const N_ELIGIBLE: WorkerIndex = 50;
     const N_CHUNKS: u32 = 50_000;
-    const N_VERSIONED: u32 = 3_000; // 6% of chunks, just above the ~5.26% threshold
+    const N_VERSIONED: u32 = 3_000; // 6% of chunks — above the old headroom threshold
 
     let mut test_data = generate_chunks(N_CHUNKS, &[1]);
     for entry in &mut test_data.entries[..N_VERSIONED as usize] {
@@ -559,7 +641,7 @@ fn test_minimum_worker_version_eligible_capacity_exceeded() {
         })
         .collect_vec();
 
-    let _ = schedule(
+    let assignment = schedule(
         &chunks,
         &workers,
         SchedulingConfig {
@@ -568,7 +650,21 @@ fn test_minimum_worker_version_eligible_capacity_exceeded() {
             min_replication: 1,
             ignore_reliability: false,
         },
-    );
+    )
+    .expect("multi-step scheduler should place the dense restricted data");
+
+    let eligible = workers[..N_ELIGIBLE as usize]
+        .iter()
+        .map(|w| w.id)
+        .collect::<std::collections::BTreeSet<_>>();
+    for (worker_id, chunk_indexes) in &assignment.worker_chunks {
+        if !eligible.contains(worker_id) {
+            assert!(
+                chunk_indexes.iter().all(|&i| i >= N_VERSIONED),
+                "restricted chunk placed on ineligible worker {worker_id:?}",
+            );
+        }
+    }
 }
 
 /// Verifies zero reassignment when version restriction is removed after

--- a/src/tests/scheduling_proptests.rs
+++ b/src/tests/scheduling_proptests.rs
@@ -166,6 +166,7 @@ fn chunks_from<'a>(dataset: &'a str, ids: &'a [String], sizes: &[u32]) -> Vec<Sc
             size,
             weight: 1,
             minimum_worker_version: None,
+            hashes: Vec::new(),
         })
         .collect()
 }

--- a/src/tests/scheduling_proptests.rs
+++ b/src/tests/scheduling_proptests.rs
@@ -1,0 +1,298 @@
+//! Property-based tests for the scheduling/scatter algorithm, kept separate from
+//! the example-based tests in `scheduling.rs`. They drive the public `schedule`
+//! plus the crate-internal `distribute` scatter (via the `placeable_at` oracle).
+//!
+//! Order: regression tests, then the property tests they came from, then helpers.
+
+use std::collections::BTreeMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Once;
+
+use libp2p_identity::PeerId;
+use proptest::prelude::*;
+use semver::Version;
+
+use crate::{
+    replication::{ReplicationError, calc_replication_factors},
+    scheduling::{ReplicatedChunk, ScheduledChunk, SchedulingConfig, distribute, schedule},
+    types::{ChunkIndex, Worker, WorkerStatus},
+};
+
+// ---- regression tests ----
+// Hardcoded counterexamples from the property tests below, each named after the
+// proptest it pins down.
+
+/// Regression for `schedule_picks_a_placeable_replication`
+/// The minimum replication places fine, but `schedule` fills capacity to a higher factor that fragments
+/// across workers and panics instead of backing off.
+#[test]
+#[should_panic(expected = "schedule should place when a feasible replication exists")]
+fn regression_schedule_picks_a_placeable_replication() {
+    let scenario = Scenario {
+        num_workers: 6,
+        chunk_sizes: vec![284, 717],
+        saturation: 0.94,
+        min_replication: 1,
+    };
+    let Outcome {
+        max_feasible,
+        derived,
+        scheduled_ok,
+    } = evaluate(&scenario);
+
+    assert!(
+        max_feasible.is_some(),
+        "min_replication should be placeable in this scenario"
+    );
+    assert!(
+        scheduled_ok,
+        "schedule should place when a feasible replication exists \
+         (max feasible = {max_feasible:?}, derived = {derived:?})",
+    );
+}
+
+// ---- property tests ----
+
+#[derive(Debug, Clone)]
+struct Scenario {
+    num_workers: usize,
+    chunk_sizes: Vec<u32>,
+    saturation: f64,
+    min_replication: u16,
+}
+
+prop_compose! {
+    // Single weight keeps replication a scalar. Coarse chunk sizes (up to a full
+    // worker) make per-worker fragmentation bite. `min_replication` depends on
+    // `num_workers`, hence the two-stage generator.
+    fn strategy_scenario()(num_workers in 2usize..=8)(
+        num_workers in Just(num_workers),
+        min_replication in 1u16..=num_workers as u16,
+        chunk_sizes in proptest::collection::vec(1u32..=WORKER_CAPACITY as u32, 1..=40),
+        saturation in 0.5f64..=0.99,
+    ) -> Scenario {
+        Scenario { num_workers, chunk_sizes, saturation, min_replication }
+    }
+}
+
+struct Outcome {
+    /// Largest uniform replication (>= min) that fits, or `None` if even `min` fragments.
+    max_feasible: Option<u16>,
+    /// The factor `schedule` derives for the whole set (diagnostics only).
+    derived: Result<BTreeMap<u16, u16>, ReplicationError>,
+    /// Whether `schedule` placed everything without panicking.
+    scheduled_ok: bool,
+}
+
+proptest! {
+    /// `schedule` fills capacity at a replication factor whose placement
+    /// (consistent-hashing first-fit) can fragment and fail — even though a lower
+    /// factor (still >= `min_replication`) would have placed everything. It never
+    /// backs off, so it panics.
+    ///
+    /// Property: if any factor `>= min_replication` places all chunks, `schedule` must too.
+    ///
+    /// `#[should_panic]`: a counterexample currently exists; remove the marker once fixed.
+    #[test]
+    #[should_panic(expected = "a placeable replication exists")]
+    fn schedule_picks_a_placeable_replication(scenario in strategy_scenario()) {
+        let Outcome { max_feasible, derived, scheduled_ok } = evaluate(&scenario);
+        prop_assert!(
+            max_feasible.is_none() || scheduled_ok,
+            "a placeable replication exists (max feasible = {max_feasible:?}, min = {min}), \
+             but schedule derived {derived:?} and failed to place — it should have backed off \
+             to the largest feasible replication (which may be above min). \
+             workers={workers}, saturation={saturation}, chunk_sizes={sizes:?}",
+            min = scenario.min_replication,
+            workers = scenario.num_workers,
+            saturation = scenario.saturation,
+            sizes = scenario.chunk_sizes,
+        );
+    }
+}
+
+// ---- helpers ----
+
+const WORKER_CAPACITY: u64 = 1_000;
+
+/// Dataset name shared by every test chunk.
+const DATASET: &str = "ds";
+
+// Chunk-id prefixes, kept distinct per role so ids never collide across chunk sets.
+const SCENARIO_CHUNK_PREFIX: char = 'c';
+
+/// Idempotent per-test setup: silence the panic printer (the intentional
+/// `catch_unwind`s would otherwise flood stderr) and route `RUST_LOG` to the test writer.
+fn setup() {
+    static HOOK: Once = Once::new();
+    HOOK.call_once(|| std::panic::set_hook(Box::new(|_| {})));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
+}
+
+/// Run `f`, returning `None` if it panicked — placement panics on capacity/version
+/// failures and we catch it rather than abort the run.
+fn no_panic<T>(f: impl FnOnce() -> T) -> Option<T> {
+    catch_unwind(AssertUnwindSafe(f)).ok()
+}
+
+/// Deterministic, distinct worker per index (stable proptest shrinking).
+fn worker_with_version(index: u64, version: Option<&str>) -> Worker {
+    let mut seed = [0u8; 32];
+    seed[..8].copy_from_slice(&index.to_le_bytes());
+    let keypair = libp2p_identity::Keypair::ed25519_from_bytes(seed).unwrap();
+    Worker {
+        id: keypair.public().to_peer_id(),
+        status: WorkerStatus::Online,
+        version: version.map(|v| Version::parse(v).unwrap()),
+    }
+}
+
+fn test_worker(index: u64) -> Worker {
+    worker_with_version(index, None)
+}
+
+/// `count` distinct chunk ids prefixed with `prefix`. Owned so callers keep them
+/// alive for the borrowed `ScheduledChunk`s.
+fn chunk_ids(prefix: char, count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("{prefix}{i}")).collect()
+}
+
+/// Weight-1 `ScheduledChunk`s pairing `ids` with `sizes`, all sharing `min_ver`.
+fn chunks_from<'a>(
+    dataset: &'a str,
+    ids: &'a [String],
+    sizes: &[u32],
+    min_ver: Option<&'a Version>,
+) -> Vec<ScheduledChunk<'a>> {
+    sizes
+        .iter()
+        .zip(ids)
+        .map(|(&size, id)| ScheduledChunk {
+            dataset,
+            chunk_id: id.as_str(),
+            size,
+            weight: 1,
+            minimum_worker_version: min_ver,
+        })
+        .collect()
+}
+
+/// Oracle: the scatter placement (worker -> chunk indices) at a uniform `replication`,
+/// or `None` if `distribute` panics (a chunk found no worker with free capacity).
+fn placement_at(
+    chunks: &[ScheduledChunk],
+    workers: &[&Worker],
+    replication: u16,
+) -> Option<BTreeMap<PeerId, Vec<ChunkIndex>>> {
+    let replicated: Vec<_> = chunks
+        .iter()
+        .map(|chunk| ReplicatedChunk {
+            dataset: chunk.dataset,
+            chunk_id: chunk.chunk_id,
+            size: chunk.size,
+            replication,
+            minimum_worker_version: None,
+        })
+        .collect();
+    no_panic(|| distribute(&replicated, workers, WORKER_CAPACITY))
+}
+
+fn placeable_at(chunks: &[ScheduledChunk], workers: &[&Worker], replication: u16) -> bool {
+    placement_at(chunks, workers, replication).is_some()
+}
+
+/// Render a scatter placement as `worker N: id(size), …` rows, sorted by worker index.
+fn format_placement(
+    placement: &BTreeMap<PeerId, Vec<ChunkIndex>>,
+    workers: &[&Worker],
+    chunks: &[ScheduledChunk],
+) -> String {
+    let mut rows: Vec<(usize, String)> = placement
+        .iter()
+        .map(|(id, indices)| {
+            let worker = workers.iter().position(|w| w.id == *id).unwrap();
+            let held = if indices.is_empty() {
+                "(empty)".to_string()
+            } else {
+                indices
+                    .iter()
+                    .map(|&i| {
+                        let c = &chunks[i as usize];
+                        format!("{}({})", c.chunk_id, c.size)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            (worker, format!("  worker {worker}: {held}"))
+        })
+        .collect();
+    rows.sort();
+    rows.into_iter()
+        .map(|(_, row)| row)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Run the scenario through both the feasibility oracle and `schedule`.
+fn evaluate(scenario: &Scenario) -> Outcome {
+    setup();
+
+    let workers: Vec<Worker> = (0..scenario.num_workers as u64).map(test_worker).collect();
+    let worker_refs: Vec<&Worker> = workers.iter().collect();
+
+    let ids = chunk_ids(SCENARIO_CHUNK_PREFIX, scenario.chunk_sizes.len());
+    let chunks = chunks_from(DATASET, &ids, &scenario.chunk_sizes, None);
+
+    let config = SchedulingConfig {
+        worker_capacity: WORKER_CAPACITY,
+        saturation: scenario.saturation,
+        min_replication: scenario.min_replication,
+        ignore_reliability: true,
+    };
+
+    // Feasibility is monotone in replication, so the feasible factors form a prefix:
+    // `take_while` collects it and `last` is the maximum.
+    let max_feasible = (config.min_replication..=scenario.num_workers as u16)
+        .take_while(|&replication| placeable_at(&chunks, &worker_refs, replication))
+        .last();
+
+    // What `schedule` derives (mirrors `schedule_to_workers`).
+    let total_size: u64 = scenario.chunk_sizes.iter().map(|&size| size as u64).sum();
+    let capacity_budget =
+        (WORKER_CAPACITY * scenario.num_workers as u64) as f64 * scenario.saturation;
+    let derived = calc_replication_factors(
+        BTreeMap::from([(1u16, total_size)]),
+        capacity_budget as u64,
+        config.min_replication,
+        scenario.num_workers as u16,
+    );
+
+    let scheduled_ok = no_panic(|| schedule(&chunks, &workers, config.clone())).is_some();
+
+    tracing::info!(
+        "derived={derived:?}, largest feasible (>= min {}) = {max_feasible:?}, placed_ok={scheduled_ok}",
+        scenario.min_replication,
+    );
+
+    // `schedule` failed but a lower replication is feasible: print the eligible
+    // placement the oracle found — the schedule `schedule` should have produced.
+    if !scheduled_ok {
+        if let Some(feasible) = max_feasible {
+            if let Some(placement) = placement_at(&chunks, &worker_refs, feasible) {
+                tracing::info!(
+                    "eligible schedule at R={feasible}:\n{}",
+                    format_placement(&placement, &worker_refs, &chunks),
+                );
+            }
+        }
+    }
+
+    Outcome {
+        max_feasible,
+        derived,
+        scheduled_ok,
+    }
+}

--- a/src/tests/scheduling_proptests.rs
+++ b/src/tests/scheduling_proptests.rs
@@ -2,6 +2,7 @@
 //! dynamically (placing replicas round by round up to the byte-budget cap), so a
 //! fragmenting placement backs off to a feasible factor instead of panicking.
 
+use std::cell::Cell;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Once;
 
@@ -104,20 +105,36 @@ fn run(scenario: &Scenario) -> Result<Assignment, ReplicationError> {
     schedule(&chunks, &workers, config)
 }
 
-/// Idempotent per-test setup: silence the panic printer (the intentional `catch_unwind`s
-/// would otherwise flood stderr) and route `RUST_LOG` to the test writer.
+thread_local! {
+    /// True while inside `no_panic`, so the hook silences only the expected panic.
+    static SILENCE_PANIC: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Idempotent per-test setup. The panic hook stays quiet inside `no_panic` but
+/// defers to the previous hook otherwise, so genuine panics still print; logs
+/// route to the test writer.
 fn setup() {
     static HOOK: Once = Once::new();
-    HOOK.call_once(|| std::panic::set_hook(Box::new(|_| {})));
+    HOOK.call_once(|| {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if !SILENCE_PANIC.with(Cell::get) {
+                prev(info);
+            }
+        }));
+    });
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_test_writer()
         .try_init();
 }
 
-/// Run `f`, returning `None` if it panicked.
+/// Run `f`, returning `None` if it panicked, without printing the panic.
 fn no_panic<T>(f: impl FnOnce() -> T) -> Option<T> {
-    catch_unwind(AssertUnwindSafe(f)).ok()
+    SILENCE_PANIC.with(|s| s.set(true));
+    let result = catch_unwind(AssertUnwindSafe(f)).ok();
+    SILENCE_PANIC.with(|s| s.set(false));
+    result
 }
 
 /// Deterministic, distinct worker per index (stable proptest shrinking).

--- a/src/tests/scheduling_proptests.rs
+++ b/src/tests/scheduling_proptests.rs
@@ -1,57 +1,71 @@
-//! Property-based tests for the scheduling/scatter algorithm, kept separate from
-//! the example-based tests in `scheduling.rs`. They drive the public `schedule`
-//! plus the crate-internal `distribute` scatter (via the `placeable_at` oracle).
-//!
-//! Order: regression tests, then the property tests they came from, then helpers.
+//! Property-based tests for the scheduler. It discovers the replication factor
+//! dynamically (placing replicas round by round up to the byte-budget cap), so a
+//! fragmenting placement backs off to a feasible factor instead of panicking.
 
-use std::collections::BTreeMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Once;
 
-use libp2p_identity::PeerId;
 use proptest::prelude::*;
-use semver::Version;
 
 use crate::{
-    replication::{ReplicationError, calc_replication_factors},
-    scheduling::{ReplicatedChunk, ScheduledChunk, SchedulingConfig, distribute, schedule},
-    types::{ChunkIndex, Worker, WorkerStatus},
+    replication::ReplicationError,
+    scheduling::{ScheduledChunk, SchedulingConfig, schedule},
+    types::{Assignment, Worker, WorkerStatus},
 };
 
-// ---- regression tests ----
-// Hardcoded counterexamples from the property tests below, each named after the
-// proptest it pins down.
-
-/// Regression for `schedule_picks_a_placeable_replication`
-/// The minimum replication places fine, but `schedule` fills capacity to a higher factor that fragments
-/// across workers and panics instead of backing off.
+/// The counterexample that made the old single-pass scatter panic.
 #[test]
-#[should_panic(expected = "schedule should place when a feasible replication exists")]
-fn regression_schedule_picks_a_placeable_replication() {
+fn schedule_backs_off_instead_of_panicking() {
     let scenario = Scenario {
         num_workers: 6,
         chunk_sizes: vec![284, 717],
         saturation: 0.94,
         min_replication: 1,
     };
-    let Outcome {
-        max_feasible,
-        derived,
-        scheduled_ok,
-    } = evaluate(&scenario);
-
-    assert!(
-        max_feasible.is_some(),
-        "min_replication should be placeable in this scenario"
-    );
-    assert!(
-        scheduled_ok,
-        "schedule should place when a feasible replication exists \
-         (max feasible = {max_feasible:?}, derived = {derived:?})",
+    let assignment = run(&scenario).expect("schedule should place the fragmenting scenario");
+    assert_eq!(
+        assignment.replication_by_weight.get(&1),
+        Some(&3),
+        "should back off to R=3, the largest factor that fits",
     );
 }
 
-// ---- property tests ----
+proptest! {
+    /// `schedule` never panics: it returns a placement or a clean `NotEnoughCapacity`.
+    /// Whenever it places, every chunk keeps at least `min_replication` replicas.
+    #[test]
+    fn schedule_never_panics(scenario in strategy_scenario()) {
+        let outcome = no_panic(|| run(&scenario));
+        prop_assert!(outcome.is_some(), "schedule must never panic");
+        if let Some(Ok(assignment)) = outcome {
+            prop_assert!(
+                assignment
+                    .replication_by_weight
+                    .values()
+                    .all(|&r| r >= scenario.min_replication),
+                "placed chunks must keep >= min_replication replicas, got {:?}",
+                assignment.replication_by_weight,
+            );
+            // Invariant: a worker never holds two replicas of the same chunk.
+            for (worker, chunks) in &assignment.worker_chunks {
+                let unique: std::collections::BTreeSet<_> = chunks.iter().collect();
+                prop_assert_eq!(
+                    unique.len(),
+                    chunks.len(),
+                    "worker {:?} holds a duplicate chunk replica: {:?}",
+                    worker,
+                    chunks,
+                );
+            }
+        }
+    }
+}
+
+// ---- helpers ----
+
+const WORKER_CAPACITY: u64 = 1_000;
+const DATASET: &str = "ds";
+const CHUNK_PREFIX: char = 'c';
 
 #[derive(Debug, Clone)]
 struct Scenario {
@@ -62,9 +76,9 @@ struct Scenario {
 }
 
 prop_compose! {
-    // Single weight keeps replication a scalar. Coarse chunk sizes (up to a full
-    // worker) make per-worker fragmentation bite. `min_replication` depends on
-    // `num_workers`, hence the two-stage generator.
+    // Single weight keeps replication a scalar. Coarse chunk sizes (up to a full worker)
+    // make per-worker fragmentation bite. `min_replication` depends on `num_workers`,
+    // hence the two-stage generator.
     fn strategy_scenario()(num_workers in 2usize..=8)(
         num_workers in Just(num_workers),
         min_replication in 1u16..=num_workers as u16,
@@ -75,54 +89,23 @@ prop_compose! {
     }
 }
 
-struct Outcome {
-    /// Largest uniform replication (>= min) that fits, or `None` if even `min` fragments.
-    max_feasible: Option<u16>,
-    /// The factor `schedule` derives for the whole set (diagnostics only).
-    derived: Result<BTreeMap<u16, u16>, ReplicationError>,
-    /// Whether `schedule` placed everything without panicking.
-    scheduled_ok: bool,
+/// Build the workers/chunks for a `Scenario` and run `schedule`.
+fn run(scenario: &Scenario) -> Result<Assignment, ReplicationError> {
+    setup();
+    let workers: Vec<Worker> = (0..scenario.num_workers as u64).map(test_worker).collect();
+    let ids = chunk_ids(CHUNK_PREFIX, scenario.chunk_sizes.len());
+    let chunks = chunks_from(DATASET, &ids, &scenario.chunk_sizes);
+    let config = SchedulingConfig {
+        worker_capacity: WORKER_CAPACITY,
+        saturation: scenario.saturation,
+        min_replication: scenario.min_replication,
+        ignore_reliability: true,
+    };
+    schedule(&chunks, &workers, config)
 }
 
-proptest! {
-    /// `schedule` fills capacity at a replication factor whose placement
-    /// (consistent-hashing first-fit) can fragment and fail — even though a lower
-    /// factor (still >= `min_replication`) would have placed everything. It never
-    /// backs off, so it panics.
-    ///
-    /// Property: if any factor `>= min_replication` places all chunks, `schedule` must too.
-    ///
-    /// `#[should_panic]`: a counterexample currently exists; remove the marker once fixed.
-    #[test]
-    #[should_panic(expected = "a placeable replication exists")]
-    fn schedule_picks_a_placeable_replication(scenario in strategy_scenario()) {
-        let Outcome { max_feasible, derived, scheduled_ok } = evaluate(&scenario);
-        prop_assert!(
-            max_feasible.is_none() || scheduled_ok,
-            "a placeable replication exists (max feasible = {max_feasible:?}, min = {min}), \
-             but schedule derived {derived:?} and failed to place — it should have backed off \
-             to the largest feasible replication (which may be above min). \
-             workers={workers}, saturation={saturation}, chunk_sizes={sizes:?}",
-            min = scenario.min_replication,
-            workers = scenario.num_workers,
-            saturation = scenario.saturation,
-            sizes = scenario.chunk_sizes,
-        );
-    }
-}
-
-// ---- helpers ----
-
-const WORKER_CAPACITY: u64 = 1_000;
-
-/// Dataset name shared by every test chunk.
-const DATASET: &str = "ds";
-
-// Chunk-id prefixes, kept distinct per role so ids never collide across chunk sets.
-const SCENARIO_CHUNK_PREFIX: char = 'c';
-
-/// Idempotent per-test setup: silence the panic printer (the intentional
-/// `catch_unwind`s would otherwise flood stderr) and route `RUST_LOG` to the test writer.
+/// Idempotent per-test setup: silence the panic printer (the intentional `catch_unwind`s
+/// would otherwise flood stderr) and route `RUST_LOG` to the test writer.
 fn setup() {
     static HOOK: Once = Once::new();
     HOOK.call_once(|| std::panic::set_hook(Box::new(|_| {})));
@@ -132,41 +115,31 @@ fn setup() {
         .try_init();
 }
 
-/// Run `f`, returning `None` if it panicked — placement panics on capacity/version
-/// failures and we catch it rather than abort the run.
+/// Run `f`, returning `None` if it panicked.
 fn no_panic<T>(f: impl FnOnce() -> T) -> Option<T> {
     catch_unwind(AssertUnwindSafe(f)).ok()
 }
 
 /// Deterministic, distinct worker per index (stable proptest shrinking).
-fn worker_with_version(index: u64, version: Option<&str>) -> Worker {
+fn test_worker(index: u64) -> Worker {
     let mut seed = [0u8; 32];
     seed[..8].copy_from_slice(&index.to_le_bytes());
     let keypair = libp2p_identity::Keypair::ed25519_from_bytes(seed).unwrap();
     Worker {
         id: keypair.public().to_peer_id(),
         status: WorkerStatus::Online,
-        version: version.map(|v| Version::parse(v).unwrap()),
+        version: None,
     }
 }
 
-fn test_worker(index: u64) -> Worker {
-    worker_with_version(index, None)
-}
-
-/// `count` distinct chunk ids prefixed with `prefix`. Owned so callers keep them
-/// alive for the borrowed `ScheduledChunk`s.
+/// `count` distinct chunk ids prefixed with `prefix`. Owned so callers keep them alive
+/// for the borrowed `ScheduledChunk`s.
 fn chunk_ids(prefix: char, count: usize) -> Vec<String> {
     (0..count).map(|i| format!("{prefix}{i}")).collect()
 }
 
-/// Weight-1 `ScheduledChunk`s pairing `ids` with `sizes`, all sharing `min_ver`.
-fn chunks_from<'a>(
-    dataset: &'a str,
-    ids: &'a [String],
-    sizes: &[u32],
-    min_ver: Option<&'a Version>,
-) -> Vec<ScheduledChunk<'a>> {
+/// Weight-1 `ScheduledChunk`s pairing `ids` with `sizes`.
+fn chunks_from<'a>(dataset: &'a str, ids: &'a [String], sizes: &[u32]) -> Vec<ScheduledChunk<'a>> {
     sizes
         .iter()
         .zip(ids)
@@ -175,124 +148,7 @@ fn chunks_from<'a>(
             chunk_id: id.as_str(),
             size,
             weight: 1,
-            minimum_worker_version: min_ver,
-        })
-        .collect()
-}
-
-/// Oracle: the scatter placement (worker -> chunk indices) at a uniform `replication`,
-/// or `None` if `distribute` panics (a chunk found no worker with free capacity).
-fn placement_at(
-    chunks: &[ScheduledChunk],
-    workers: &[&Worker],
-    replication: u16,
-) -> Option<BTreeMap<PeerId, Vec<ChunkIndex>>> {
-    let replicated: Vec<_> = chunks
-        .iter()
-        .map(|chunk| ReplicatedChunk {
-            dataset: chunk.dataset,
-            chunk_id: chunk.chunk_id,
-            size: chunk.size,
-            replication,
             minimum_worker_version: None,
         })
-        .collect();
-    no_panic(|| distribute(&replicated, workers, WORKER_CAPACITY))
-}
-
-fn placeable_at(chunks: &[ScheduledChunk], workers: &[&Worker], replication: u16) -> bool {
-    placement_at(chunks, workers, replication).is_some()
-}
-
-/// Render a scatter placement as `worker N: id(size), …` rows, sorted by worker index.
-fn format_placement(
-    placement: &BTreeMap<PeerId, Vec<ChunkIndex>>,
-    workers: &[&Worker],
-    chunks: &[ScheduledChunk],
-) -> String {
-    let mut rows: Vec<(usize, String)> = placement
-        .iter()
-        .map(|(id, indices)| {
-            let worker = workers.iter().position(|w| w.id == *id).unwrap();
-            let held = if indices.is_empty() {
-                "(empty)".to_string()
-            } else {
-                indices
-                    .iter()
-                    .map(|&i| {
-                        let c = &chunks[i as usize];
-                        format!("{}({})", c.chunk_id, c.size)
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-            (worker, format!("  worker {worker}: {held}"))
-        })
-        .collect();
-    rows.sort();
-    rows.into_iter()
-        .map(|(_, row)| row)
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-/// Run the scenario through both the feasibility oracle and `schedule`.
-fn evaluate(scenario: &Scenario) -> Outcome {
-    setup();
-
-    let workers: Vec<Worker> = (0..scenario.num_workers as u64).map(test_worker).collect();
-    let worker_refs: Vec<&Worker> = workers.iter().collect();
-
-    let ids = chunk_ids(SCENARIO_CHUNK_PREFIX, scenario.chunk_sizes.len());
-    let chunks = chunks_from(DATASET, &ids, &scenario.chunk_sizes, None);
-
-    let config = SchedulingConfig {
-        worker_capacity: WORKER_CAPACITY,
-        saturation: scenario.saturation,
-        min_replication: scenario.min_replication,
-        ignore_reliability: true,
-    };
-
-    // Feasibility is monotone in replication, so the feasible factors form a prefix:
-    // `take_while` collects it and `last` is the maximum.
-    let max_feasible = (config.min_replication..=scenario.num_workers as u16)
-        .take_while(|&replication| placeable_at(&chunks, &worker_refs, replication))
-        .last();
-
-    // What `schedule` derives (mirrors `schedule_to_workers`).
-    let total_size: u64 = scenario.chunk_sizes.iter().map(|&size| size as u64).sum();
-    let capacity_budget =
-        (WORKER_CAPACITY * scenario.num_workers as u64) as f64 * scenario.saturation;
-    let derived = calc_replication_factors(
-        BTreeMap::from([(1u16, total_size)]),
-        capacity_budget as u64,
-        config.min_replication,
-        scenario.num_workers as u16,
-    );
-
-    let scheduled_ok = no_panic(|| schedule(&chunks, &workers, config.clone())).is_some();
-
-    tracing::info!(
-        "derived={derived:?}, largest feasible (>= min {}) = {max_feasible:?}, placed_ok={scheduled_ok}",
-        scenario.min_replication,
-    );
-
-    // `schedule` failed but a lower replication is feasible: print the eligible
-    // placement the oracle found — the schedule `schedule` should have produced.
-    if !scheduled_ok {
-        if let Some(feasible) = max_feasible {
-            if let Some(placement) = placement_at(&chunks, &worker_refs, feasible) {
-                tracing::info!(
-                    "eligible schedule at R={feasible}:\n{}",
-                    format_placement(&placement, &worker_refs, &chunks),
-                );
-            }
-        }
-    }
-
-    Outcome {
-        max_feasible,
-        derived,
-        scheduled_ok,
-    }
+        .collect()
 }

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -4,13 +4,13 @@ use libp2p_identity::PeerId;
 
 use crate::{cli, types::WorkerIndex};
 
-use super::{Chunk, ChunkIndex, Worker, WorkerStatus};
+use super::{Chunk, ChunkIndex, ChunkWeight, ReplicationFactor, Worker, WorkerStatus};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Assignment {
     // chunk indexes are sorted
     pub worker_chunks: BTreeMap<PeerId, Vec<ChunkIndex>>,
-    pub replication_by_weight: BTreeMap<u16, u16>,
+    pub replication_by_weight: BTreeMap<ChunkWeight, ReplicationFactor>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -109,7 +109,7 @@ impl Assignment {
 
             let is_last_in_dataset = iter
                 .peek()
-                .map_or(true, |(next, _)| next.dataset != chunk.dataset);
+                .is_none_or(|(next, _)| next.dataset != chunk.dataset);
 
             let download_url = if config.storage_allow_insecure_scheme {
                 format!("http://{}/{}/", config.storage_domain, chunk.bucket())

--- a/tools/reshuffle_sim/src/scheduler.rs
+++ b/tools/reshuffle_sim/src/scheduler.rs
@@ -82,6 +82,7 @@ fn to_scheduled_chunks<'a>(
                 size: chunk.size,
                 weight: *weight,
                 minimum_worker_version,
+                hashes: Vec::new(),
             }
         })
         .collect()


### PR DESCRIPTION
Closes: https://linear.app/sqd-ai/issue/NET-786/scheduling-missing-replication-backoff

## What is this PR about?

The existing scheduling algorithm picks a single replication factor from the available capacity and tries to place every copy at that factor in one pass. When that factor can't actually be realized it panics - even when a lower
factor that is still ≥ `min_replication` would have placed every chunk.

The factor is estimated from total data size vs. total worker capacity, which assumes the data packs evenly across workers. It doesn't: a worker holds at most one copy of a given chunk and must store it whole, so when chunks are large relative to a worker's capacity, fewer copies fit than the estimate assumes and the target factor becomes unreachable.

This PR makes the scheduler back off instead of failing. It treats the estimated factor as an upper bound and places copies in phases, getting as close to it as the workers can actually hold:

- version-restricted chunks first, up to the minimum replication (they can only go on the few upgraded workers);
- unrestricted chunks, up to the minimum replication;
- all chunks together, topped up toward the estimate as far as space allows.

The minimum replication is still mandatory: if it can't be met, scheduling returns a capacity error rather than panicking.

### Notable behaviour changes
- Scheduling no longer panics on an unplaceable factor; it returns a result and the caller surfaces it as an error.
- The up-front version-restriction validation (rejecting setups that needed more copies than eligible workers, or too much restricted data for the spare capacity) is removed — those cases now degrade gracefully during placement.
- The replication reported per weight is the smallest factor actually achieved across that weight's chunks (a pessimistic figure) rather than the estimate.

## Structure

The PR is split into two commits:

1. **Add the failing property-based test** that reproduces the bug - the scheduler can't distribute chunks even when a feasible factor ≥ `min_replication` exists.
2. **Fix it** with the phased, best-effort placement described above. New property tests assert that scheduling never panics, always meets the minimum replication when it succeeds, and never places two copies of a chunk on the same worker, with regressions for the back-off and restricted-minimum cases.