### PR TITLE
feat(reshuffle-sim): simulate version-restricted chunks and worker upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +2693,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2861,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3150,6 +3189,7 @@ dependencies = [
  "rand 0.9.1",
  "semver",
  "sqd-assignments 0.1.0",
+ "tabled",
 ]
 
 [[package]]
@@ -3765,6 +3805,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,6 +3839,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4082,6 +4155,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"

--- a/tools/reshuffle_sim/Cargo.toml
+++ b/tools/reshuffle_sim/Cargo.toml
@@ -14,3 +14,4 @@ libp2p-identity = { version = "0.2.10", features = ["peerid"] }
 semver = "1.0.26"
 bytesize = "2.3.1"
 rand = "0.9.1"
+tabled = "0.21"

--- a/tools/reshuffle_sim/README.md
+++ b/tools/reshuffle_sim/README.md
@@ -7,3 +7,35 @@ Simulates chunk ingestion over multiple steps against a real assignment, runs th
 ```sh
 cargo run -p reshuffle-sim -- -c config.yaml --chunks-per-step 1000 --steps 10 --report report.html input.fb.gz
 ```
+
+## Version-restricted chunks & worker upgrades
+
+The simulator can mark a fraction of newly ingested chunks as requiring a newer
+worker version, and model the worker fleet upgrading to that version over time.
+This shows how reshuffling behaves while a version rollout is in progress.
+
+```sh
+cargo run -p reshuffle-sim -- -c config.yaml \
+  --chunks-per-step 200 --steps 60 \
+  --restricted-fraction 0.3 \
+  --upgrade-schedule "1:0,5:0.25,30:0.6,50:1.0" \
+  --report report.html input.fb.gz
+```
+
+- `--restricted-fraction` — fraction (0.0–1.0) of each step's new chunks that
+  require the new worker version. Default `0.0` (feature off).
+- `--upgrade-schedule` — ascending `step:fraction` breakpoints for the share of
+  workers on the new version, held constant between breakpoints (e.g.
+  `1:0,5:0.25,50:1.0`). Default empty.
+- `--initial-new-fraction` — share (0.0–1.0) of workers already on the new
+  version at step 0. Default `0.0`.
+
+With all three at their defaults the run is identical to the basic simulation
+above. The report and console table gain three columns: workers eligible for
+restricted data, whether the step scheduled successfully, and the restricted
+download volume.
+
+The scheduler enforces version restrictions by panicking when restricted data
+cannot fit the eligible-worker pool. The simulator catches that, records the
+failed step, and stops — so an early, under-upgraded fleet ends the run cleanly
+(with the report written) rather than crashing.

--- a/tools/reshuffle_sim/README.md
+++ b/tools/reshuffle_sim/README.md
@@ -8,6 +8,50 @@ Simulates chunk ingestion over multiple steps against a real assignment, runs th
 cargo run -p reshuffle-sim -- -c config.yaml --chunks-per-step 1000 --steps 10 --report report.html input.fb.gz
 ```
 
+`--chunk-size` overrides the size of each generated chunk (e.g. `--chunk-size 256MiB`);
+by default each chunk uses its dataset's average chunk size.
+
+## Chunk ingestion shapes
+
+By default the simulator ingests `--chunks-per-step` chunks every step. Use
+`--chunks-shape` to vary that count over the run instead — it's a `name:key=value,…`
+spec where **every parameter has a default and can be overridden**, so the shape name
+alone already works. The shape only changes *how many* chunks are added per step; it
+composes with all the other options.
+
+| Shape | Spec (with defaults) | Behaviour |
+|-------|----------------------|-----------|
+| `constant` | `constant:n=1000` | flat (same as `--chunks-per-step`) |
+| `ramp` | `ramp:from=0,to=1000` | linear from the first to the last step |
+| `triangle` | `triangle:peak=1000,center=<middle>` | rises to `center`, then falls |
+| `gaussian` | `gaussian:peak=1000,sigma=<steps/6>,center=<middle>` | smooth bump |
+| `pulse` | `pulse:size=10000,at=<middle>,base=0,width=1` | one bulk insert |
+| `bursts` | `bursts:size=10000,every=5,base=0,until=<end>` | periodic bulk inserts |
+| `points` | `points:1=0,50=5000,100=0` | arbitrary piecewise-linear profile |
+
+Examples:
+
+```sh
+# Slow ramp up to the middle, then declining
+cargo run -p reshuffle-sim -- -c config.yaml --steps 100 \
+  --chunks-shape triangle:peak=5000 input.fb.gz
+
+# One large bulk insert in the middle of the run
+cargo run -p reshuffle-sim -- -c config.yaml --steps 100 \
+  --chunks-shape pulse:size=50000 input.fb.gz
+
+# Small bulk every 5 steps for the first half, then nothing
+cargo run -p reshuffle-sim -- -c config.yaml --steps 100 \
+  --chunks-shape bursts:size=10000,every=5,until=50 input.fb.gz
+
+# Hand-drawn profile: nothing, ramp to 5000 by step 50, back to nothing by 100
+cargo run -p reshuffle-sim -- -c config.yaml --steps 100 \
+  --chunks-shape points:1=0,50=5000,100=0 input.fb.gz
+```
+
+`--chunks-shape` takes precedence over `--chunks-per-step`; without it the run uses
+the constant rate.
+
 ## Version-restricted chunks & worker upgrades
 
 The simulator can mark a fraction of newly ingested chunks as requiring a newer

--- a/tools/reshuffle_sim/src/chunks.rs
+++ b/tools/reshuffle_sim/src/chunks.rs
@@ -1,0 +1,147 @@
+//! Synthetic chunk generation for the simulation.
+
+use std::sync::Arc;
+
+use network_scheduler::types::Chunk;
+use rand::prelude::*;
+use rand::seq::SliceRandom;
+
+use crate::ChunkId;
+use crate::baseline::DatasetInfo;
+
+/// Generates `count` synthetic chunks at the head (latest blocks) of the
+/// datasets, sampling each dataset proportionally to its current chunk count.
+/// A `round(restricted_fraction * count)` share is tagged as version-restricted;
+/// their ids are returned alongside the chunks.
+///
+/// `chunk_size` overrides every chunk's size; when `None` each chunk uses its
+/// dataset's average chunk size.
+pub fn generate_new_chunks(
+    datasets: &mut [DatasetInfo],
+    count: u32,
+    restricted_fraction: f64,
+    chunk_size: Option<u32>,
+    rng: &mut impl Rng,
+) -> (Vec<Chunk>, Vec<ChunkId>) {
+    let chunks = generate_chunks(datasets, count, chunk_size, rng);
+    let restricted = pick_restricted(&chunks, restricted_fraction, rng);
+    (chunks, restricted)
+}
+
+fn generate_chunks(
+    datasets: &mut [DatasetInfo],
+    count: u32,
+    chunk_size: Option<u32>,
+    rng: &mut impl Rng,
+) -> Vec<Chunk> {
+    let distribution = cumulative_chunk_distribution(datasets);
+    (0..count)
+        .map(|_| {
+            let index = sample_dataset(&distribution, rng);
+            extend_dataset(&mut datasets[index], chunk_size)
+        })
+        .collect()
+}
+
+/// Appends one chunk to the head of `dataset`, advancing its block range and
+/// chunk count, and returns the new chunk.
+fn extend_dataset(dataset: &mut DatasetInfo, chunk_size: Option<u32>) -> Chunk {
+    let first_block = dataset.last_block + 1;
+    let last_block = first_block + dataset.avg_block_span - 1;
+    let id = format!(
+        "{:010}/{:010}-{:010}-{:08x}",
+        first_block, first_block, last_block, first_block as u32
+    );
+
+    dataset.last_block = last_block;
+    dataset.chunk_count += 1;
+
+    Chunk {
+        dataset: dataset.dataset_id.clone(),
+        id: Arc::new(id),
+        size: chunk_size.unwrap_or(dataset.avg_chunk_size),
+        blocks: first_block..=last_block,
+        files: Arc::new(vec![]),
+        summary: None,
+    }
+}
+
+/// Randomly selects `round(fraction * len)` of the chunks as restricted.
+fn pick_restricted(chunks: &[Chunk], fraction: f64, rng: &mut impl Rng) -> Vec<ChunkId> {
+    let restricted_count = ((fraction * chunks.len() as f64).round() as usize).min(chunks.len());
+    let mut indices: Vec<usize> = (0..chunks.len()).collect();
+    indices.shuffle(rng);
+    indices[..restricted_count]
+        .iter()
+        .map(|&i| (chunks[i].dataset.clone(), chunks[i].id.clone()))
+        .collect()
+}
+
+/// Cumulative `(dataset_index, threshold)` weights, where each dataset's share
+/// is proportional to its chunk count. Used to sample datasets for new chunks.
+fn cumulative_chunk_distribution(datasets: &[DatasetInfo]) -> Vec<(usize, f64)> {
+    let total: f64 = datasets.iter().map(|d| d.chunk_count as f64).sum();
+    let mut cumulative = Vec::with_capacity(datasets.len());
+    let mut acc = 0.0;
+    for (index, dataset) in datasets.iter().enumerate() {
+        acc += dataset.chunk_count as f64 / total;
+        cumulative.push((index, acc));
+    }
+    cumulative
+}
+
+fn sample_dataset(distribution: &[(usize, f64)], rng: &mut impl Rng) -> usize {
+    let r: f64 = rng.random();
+    distribution
+        .iter()
+        .find(|(_, threshold)| r <= *threshold)
+        .map(|(index, _)| *index)
+        .unwrap_or(distribution.len() - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    fn dataset(id: &str, count: u32) -> DatasetInfo {
+        DatasetInfo {
+            dataset_id: Arc::new(id.to_string()),
+            chunk_count: count,
+            last_block: 1000,
+            avg_block_span: 100,
+            avg_chunk_size: 1000,
+        }
+    }
+
+    #[test]
+    fn tags_restricted_fraction_of_chunks() {
+        let mut datasets = vec![dataset("ds", 100)];
+        let mut rng = StdRng::seed_from_u64(42);
+        let (chunks, restricted) = generate_new_chunks(&mut datasets, 100, 0.25, None, &mut rng);
+        assert_eq!(chunks.len(), 100);
+        assert_eq!(restricted.len(), 25);
+        let ids: std::collections::HashSet<_> = chunks
+            .iter()
+            .map(|c| (c.dataset.clone(), c.id.clone()))
+            .collect();
+        assert!(restricted.iter().all(|r| ids.contains(r)));
+    }
+
+    #[test]
+    fn zero_fraction_tags_nothing() {
+        let mut datasets = vec![dataset("ds", 10)];
+        let mut rng = StdRng::seed_from_u64(1);
+        let (chunks, restricted) = generate_new_chunks(&mut datasets, 10, 0.0, None, &mut rng);
+        assert_eq!(chunks.len(), 10);
+        assert!(restricted.is_empty());
+    }
+
+    #[test]
+    fn chunk_size_override_applies_to_all() {
+        let mut datasets = vec![dataset("ds", 10)];
+        let mut rng = StdRng::seed_from_u64(1);
+        let (chunks, _) = generate_new_chunks(&mut datasets, 10, 0.0, Some(777), &mut rng);
+        assert!(chunks.iter().all(|c| c.size == 777));
+    }
+}

--- a/tools/reshuffle_sim/src/main.rs
+++ b/tools/reshuffle_sim/src/main.rs
@@ -9,15 +9,17 @@
 mod baseline;
 mod report;
 mod simulation;
+mod upgrade;
 mod util;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     path::PathBuf,
     sync::Arc,
 };
 
 use anyhow::Context;
+use bytesize::ByteSize;
 use clap::Parser;
 use libp2p_identity::PeerId;
 use network_scheduler::{cli::Config, scheduling::SchedulingConfig, types::Chunk};
@@ -45,6 +47,11 @@ struct Args {
     #[arg(long, default_value = "1000")]
     chunks_per_step: u32,
 
+    /// Size of each generated chunk (e.g. 256MiB); defaults to the dataset's
+    /// average chunk size
+    #[arg(long)]
+    chunk_size: Option<ByteSize>,
+
     /// Number of simulation steps
     #[arg(long, default_value = "10")]
     steps: u32,
@@ -52,6 +59,26 @@ struct Args {
     /// Random seed for reproducibility
     #[arg(long, default_value = "42")]
     seed: u64,
+
+    /// Fraction (0.0–1.0) of each step's new chunks that require the new worker version
+    #[arg(long, default_value = "0.0")]
+    restricted_fraction: f64,
+
+    /// Worker upgrade schedule: ascending `step:fraction` breakpoints, e.g.
+    /// "1:0,5:0.25,50:0.5". The fraction of workers on the new version is held
+    /// constant between breakpoints.
+    #[arg(long, default_value = "")]
+    upgrade_schedule: String,
+
+    /// Fraction (0.0–1.0) of workers already on the new version at step 0
+    #[arg(long, default_value = "0.0")]
+    initial_new_fraction: f64,
+
+    /// Step at which to lift version restrictions: previously restricted chunks
+    /// are removed and no further restricted chunks are generated (new
+    /// unrestricted chunks keep being generated).
+    #[arg(long)]
+    lift_restriction_at_step: Option<u32>,
 
     /// Write an HTML report with charts to this path
     #[arg(long)]
@@ -65,6 +92,16 @@ struct Args {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    anyhow::ensure!(
+        (0.0..=1.0).contains(&args.restricted_fraction),
+        "--restricted-fraction must be in [0.0, 1.0], got {}",
+        args.restricted_fraction
+    );
+    anyhow::ensure!(
+        (0.0..=1.0).contains(&args.initial_new_fraction),
+        "--initial-new-fraction must be in [0.0, 1.0], got {}",
+        args.initial_new_fraction
+    );
     let _profiler = args.dhat.then(dhat::Profiler::new_heap);
     let config = Config::load(&args.config).context("Failed to load config")?;
 
@@ -78,42 +115,127 @@ fn main() -> anyhow::Result<()> {
         ignore_reliability: config.ignore_reliability,
     };
 
+    let chunk_size = args
+        .chunk_size
+        .map(|s| s.as_u64().min(u32::MAX as u64) as u32);
+
     let mut rng = StdRng::seed_from_u64(args.seed);
     let mut accumulated_new_chunks: Vec<Chunk> = Vec::new();
     let mut previous_chunk_owners = baseline.chunk_owners;
     let mut all_metrics = Vec::new();
 
-    util::print_header();
+    let new_worker_version = upgrade::new_version();
+    let upgrade_schedule = upgrade::UpgradeSchedule::parse(&args.upgrade_schedule)?;
+    let mut version_state = upgrade::WorkerVersionState::new(
+        baseline.workers.len(),
+        args.initial_new_fraction,
+        &mut rng,
+    );
+    let mut restricted_ids: HashSet<ChunkId> = HashSet::new();
+
+    // Stamp the initial fleet versions before reporting the starting distribution.
+    version_state.apply(&mut baseline.workers, &new_worker_version);
+    println!(
+        "Worker version distribution: {}",
+        util::format_version_distribution(&baseline.workers)
+    );
+
+    let mut live_table = util::LiveTable::new();
 
     for step in 1..=args.steps {
-        let step_chunks =
-            simulation::generate_new_chunks(&mut baseline.datasets, args.chunks_per_step, &mut rng);
-        let new_count = step_chunks.len() as u32;
-        accumulated_new_chunks.extend(step_chunks);
+        // At the lift step, remove the previously-restricted chunks and stop
+        // tagging new ones; unrestricted chunks keep being generated.
+        let lifted = args.lift_restriction_at_step.is_some_and(|n| step >= n);
+        if args.lift_restriction_at_step == Some(step) {
+            accumulated_new_chunks
+                .retain(|c| !restricted_ids.contains(&(c.dataset.clone(), c.id.clone())));
+            restricted_ids.clear();
+        }
+        let restricted_fraction = if lifted {
+            0.0
+        } else {
+            args.restricted_fraction
+        };
 
-        let (filtered_chunks, assignment) = simulation::schedule_combined_chunks(
+        let (step_chunks, step_restricted) = simulation::generate_new_chunks(
+            &mut baseline.datasets,
+            args.chunks_per_step,
+            restricted_fraction,
+            chunk_size,
+            &mut rng,
+        );
+        let new_count = step_chunks.len() as u32;
+        let new_restricted = step_restricted.len() as u32;
+        accumulated_new_chunks.extend(step_chunks);
+        restricted_ids.extend(step_restricted);
+
+        version_state.advance(&upgrade_schedule, step);
+        version_state.apply(&mut baseline.workers, &new_worker_version);
+        let eligible_workers = version_state.eligible_count();
+
+        let (filtered_chunks, schedule_result) = simulation::schedule_combined_chunks(
             &baseline.chunks,
             &accumulated_new_chunks,
             &baseline.workers,
             &config.datasets,
             &scheduling_config,
-        )?;
-
-        let (metrics, current_chunk_owners) = simulation::measure_reshuffle(
-            &previous_chunk_owners,
-            &filtered_chunks,
-            &assignment,
-            step,
-            new_count,
-            baseline.workers.len(),
-            scheduling_config.worker_capacity,
+            &restricted_ids,
+            &new_worker_version,
         );
 
-        util::print_step(&metrics);
-        all_metrics.push(metrics);
-
-        previous_chunk_owners = current_chunk_owners;
+        match schedule_result {
+            Ok(assignment) => {
+                let (metrics, current_chunk_owners) = simulation::measure_reshuffle(
+                    &previous_chunk_owners,
+                    &filtered_chunks,
+                    &assignment,
+                    step,
+                    new_count,
+                    new_restricted,
+                    baseline.workers.len(),
+                    scheduling_config.worker_capacity,
+                    &restricted_ids,
+                    eligible_workers,
+                );
+                previous_chunk_owners = current_chunk_owners;
+                all_metrics.push(metrics);
+                live_table.update(&all_metrics);
+            }
+            // Scheduling failed (panicked on infeasible version restrictions);
+            // record the step and stop.
+            Err(reason) => {
+                let metrics = simulation::failed_step_metrics(
+                    step,
+                    new_count,
+                    new_restricted,
+                    filtered_chunks.len(),
+                    restricted_ids.len(),
+                    baseline.workers.len(),
+                    scheduling_config.worker_capacity,
+                    eligible_workers,
+                    reason.clone(),
+                );
+                all_metrics.push(metrics);
+                live_table.update(&all_metrics);
+                eprintln!("Scheduling failed at step {step}: {reason}. Stopping simulation.");
+                break;
+            }
+        }
     }
+
+    live_table.finish(&all_metrics);
+
+    let total_added = accumulated_new_chunks.len();
+    let restricted_added = restricted_ids.len();
+    println!(
+        "\nChunks added: {total_added} (version-restricted: {restricted_added}, non-restricted: {})",
+        total_added - restricted_added
+    );
+    println!(
+        "Workers upgraded to {new_worker_version}: {} of {}",
+        version_state.eligible_count(),
+        baseline.workers.len()
+    );
 
     if let Some(report_path) = &args.report {
         report::generate_html(&all_metrics, report_path)?;

--- a/tools/reshuffle_sim/src/main.rs
+++ b/tools/reshuffle_sim/src/main.rs
@@ -1,19 +1,24 @@
-/// Simulates chunk ingestion over multiple steps and measures reshuffling impact.
-///
-/// Reads a real assignment (flatbuffer), generates new chunks at the head of each
-/// dataset proportionally to existing sizes, then runs the scheduler and diffs
-/// against the original assignment.
-///
-/// Usage:
-///   cargo run -p reshuffle-sim -- -c config.yaml --chunks-per-step 1000 --steps 10 input.fb.gz
+//! Simulates chunk ingestion over multiple steps and measures reshuffling impact.
+//!
+//! Reads a real assignment (flatbuffer), generates new chunks at the head of each
+//! dataset proportionally to existing sizes, then runs the scheduler and diffs
+//! against the original assignment.
+//!
+//! Usage:
+//!   cargo run -p reshuffle-sim -- -c config.yaml --chunks-per-step 1000 --steps 10 input.fb.gz
+
 mod baseline;
+mod chunks;
+mod metrics;
+mod rate;
 mod report;
+mod scheduler;
 mod simulation;
 mod upgrade;
 mod util;
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     path::PathBuf,
     sync::Arc,
 };
@@ -22,8 +27,10 @@ use anyhow::Context;
 use bytesize::ByteSize;
 use clap::Parser;
 use libp2p_identity::PeerId;
-use network_scheduler::{cli::Config, scheduling::SchedulingConfig, types::Chunk};
+use network_scheduler::{cli::Config, scheduling::SchedulingConfig};
 use rand::prelude::*;
+
+use crate::simulation::{Simulation, SimulationParams};
 
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
@@ -43,9 +50,15 @@ struct Args {
     #[arg(long, short)]
     config: PathBuf,
 
-    /// Number of new chunks to generate per step
+    /// Number of new chunks to generate per step (used when --chunks-shape is unset)
     #[arg(long, default_value = "1000")]
     chunks_per_step: u32,
+
+    /// Per-step ingestion shape, overriding --chunks-per-step. Examples:
+    /// "triangle:peak=5000", "pulse:size=50000,at=50", "bursts:size=10000,every=5,until=30",
+    /// "ramp:from=0,to=2000", "gaussian:peak=5000,sigma=8", "points:1=0,50=5000,100=0"
+    #[arg(long)]
+    chunks_shape: Option<String>,
 
     /// Size of each generated chunk (e.g. 256MiB); defaults to the dataset's
     /// average chunk size
@@ -103,10 +116,11 @@ fn main() -> anyhow::Result<()> {
         args.initial_new_fraction
     );
     let _profiler = args.dhat.then(dhat::Profiler::new_heap);
+
     let config = Config::load(&args.config).context("Failed to load config")?;
 
     eprintln!("Loading baseline assignment from {:?}", args.input);
-    let mut baseline = baseline::load_baseline(&args.input, &config.min_supported_worker_version)?;
+    let baseline = baseline::load_baseline(&args.input, &config.min_supported_worker_version)?;
 
     let scheduling_config = SchedulingConfig {
         worker_capacity: config.worker_storage_bytes,
@@ -114,132 +128,59 @@ fn main() -> anyhow::Result<()> {
         min_replication: config.min_replication,
         ignore_reliability: config.ignore_reliability,
     };
+    let chunk_rate = match &args.chunks_shape {
+        Some(spec) => rate::ChunkRate::parse(spec).context("Failed to parse --chunks-shape")?,
+        None => rate::ChunkRate::Constant {
+            n: args.chunks_per_step,
+        },
+    };
+    let params = SimulationParams {
+        steps: args.steps,
+        chunk_rate,
+        chunk_size: args
+            .chunk_size
+            .map(|s| s.as_u64().min(u32::MAX as u64) as u32),
+        restricted_fraction: args.restricted_fraction,
+        initial_new_fraction: args.initial_new_fraction,
+        upgrade_schedule: upgrade::UpgradeSchedule::parse(&args.upgrade_schedule)?,
+        lift_restriction_at_step: args.lift_restriction_at_step,
+    };
 
-    let chunk_size = args
-        .chunk_size
-        .map(|s| s.as_u64().min(u32::MAX as u64) as u32);
-
-    let mut rng = StdRng::seed_from_u64(args.seed);
-    let mut accumulated_new_chunks: Vec<Chunk> = Vec::new();
-    let mut previous_chunk_owners = baseline.chunk_owners;
-    let mut all_metrics = Vec::new();
-
-    let new_worker_version = upgrade::new_version();
-    let upgrade_schedule = upgrade::UpgradeSchedule::parse(&args.upgrade_schedule)?;
-    let mut version_state = upgrade::WorkerVersionState::new(
-        baseline.workers.len(),
-        args.initial_new_fraction,
-        &mut rng,
+    let rng = StdRng::seed_from_u64(args.seed);
+    let mut simulation = Simulation::new(
+        baseline,
+        config.datasets.clone(),
+        scheduling_config,
+        params,
+        rng,
     );
-    let mut restricted_ids: HashSet<ChunkId> = HashSet::new();
 
-    // Stamp the initial fleet versions before reporting the starting distribution.
-    version_state.apply(&mut baseline.workers, &new_worker_version);
     println!(
         "Worker version distribution: {}",
-        util::format_version_distribution(&baseline.workers)
+        util::format_version_distribution(simulation.workers())
     );
 
     let mut live_table = util::LiveTable::new();
-
-    for step in 1..=args.steps {
-        // At the lift step, remove the previously-restricted chunks and stop
-        // tagging new ones; unrestricted chunks keep being generated.
-        let lifted = args.lift_restriction_at_step.is_some_and(|n| step >= n);
-        if args.lift_restriction_at_step == Some(step) {
-            accumulated_new_chunks
-                .retain(|c| !restricted_ids.contains(&(c.dataset.clone(), c.id.clone())));
-            restricted_ids.clear();
-        }
-        let restricted_fraction = if lifted {
-            0.0
-        } else {
-            args.restricted_fraction
-        };
-
-        let (step_chunks, step_restricted) = simulation::generate_new_chunks(
-            &mut baseline.datasets,
-            args.chunks_per_step,
-            restricted_fraction,
-            chunk_size,
-            &mut rng,
-        );
-        let new_count = step_chunks.len() as u32;
-        let new_restricted = step_restricted.len() as u32;
-        accumulated_new_chunks.extend(step_chunks);
-        restricted_ids.extend(step_restricted);
-
-        version_state.advance(&upgrade_schedule, step);
-        version_state.apply(&mut baseline.workers, &new_worker_version);
-        let eligible_workers = version_state.eligible_count();
-
-        let (filtered_chunks, schedule_result) = simulation::schedule_combined_chunks(
-            &baseline.chunks,
-            &accumulated_new_chunks,
-            &baseline.workers,
-            &config.datasets,
-            &scheduling_config,
-            &restricted_ids,
-            &new_worker_version,
-        );
-
-        match schedule_result {
-            Ok(assignment) => {
-                let (metrics, current_chunk_owners) = simulation::measure_reshuffle(
-                    &previous_chunk_owners,
-                    &filtered_chunks,
-                    &assignment,
-                    step,
-                    new_count,
-                    new_restricted,
-                    baseline.workers.len(),
-                    scheduling_config.worker_capacity,
-                    &restricted_ids,
-                    eligible_workers,
-                );
-                previous_chunk_owners = current_chunk_owners;
-                all_metrics.push(metrics);
-                live_table.update(&all_metrics);
-            }
-            // Scheduling failed (panicked on infeasible version restrictions);
-            // record the step and stop.
-            Err(reason) => {
-                let metrics = simulation::failed_step_metrics(
-                    step,
-                    new_count,
-                    new_restricted,
-                    filtered_chunks.len(),
-                    restricted_ids.len(),
-                    baseline.workers.len(),
-                    scheduling_config.worker_capacity,
-                    eligible_workers,
-                    reason.clone(),
-                );
-                all_metrics.push(metrics);
-                live_table.update(&all_metrics);
-                eprintln!("Scheduling failed at step {step}: {reason}. Stopping simulation.");
-                break;
-            }
-        }
-    }
-
+    let all_metrics = simulation.run(|metrics| live_table.update(metrics));
     live_table.finish(&all_metrics);
 
-    let total_added = accumulated_new_chunks.len();
-    let restricted_added = restricted_ids.len();
-    println!(
-        "\nChunks added: {total_added} (version-restricted: {restricted_added}, non-restricted: {})",
-        total_added - restricted_added
-    );
-    println!(
-        "Workers upgraded to {new_worker_version}: {} of {}",
-        version_state.eligible_count(),
-        baseline.workers.len()
-    );
+    print_summary(&simulation.summary());
 
     if let Some(report_path) = &args.report {
         report::generate_html(&all_metrics, report_path)?;
     }
 
     Ok(())
+}
+
+fn print_summary(summary: &simulation::Summary) {
+    let non_restricted = summary.total_chunks_added - summary.restricted_chunks;
+    println!(
+        "\nChunks added: {} (version-restricted: {}, non-restricted: {non_restricted})",
+        summary.total_chunks_added, summary.restricted_chunks
+    );
+    println!(
+        "Workers upgraded to {}: {} of {}",
+        summary.new_worker_version, summary.upgraded_workers, summary.total_workers
+    );
 }

--- a/tools/reshuffle_sim/src/metrics.rs
+++ b/tools/reshuffle_sim/src/metrics.rs
@@ -1,0 +1,257 @@
+//! Reshuffle metrics and the assignment diffing that produces them.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use libp2p_identity::PeerId;
+use network_scheduler::types::{Assignment, Chunk};
+
+use crate::{ChunkId, ChunkOwners, ChunkSizeIndex};
+
+/// Metrics for a single simulation step.
+pub struct ReshuffleMetrics {
+    pub step: u32,
+    pub new_chunks_in_step: u32,
+    /// How many of this step's new chunks are version-restricted.
+    pub new_restricted_in_step: u32,
+    pub total_chunks: usize,
+    /// Cumulative count of version-restricted chunks.
+    pub total_restricted_chunks: usize,
+    pub replication_by_weight: BTreeMap<u16, u16>,
+    pub data_movement: DataMovement,
+    pub total_capacity_bytes: u64,
+    pub used_capacity_bytes: u64,
+    pub eligible_workers: usize,
+    /// False when scheduling failed (panicked) at this step; the run stops after.
+    pub scheduled: bool,
+    pub failure_reason: Option<String>,
+    /// Data movement restricted to version-restricted chunks only.
+    pub restricted_movement: DataMovement,
+}
+
+/// Data movement between two assignments, classified by cause.
+#[derive(Default)]
+pub struct DataMovement {
+    pub new_chunk_bytes: u64,
+    pub shuffled_bytes: u64,
+    pub shuffled_count: u32,
+    pub increased_replication_bytes: u64,
+    pub decreased_replication_bytes: u64,
+    pub workers_receiving_new: usize,
+    pub workers_losing: usize,
+    pub workers_shuffled: usize,
+}
+
+impl DataMovement {
+    pub fn zero() -> Self {
+        DataMovement::default()
+    }
+}
+
+/// Per-step counters shared by the success and failure metric builders.
+pub struct StepStats {
+    pub step: u32,
+    pub new_chunks: u32,
+    pub new_restricted: u32,
+    pub eligible_workers: usize,
+}
+
+/// Computes a step's metrics by diffing the new assignment against the previous
+/// one. Returns the current chunk owners for use as the next step's previous.
+pub fn measure_reshuffle(
+    previous_owners: &ChunkOwners,
+    chunks: &[Chunk],
+    assignment: &Assignment,
+    restricted: &HashSet<ChunkId>,
+    stats: StepStats,
+    total_capacity_bytes: u64,
+) -> (ReshuffleMetrics, ChunkOwners) {
+    let current_owners = chunk_owners(chunks, assignment);
+    let chunk_sizes = index_chunk_sizes(chunks);
+
+    let data_movement = compute_data_movement(previous_owners, &current_owners, &chunk_sizes);
+    let restricted_movement = compute_data_movement(
+        &filter_owners(previous_owners, restricted),
+        &filter_owners(&current_owners, restricted),
+        &chunk_sizes,
+    );
+
+    let metrics = ReshuffleMetrics {
+        step: stats.step,
+        new_chunks_in_step: stats.new_chunks,
+        new_restricted_in_step: stats.new_restricted,
+        total_chunks: chunks.len(),
+        total_restricted_chunks: restricted.len(),
+        replication_by_weight: assignment.replication_by_weight.clone(),
+        data_movement,
+        total_capacity_bytes,
+        used_capacity_bytes: used_capacity(chunks, assignment),
+        eligible_workers: stats.eligible_workers,
+        scheduled: true,
+        failure_reason: None,
+        restricted_movement,
+    };
+
+    (metrics, current_owners)
+}
+
+/// Metrics for the step at which scheduling failed: zero movement, and the run
+/// stops afterwards.
+pub fn failed_step_metrics(
+    stats: StepStats,
+    total_chunks: usize,
+    total_restricted_chunks: usize,
+    total_capacity_bytes: u64,
+    reason: String,
+) -> ReshuffleMetrics {
+    ReshuffleMetrics {
+        step: stats.step,
+        new_chunks_in_step: stats.new_chunks,
+        new_restricted_in_step: stats.new_restricted,
+        total_chunks,
+        total_restricted_chunks,
+        replication_by_weight: BTreeMap::new(),
+        data_movement: DataMovement::zero(),
+        total_capacity_bytes,
+        used_capacity_bytes: 0,
+        eligible_workers: stats.eligible_workers,
+        scheduled: false,
+        failure_reason: Some(reason),
+        restricted_movement: DataMovement::zero(),
+    }
+}
+
+/// Maps each chunk to the set of workers holding it in `assignment`.
+fn chunk_owners(chunks: &[Chunk], assignment: &Assignment) -> ChunkOwners {
+    let mut owners: ChunkOwners = BTreeMap::new();
+    for (worker, indexes) in &assignment.worker_chunks {
+        for &index in indexes {
+            let chunk = &chunks[index as usize];
+            owners
+                .entry((chunk.dataset.clone(), chunk.id.clone()))
+                .or_default()
+                .insert(*worker);
+        }
+    }
+    owners
+}
+
+fn index_chunk_sizes(chunks: &[Chunk]) -> ChunkSizeIndex {
+    chunks
+        .iter()
+        .map(|c| ((c.dataset.clone(), c.id.clone()), c.size))
+        .collect()
+}
+
+fn used_capacity(chunks: &[Chunk], assignment: &Assignment) -> u64 {
+    assignment
+        .worker_chunks
+        .values()
+        .flatten()
+        .map(|&index| chunks[index as usize].size as u64)
+        .sum()
+}
+
+/// Keeps only the owner entries whose chunk id is in `restricted`.
+fn filter_owners(owners: &ChunkOwners, restricted: &HashSet<ChunkId>) -> ChunkOwners {
+    owners
+        .iter()
+        .filter(|(id, _)| restricted.contains(*id))
+        .map(|(id, workers)| (id.clone(), workers.clone()))
+        .collect()
+}
+
+/// Classifies data movement between two assignments by cause:
+/// - a chunk only in `current` is new — all its replicas are downloads;
+/// - a chunk in both may have gained/lost replicas — gains are split into 1:1
+///   swaps (shuffle) and net replication increase;
+/// - a chunk only in `previous` was removed — its replicas are freed.
+fn compute_data_movement(
+    previous: &ChunkOwners,
+    current: &ChunkOwners,
+    chunk_sizes: &ChunkSizeIndex,
+) -> DataMovement {
+    let mut movement = Movement::default();
+
+    for (chunk_id, current_workers) in current {
+        let size = chunk_size(chunk_sizes, chunk_id);
+        match previous.get(chunk_id) {
+            Some(previous_workers) => {
+                movement.record_existing(size, previous_workers, current_workers)
+            }
+            None => movement.record_added(size, current_workers),
+        }
+    }
+    for (chunk_id, previous_workers) in previous {
+        if !current.contains_key(chunk_id) {
+            movement.record_removed(chunk_size(chunk_sizes, chunk_id), previous_workers);
+        }
+    }
+
+    movement.finish()
+}
+
+fn chunk_size(chunk_sizes: &ChunkSizeIndex, chunk_id: &ChunkId) -> u64 {
+    *chunk_sizes.get(chunk_id).unwrap_or(&0) as u64
+}
+
+/// Accumulates data movement while iterating chunks, tracking distinct affected
+/// workers as sets before collapsing to counts in [`Movement::finish`].
+#[derive(Default)]
+struct Movement {
+    new_chunk_bytes: u64,
+    shuffled_bytes: u64,
+    shuffled_count: u32,
+    increased_replication_bytes: u64,
+    decreased_replication_bytes: u64,
+    workers_receiving_new: BTreeSet<PeerId>,
+    workers_losing: BTreeSet<PeerId>,
+    workers_shuffled: BTreeSet<PeerId>,
+}
+
+impl Movement {
+    fn record_existing(
+        &mut self,
+        size: u64,
+        previous: &BTreeSet<PeerId>,
+        current: &BTreeSet<PeerId>,
+    ) {
+        let gained = current.difference(previous).count();
+        let lost = previous.difference(current).count();
+        let shuffled = gained.min(lost);
+
+        if shuffled > 0 {
+            self.shuffled_count += 1;
+            self.shuffled_bytes += size * shuffled as u64;
+        }
+        self.increased_replication_bytes += size * gained.saturating_sub(lost) as u64;
+        self.decreased_replication_bytes += size * lost.saturating_sub(gained) as u64;
+
+        self.workers_shuffled
+            .extend(current.difference(previous).copied());
+        self.workers_losing
+            .extend(previous.difference(current).copied());
+    }
+
+    fn record_added(&mut self, size: u64, current: &BTreeSet<PeerId>) {
+        self.new_chunk_bytes += size * current.len() as u64;
+        self.workers_receiving_new.extend(current.iter().copied());
+    }
+
+    fn record_removed(&mut self, size: u64, previous: &BTreeSet<PeerId>) {
+        self.decreased_replication_bytes += size * previous.len() as u64;
+        self.workers_losing.extend(previous.iter().copied());
+    }
+
+    fn finish(self) -> DataMovement {
+        DataMovement {
+            new_chunk_bytes: self.new_chunk_bytes,
+            shuffled_bytes: self.shuffled_bytes,
+            shuffled_count: self.shuffled_count,
+            increased_replication_bytes: self.increased_replication_bytes,
+            decreased_replication_bytes: self.decreased_replication_bytes,
+            workers_receiving_new: self.workers_receiving_new.len(),
+            workers_losing: self.workers_losing.len(),
+            workers_shuffled: self.workers_shuffled.len(),
+        }
+    }
+}

--- a/tools/reshuffle_sim/src/rate.rs
+++ b/tools/reshuffle_sim/src/rate.rs
@@ -221,13 +221,6 @@ impl Params {
             .map(|(_, v)| v.as_str())
     }
 
-    fn u32(&self, key: &str) -> anyhow::Result<u32> {
-        self.get(key)
-            .with_context(|| format!("missing '{key}'"))?
-            .parse()
-            .with_context(|| format!("invalid '{key}'"))
-    }
-
     fn u32_or(&self, key: &str, default: u32) -> anyhow::Result<u32> {
         match self.get(key) {
             Some(value) => value.parse().with_context(|| format!("invalid '{key}'")),

--- a/tools/reshuffle_sim/src/rate.rs
+++ b/tools/reshuffle_sim/src/rate.rs
@@ -1,0 +1,365 @@
+//! Per-step chunk ingestion rate — how many chunks to generate at each step.
+//!
+//! A [`ChunkRate`] is a pure function `count(step, total_steps) -> u32`,
+//! evaluated once per step. Steps are 1-indexed.
+
+use anyhow::{Context, bail, ensure};
+
+/// Default per-step count for the steady/peak shapes.
+const DEFAULT_COUNT: u32 = 1000;
+/// Default size of a bulk insert (`pulse`, `bursts`).
+const DEFAULT_BULK: u32 = 10_000;
+/// Default period for `bursts`.
+const DEFAULT_EVERY: u32 = 5;
+
+/// A shape describing how many chunks to generate at each step. Every parameter
+/// has a sane default and can be overridden in the spec.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChunkRate {
+    /// `n` chunks every step.
+    Constant { n: u32 },
+    /// Linear from `from` (step 1) to `to` (last step).
+    Ramp { from: u32, to: u32 },
+    /// Linear `0 → peak` up to `center`, then `peak → 0` (default center: middle).
+    Triangle { peak: u32, center: Option<u32> },
+    /// Bell curve `peak · e^(−(step − center)² / 2σ²)`. Defaults: center =
+    /// middle, sigma = `total_steps / 6`.
+    Gaussian {
+        peak: u32,
+        sigma: Option<f64>,
+        center: Option<u32>,
+    },
+    /// `base` everywhere, but `size` for `width` steps starting at `at` (default
+    /// `at`: middle).
+    Pulse {
+        size: u32,
+        at: Option<u32>,
+        base: u32,
+        width: u32,
+    },
+    /// `size` on every `every`-th step (up to `until`), else `base`.
+    Bursts {
+        size: u32,
+        every: u32,
+        base: u32,
+        until: Option<u32>,
+    },
+    /// Piecewise-linear interpolation between `(step, count)` breakpoints.
+    Points { breakpoints: Vec<(u32, u32)> },
+}
+
+impl ChunkRate {
+    /// Parses a shape spec like `triangle:peak=5000,center=50` or
+    /// `points:1=0,50=5000,100=0`.
+    pub fn parse(spec: &str) -> anyhow::Result<Self> {
+        let (name, rest) = match spec.split_once(':') {
+            Some((name, rest)) => (name.trim(), rest.trim()),
+            None => (spec.trim(), ""),
+        };
+        let params = Params::parse(rest)?;
+
+        let rate = match name {
+            "constant" => ChunkRate::Constant {
+                n: params.u32_or("n", DEFAULT_COUNT)?,
+            },
+            "ramp" => ChunkRate::Ramp {
+                from: params.u32_or("from", 0)?,
+                to: params.u32_or("to", DEFAULT_COUNT)?,
+            },
+            "triangle" => ChunkRate::Triangle {
+                peak: params.u32_or("peak", DEFAULT_COUNT)?,
+                center: params.opt_u32("center")?,
+            },
+            "gaussian" => ChunkRate::Gaussian {
+                peak: params.u32_or("peak", DEFAULT_COUNT)?,
+                sigma: params.opt_f64("sigma")?,
+                center: params.opt_u32("center")?,
+            },
+            "pulse" => ChunkRate::Pulse {
+                size: params.u32_or("size", DEFAULT_BULK)?,
+                at: params.opt_u32("at")?,
+                base: params.u32_or("base", 0)?,
+                width: params.u32_or("width", 1)?,
+            },
+            "bursts" => ChunkRate::Bursts {
+                size: params.u32_or("size", DEFAULT_BULK)?,
+                every: params.u32_or("every", DEFAULT_EVERY)?,
+                base: params.u32_or("base", 0)?,
+                until: params.opt_u32("until")?,
+            },
+            "points" => ChunkRate::Points {
+                breakpoints: params.breakpoints()?,
+            },
+            other => bail!("unknown chunks shape '{other}'"),
+        };
+        rate.validate()?;
+        Ok(rate)
+    }
+
+    fn validate(&self) -> anyhow::Result<()> {
+        match self {
+            ChunkRate::Gaussian {
+                sigma: Some(sigma), ..
+            } => ensure!(*sigma > 0.0, "gaussian sigma must be positive"),
+            ChunkRate::Pulse { width, .. } => ensure!(*width > 0, "pulse width must be positive"),
+            ChunkRate::Bursts { every, .. } => ensure!(*every > 0, "bursts every must be positive"),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Number of chunks to generate at `step` (1-indexed) of `total_steps`.
+    pub fn count_at(&self, step: u32, total_steps: u32) -> u32 {
+        match self {
+            ChunkRate::Constant { n } => *n,
+            ChunkRate::Ramp { from, to } => lerp(*from, *to, step, 1, total_steps),
+            ChunkRate::Triangle { peak, center } => {
+                let center = middle_or(*center, total_steps);
+                if step <= center {
+                    lerp(0, *peak, step, 1, center)
+                } else {
+                    lerp(*peak, 0, step, center, total_steps)
+                }
+            }
+            ChunkRate::Gaussian {
+                peak,
+                sigma,
+                center,
+            } => {
+                let center = middle_or(*center, total_steps) as f64;
+                let sigma = sigma.unwrap_or((total_steps as f64 / 6.0).max(1.0));
+                let exponent = -((step as f64 - center).powi(2)) / (2.0 * sigma * sigma);
+                (*peak as f64 * exponent.exp()).round() as u32
+            }
+            ChunkRate::Pulse {
+                size,
+                at,
+                base,
+                width,
+            } => {
+                let at = middle_or(*at, total_steps);
+                if step >= at && step < at + width {
+                    *size
+                } else {
+                    *base
+                }
+            }
+            ChunkRate::Bursts {
+                size,
+                every,
+                base,
+                until,
+            } => {
+                let within = until.is_none_or(|u| step <= u);
+                if within && step % every == 0 {
+                    *size
+                } else {
+                    *base
+                }
+            }
+            ChunkRate::Points { breakpoints } => interpolate(breakpoints, step),
+        }
+    }
+}
+
+/// Resolves an optional step position, defaulting to the middle of the run.
+fn middle_or(value: Option<u32>, total_steps: u32) -> u32 {
+    value.unwrap_or_else(|| total_steps.div_ceil(2)).max(1)
+}
+
+/// Linearly interpolates a count from `(x0, y0)` to `(x1, y1)`, clamped to the
+/// `[x0, x1]` range. Handles decreasing segments (`y1 < y0`).
+fn lerp(y0: u32, y1: u32, x: u32, x0: u32, x1: u32) -> u32 {
+    if x1 <= x0 {
+        return y1;
+    }
+    let x = x.clamp(x0, x1);
+    let t = (x - x0) as f64 / (x1 - x0) as f64;
+    (y0 as f64 + (y1 as f64 - y0 as f64) * t).round() as u32
+}
+
+/// Piecewise-linear interpolation between ascending `(step, count)` breakpoints;
+/// flat before the first and after the last.
+fn interpolate(breakpoints: &[(u32, u32)], step: u32) -> u32 {
+    let first = breakpoints[0];
+    let last = *breakpoints.last().unwrap();
+    if step <= first.0 {
+        return first.1;
+    }
+    if step >= last.0 {
+        return last.1;
+    }
+    for segment in breakpoints.windows(2) {
+        let (s0, c0) = segment[0];
+        let (s1, c1) = segment[1];
+        if step <= s1 {
+            return lerp(c0, c1, step, s0, s1);
+        }
+    }
+    last.1
+}
+
+/// Parsed `key=value` parameters of a shape spec.
+struct Params(Vec<(String, String)>);
+
+impl Params {
+    fn parse(rest: &str) -> anyhow::Result<Self> {
+        let mut pairs = Vec::new();
+        for entry in rest.split(',').map(str::trim).filter(|e| !e.is_empty()) {
+            let (key, value) = entry
+                .split_once('=')
+                .with_context(|| format!("expected key=value in '{entry}'"))?;
+            pairs.push((key.trim().to_string(), value.trim().to_string()));
+        }
+        Ok(Params(pairs))
+    }
+
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn u32(&self, key: &str) -> anyhow::Result<u32> {
+        self.get(key)
+            .with_context(|| format!("missing '{key}'"))?
+            .parse()
+            .with_context(|| format!("invalid '{key}'"))
+    }
+
+    fn u32_or(&self, key: &str, default: u32) -> anyhow::Result<u32> {
+        match self.get(key) {
+            Some(value) => value.parse().with_context(|| format!("invalid '{key}'")),
+            None => Ok(default),
+        }
+    }
+
+    fn opt_u32(&self, key: &str) -> anyhow::Result<Option<u32>> {
+        self.get(key)
+            .map(|value| value.parse().with_context(|| format!("invalid '{key}'")))
+            .transpose()
+    }
+
+    fn opt_f64(&self, key: &str) -> anyhow::Result<Option<f64>> {
+        self.get(key)
+            .map(|value| value.parse().with_context(|| format!("invalid '{key}'")))
+            .transpose()
+    }
+
+    /// Interprets every `key=value` pair as a `step=count` breakpoint.
+    fn breakpoints(&self) -> anyhow::Result<Vec<(u32, u32)>> {
+        let mut points = Vec::new();
+        for (key, value) in &self.0 {
+            let step: u32 = key
+                .parse()
+                .with_context(|| format!("invalid step '{key}'"))?;
+            let count: u32 = value
+                .parse()
+                .with_context(|| format!("invalid count '{value}'"))?;
+            points.push((step, count));
+        }
+        ensure!(
+            !points.is_empty(),
+            "points shape needs at least one 'step=count'"
+        );
+        points.sort_by_key(|(step, _)| *step);
+        Ok(points)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_is_flat() {
+        let rate = ChunkRate::parse("constant:n=1000").unwrap();
+        assert_eq!(rate.count_at(1, 10), 1000);
+        assert_eq!(rate.count_at(7, 10), 1000);
+    }
+
+    #[test]
+    fn ramp_interpolates_endpoints() {
+        let rate = ChunkRate::parse("ramp:from=0,to=100").unwrap();
+        assert_eq!(rate.count_at(1, 11), 0);
+        assert_eq!(rate.count_at(6, 11), 50);
+        assert_eq!(rate.count_at(11, 11), 100);
+    }
+
+    #[test]
+    fn triangle_peaks_in_the_middle() {
+        let rate = ChunkRate::parse("triangle:peak=100,center=5").unwrap();
+        assert_eq!(rate.count_at(1, 10), 0);
+        assert_eq!(rate.count_at(3, 10), 50);
+        assert_eq!(rate.count_at(5, 10), 100);
+        assert_eq!(rate.count_at(10, 10), 0);
+    }
+
+    #[test]
+    fn gaussian_peaks_at_center() {
+        let rate = ChunkRate::parse("gaussian:peak=100,sigma=2,center=5").unwrap();
+        assert_eq!(rate.count_at(5, 10), 100);
+        assert!(rate.count_at(1, 10) < rate.count_at(3, 10));
+        assert!(rate.count_at(3, 10) < rate.count_at(5, 10));
+    }
+
+    #[test]
+    fn pulse_spikes_once() {
+        let rate = ChunkRate::parse("pulse:size=500,at=5").unwrap();
+        assert_eq!(rate.count_at(4, 10), 0);
+        assert_eq!(rate.count_at(5, 10), 500);
+        assert_eq!(rate.count_at(6, 10), 0);
+    }
+
+    #[test]
+    fn bursts_repeat_until_limit() {
+        let rate = ChunkRate::parse("bursts:size=10,every=3,until=6").unwrap();
+        assert_eq!(rate.count_at(2, 10), 0);
+        assert_eq!(rate.count_at(3, 10), 10);
+        assert_eq!(rate.count_at(6, 10), 10);
+        assert_eq!(rate.count_at(9, 10), 0); // past `until`
+    }
+
+    #[test]
+    fn points_interpolate_piecewise() {
+        let rate = ChunkRate::parse("points:1=0,5=100,9=0").unwrap();
+        assert_eq!(rate.count_at(1, 10), 0);
+        assert_eq!(rate.count_at(3, 10), 50);
+        assert_eq!(rate.count_at(5, 10), 100);
+        assert_eq!(rate.count_at(7, 10), 50);
+        assert_eq!(rate.count_at(9, 10), 0);
+    }
+
+    #[test]
+    fn defaults_apply_without_params() {
+        assert_eq!(ChunkRate::parse("constant").unwrap().count_at(3, 10), 1000);
+        assert_eq!(ChunkRate::parse("ramp").unwrap().count_at(10, 10), 1000);
+        assert_eq!(ChunkRate::parse("triangle").unwrap().count_at(5, 10), 1000);
+        assert_eq!(ChunkRate::parse("gaussian").unwrap().count_at(5, 10), 1000);
+        assert_eq!(ChunkRate::parse("pulse").unwrap().count_at(5, 10), 10_000);
+        assert_eq!(ChunkRate::parse("pulse").unwrap().count_at(1, 10), 0);
+        assert_eq!(ChunkRate::parse("bursts").unwrap().count_at(5, 10), 10_000);
+    }
+
+    #[test]
+    fn params_override_defaults() {
+        let rate = ChunkRate::parse("triangle:peak=200").unwrap();
+        assert_eq!(rate.count_at(5, 10), 200);
+    }
+
+    #[test]
+    fn rejects_unknown_shape() {
+        assert!(ChunkRate::parse("spiral:peak=1").is_err());
+    }
+
+    #[test]
+    fn points_requires_breakpoints() {
+        assert!(ChunkRate::parse("points").is_err());
+    }
+
+    #[test]
+    fn rejects_non_positive_sigma() {
+        assert!(ChunkRate::parse("gaussian:peak=1,sigma=0").is_err());
+    }
+}

--- a/tools/reshuffle_sim/src/report.rs
+++ b/tools/reshuffle_sim/src/report.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use bytesize::ByteSize;
 
-use crate::simulation::ReshuffleMetrics;
+use crate::metrics::ReshuffleMetrics;
 
 pub fn generate_html(metrics: &[ReshuffleMetrics], path: &Path) -> anyhow::Result<()> {
     let steps: Vec<u32> = metrics.iter().map(|m| m.step).collect();

--- a/tools/reshuffle_sim/src/report.rs
+++ b/tools/reshuffle_sim/src/report.rs
@@ -62,6 +62,15 @@ pub fn generate_html(metrics: &[ReshuffleMetrics], path: &Path) -> anyhow::Resul
         .iter()
         .map(|m| m.data_movement.workers_shuffled)
         .collect();
+    let eligible_workers: Vec<usize> = metrics.iter().map(|m| m.eligible_workers).collect();
+    let scheduled_flags: Vec<u8> = metrics.iter().map(|m| m.scheduled as u8).collect();
+    let restricted_download_raw: Vec<u64> = metrics
+        .iter()
+        .map(|m| {
+            let r = &m.restricted_movement;
+            r.new_chunk_bytes + r.shuffled_bytes + r.increased_replication_bytes
+        })
+        .collect();
 
     let new_chunk_bytes_fmt: Vec<String> = new_chunk_bytes_raw
         .iter()
@@ -100,6 +109,25 @@ pub fn generate_html(metrics: &[ReshuffleMetrics], path: &Path) -> anyhow::Resul
         })
         .collect();
 
+    // If the run stopped because scheduling failed, show the recorded reason.
+    let stop_banner = metrics
+        .iter()
+        .find(|m| !m.scheduled)
+        .map(|m| {
+            let reason = m
+                .failure_reason
+                .as_deref()
+                .unwrap_or("scheduling failed")
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;");
+            format!(
+                r#"<div class="stop-banner"><strong>Simulation stopped at step {}:</strong> {}</div>"#,
+                m.step, reason
+            )
+        })
+        .unwrap_or_default();
+
     let html = format!(
         r##"<!DOCTYPE html>
 <html lang="en">
@@ -117,12 +145,14 @@ pub fn generate_html(metrics: &[ReshuffleMetrics], path: &Path) -> anyhow::Resul
   canvas {{ width: 100% !important; }}
   table {{ border-collapse: collapse; width: 100%; font-size: 13px; }}
   th, td {{ border: 1px solid #ddd; padding: 6px 10px; text-align: right; }}
+  .stop-banner {{ max-width: 1400px; margin: 0 auto 16px; padding: 12px 16px; background: #ffe5e5; border: 1px solid #ffb3b3; border-radius: 8px; color: #900; }}
   th {{ background: #f0f0f0; position: sticky; top: 0; }}
   td:first-child, th:first-child {{ text-align: center; }}
 </style>
 </head>
 <body>
 <h1>Reshuffle Simulation Report</h1>
+{stop_banner}
 <div class="grid">
 
 <div class="card">
@@ -157,16 +187,25 @@ pub fn generate_html(metrics: &[ReshuffleMetrics], path: &Path) -> anyhow::Resul
   <canvas id="capacityChart"></canvas>
 </div>
 
+<div class="card">
+  <canvas id="eligibleWorkersChart"></canvas>
+</div>
+
+<div class="card">
+  <canvas id="restrictedDownloadChart"></canvas>
+</div>
+
 <div class="card wide">
 <h3 style="margin-top:0">Raw Data</h3>
 <div style="overflow-x:auto">
 <table>
 <tr>
-  <th>Step</th><th>New chunks</th><th>Total chunks</th><th>Replication factor</th>
+  <th>Step</th><th>New chunks</th><th>New restricted</th><th>Total chunks</th><th>Total restricted</th><th>Replication factor</th>
   <th>New chunks download (all replicas)</th><th>Shuffled chunks</th><th>Shuffled chunks download (all replicas)</th>
   <th>Replication increase download</th><th>Replication decrease freed</th><th>Total S3 download (all replicas)</th>
   <th>Free capacity</th><th>Used %</th>
   <th>Workers receiving new</th><th>Workers losing</th><th>Workers receiving shuffled</th>
+  <th>Eligible workers</th><th>Scheduled</th><th>Restricted download (all replicas)</th>
 </tr>
 {table_rows}
 </table>
@@ -190,6 +229,9 @@ const usedPct = {used_pct:?};
 const workersReceivingNew = {workers_receiving_new:?};
 const workersLosing = {workers_losing:?};
 const workersShuffled = {workers_shuffled:?};
+const eligibleWorkers = {eligible_workers:?};
+const scheduledFlags = {scheduled_flags:?};
+const restrictedDownload = {restricted_download_raw:?};
 
 function formatBytes(b) {{
   if (b === 0) return '0 B';
@@ -331,6 +373,38 @@ new Chart(document.getElementById('capacityChart'), {{
     }}
   }}
 }});
+
+new Chart(document.getElementById('eligibleWorkersChart'), {{
+  type: 'line',
+  data: {{
+    labels: stepLabels,
+    datasets: [
+      {{ label: 'Workers on new version', data: eligibleWorkers, borderColor: '#36a2eb', backgroundColor: 'rgba(54,162,235,0.1)', fill: true }}
+    ]
+  }},
+  options: {{
+    plugins: {{ title: {{ display: true, text: 'Worker Version Upgrade Progress (eligible workers)' }} }},
+    scales: {{ y: {{ beginAtZero: true }} }}
+  }}
+}});
+
+new Chart(document.getElementById('restrictedDownloadChart'), {{
+  type: 'bar',
+  data: {{
+    labels: stepLabels,
+    datasets: [
+      {{
+        label: 'Restricted chunk download (all replicas)',
+        data: restrictedDownload,
+        backgroundColor: scheduledFlags.map(f => f ? 'rgba(153,102,255,0.7)' : 'rgba(255,99,132,0.9)')
+      }}
+    ]
+  }},
+  options: {{
+    plugins: {{ title: {{ display: true, text: 'Version-Restricted Download per Step (red = scheduling failed)' }}, tooltip: bytesTooltip }},
+    scales: {{ y: bytesScale }}
+  }}
+}});
 </script>
 </body>
 </html>"##,
@@ -368,11 +442,16 @@ fn build_table_rows(
         .enumerate()
         .map(|(i, m)| {
             let dm = &m.data_movement;
+            let r = &m.restricted_movement;
+            let restricted_dl = r.new_chunk_bytes + r.shuffled_bytes + r.increased_replication_bytes;
+            let scheduled = if m.scheduled { "yes" } else { "NO" };
             format!(
-                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
                 m.step,
                 m.new_chunks_in_step,
+                m.new_restricted_in_step,
                 m.total_chunks,
+                m.total_restricted_chunks,
                 replication_labels[i],
                 new_chunk_bytes[i],
                 dm.shuffled_count,
@@ -385,6 +464,9 @@ fn build_table_rows(
                 dm.workers_receiving_new,
                 dm.workers_losing,
                 dm.workers_shuffled,
+                m.eligible_workers,
+                scheduled,
+                ByteSize(restricted_dl),
             )
         })
         .collect::<Vec<_>>()

--- a/tools/reshuffle_sim/src/scheduler.rs
+++ b/tools/reshuffle_sim/src/scheduler.rs
@@ -1,0 +1,121 @@
+//! Runs the network scheduler over the simulation's chunks, applying version
+//! restrictions and turning its panics into recoverable errors.
+
+use std::any::Any;
+use std::collections::HashSet;
+use std::panic::AssertUnwindSafe;
+
+use network_scheduler::{
+    cli::DatasetsConfig,
+    scheduling::{ScheduledChunk, SchedulingConfig, schedule},
+    types::{Assignment, Chunk, ChunkWeight, Worker},
+    weight::prepare_chunks,
+};
+use semver::Version;
+
+use crate::ChunkId;
+
+/// A chunk with its scheduling weight and config-derived minimum worker version,
+/// as produced by [`prepare_chunks`].
+type PreparedChunk = (Chunk, ChunkWeight, Option<Version>);
+
+/// Merges existing and new chunks and runs the scheduler. Chunks in `restricted`
+/// require `new_version`; others keep the config's minimum worker version.
+///
+/// The scheduler panics on infeasible version restrictions, so it runs inside
+/// `catch_unwind`; the returned `Err(reason)` signals the caller to stop.
+pub fn schedule_combined_chunks(
+    existing_chunks: &[Chunk],
+    new_chunks: &[Chunk],
+    workers: &[Worker],
+    datasets_config: &DatasetsConfig,
+    scheduling_config: &SchedulingConfig,
+    restricted: &HashSet<ChunkId>,
+    new_version: &Version,
+) -> (Vec<Chunk>, Result<Assignment, String>) {
+    let prepared = prepare_combined_chunks(existing_chunks, new_chunks, datasets_config);
+
+    let scheduled = to_scheduled_chunks(&prepared, restricted, new_version);
+    let assignment = run_scheduler(&scheduled, workers, scheduling_config);
+    drop(scheduled);
+
+    let chunks = prepared.into_iter().map(|(chunk, _, _)| chunk).collect();
+    (chunks, assignment)
+}
+
+/// Merges existing and new chunks, sorts them by dataset then block, and assigns
+/// weights/versions via the config.
+fn prepare_combined_chunks(
+    existing: &[Chunk],
+    new: &[Chunk],
+    config: &DatasetsConfig,
+) -> Vec<PreparedChunk> {
+    let mut combined: Vec<Chunk> = existing.to_vec();
+    combined.extend_from_slice(new);
+    combined.sort_by(|a, b| {
+        a.dataset
+            .cmp(&b.dataset)
+            .then(a.blocks.start().cmp(b.blocks.start()))
+    });
+    prepare_chunks(combined, config)
+}
+
+/// Builds the scheduler input, overriding the minimum worker version to
+/// `new_version` for restricted chunks.
+fn to_scheduled_chunks<'a>(
+    prepared: &'a [PreparedChunk],
+    restricted: &HashSet<ChunkId>,
+    new_version: &'a Version,
+) -> Vec<ScheduledChunk<'a>> {
+    prepared
+        .iter()
+        .map(|(chunk, weight, config_version)| {
+            let key = (chunk.dataset.clone(), chunk.id.clone());
+            let minimum_worker_version = if restricted.contains(&key) {
+                Some(new_version)
+            } else {
+                config_version.as_ref()
+            };
+            ScheduledChunk {
+                dataset: &chunk.dataset,
+                chunk_id: &chunk.id,
+                size: chunk.size,
+                weight: *weight,
+                minimum_worker_version,
+            }
+        })
+        .collect()
+}
+
+/// Runs the scheduler under `catch_unwind`, returning any panic or error as a
+/// message. The default panic hook is silenced so an expected version-restriction
+/// panic isn't also dumped to stderr.
+fn run_scheduler(
+    scheduled: &[ScheduledChunk],
+    workers: &[Worker],
+    config: &SchedulingConfig,
+) -> Result<Assignment, String> {
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        schedule(scheduled, workers, config.clone())
+    }));
+    std::panic::set_hook(previous_hook);
+
+    match result {
+        Ok(Ok(assignment)) => Ok(assignment),
+        Ok(Err(error)) => Err(format!("scheduling error: {error}")),
+        Err(panic) => Err(panic_message(panic)),
+    }
+}
+
+/// Extracts a human-readable message from a caught panic payload.
+fn panic_message(panic: Box<dyn Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "scheduler panicked".to_string()
+    }
+}

--- a/tools/reshuffle_sim/src/simulation.rs
+++ b/tools/reshuffle_sim/src/simulation.rs
@@ -1,9 +1,8 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
 };
 
-use anyhow::Context;
 use libp2p_identity::PeerId;
 use network_scheduler::{
     scheduling::{ScheduledChunk, SchedulingConfig, schedule},
@@ -11,17 +10,29 @@ use network_scheduler::{
     weight::prepare_chunks,
 };
 use rand::prelude::*;
+use rand::seq::SliceRandom;
+use semver::Version;
 
 use crate::{ChunkOwners, ChunkSizeIndex, baseline::DatasetInfo};
 
 pub struct ReshuffleMetrics {
     pub step: u32,
     pub new_chunks_in_step: u32,
+    /// How many of this step's new chunks are version-restricted.
+    pub new_restricted_in_step: u32,
     pub total_chunks: usize,
+    /// Cumulative count of version-restricted chunks.
+    pub total_restricted_chunks: usize,
     pub replication_by_weight: BTreeMap<u16, u16>,
     pub data_movement: DataMovement,
     pub total_capacity_bytes: u64,
     pub used_capacity_bytes: u64,
+    // --- version-restriction additions ---
+    pub eligible_workers: usize,
+    /// False when scheduling failed (panicked) at this step; the run stops after.
+    pub scheduled: bool,
+    pub failure_reason: Option<String>,
+    pub restricted_movement: DataMovement,
 }
 
 pub struct DataMovement {
@@ -33,6 +44,21 @@ pub struct DataMovement {
     pub workers_receiving_new: usize,
     pub workers_losing: usize,
     pub workers_shuffled: usize,
+}
+
+impl DataMovement {
+    pub fn zero() -> Self {
+        DataMovement {
+            new_chunk_bytes: 0,
+            shuffled_bytes: 0,
+            shuffled_count: 0,
+            increased_replication_bytes: 0,
+            decreased_replication_bytes: 0,
+            workers_receiving_new: 0,
+            workers_losing: 0,
+            workers_shuffled: 0,
+        }
+    }
 }
 
 // --- Chunk generation ---
@@ -61,11 +87,21 @@ fn sample_dataset_index(cumulative: &[(usize, f64)], rng: &mut impl Rng) -> usiz
 /// Datasets are sampled proportionally to their existing chunk counts —
 /// a dataset with 60% of total chunks receives ~60% of new chunks.
 /// Each generated chunk extends the dataset's block range using its average block span and size.
+///
+/// Additionally tags `round(restricted_fraction * count)` of the generated
+/// chunks (selected uniformly at random) as "restricted", returning their ids
+/// alongside the chunks. Restricted chunks are later forced to require the new
+/// worker version.
+///
+/// `chunk_size` overrides the size of every generated chunk; when `None` each
+/// chunk uses its dataset's average chunk size.
 pub fn generate_new_chunks(
     datasets: &mut Vec<DatasetInfo>,
     chunks_to_generate: u32,
+    restricted_fraction: f64,
+    chunk_size: Option<u32>,
     rng: &mut impl Rng,
-) -> Vec<Chunk> {
+) -> (Vec<Chunk>, Vec<crate::ChunkId>) {
     let cumulative_distribution = build_cumulative_distribution(datasets);
     let mut new_chunks = Vec::with_capacity(chunks_to_generate as usize);
 
@@ -83,7 +119,7 @@ pub fn generate_new_chunks(
         new_chunks.push(Chunk {
             dataset: dataset.dataset_id.clone(),
             id: Arc::new(chunk_id),
-            size: dataset.avg_chunk_size,
+            size: chunk_size.unwrap_or(dataset.avg_chunk_size),
             blocks: first_block..=last_block,
             files: Arc::new(vec![]),
             summary: None,
@@ -93,22 +129,37 @@ pub fn generate_new_chunks(
         dataset.chunk_count += 1;
     }
 
-    new_chunks
+    let restricted_count =
+        ((restricted_fraction * new_chunks.len() as f64).round() as usize).min(new_chunks.len());
+    let mut indices: Vec<usize> = (0..new_chunks.len()).collect();
+    indices.shuffle(rng);
+    let restricted: Vec<crate::ChunkId> = indices[..restricted_count]
+        .iter()
+        .map(|&i| (new_chunks[i].dataset.clone(), new_chunks[i].id.clone()))
+        .collect();
+
+    (new_chunks, restricted)
 }
 
 // --- Scheduling ---
 
-/// Merges existing and new chunks, assigns weights via the config's dataset segments,
-/// and runs the full scheduling algorithm. Chunks are sorted by dataset then block number
-/// so that `prepare_chunks` can resolve relative segment boundaries (e.g. `from: -10000000`)
-/// against the updated last_block of each dataset.
+/// Merges existing and new chunks and runs the scheduler. Chunks in `restricted`
+/// require `new_version`; others keep the config's minimum_worker_version.
+///
+/// The scheduler panics on infeasible version restrictions, so it's wrapped in
+/// `catch_unwind`; the inner `Err(reason)` signals the caller to stop.
 pub fn schedule_combined_chunks(
     existing_chunks: &[Chunk],
     new_chunks: &[Chunk],
     workers: &[Worker],
     datasets_config: &network_scheduler::cli::DatasetsConfig,
     scheduling_config: &SchedulingConfig,
-) -> anyhow::Result<(Vec<Chunk>, network_scheduler::types::Assignment)> {
+    restricted: &HashSet<crate::ChunkId>,
+    new_version: &Version,
+) -> (
+    Vec<Chunk>,
+    Result<network_scheduler::types::Assignment, String>,
+) {
     let mut combined: Vec<Chunk> = existing_chunks.to_vec();
     combined.extend_from_slice(new_chunks);
     combined.sort_by(|a, b| {
@@ -121,22 +172,51 @@ pub fn schedule_combined_chunks(
 
     let scheduled_chunks: Vec<ScheduledChunk> = prepared
         .iter()
-        .map(|(chunk, weight, mwv)| ScheduledChunk {
-            dataset: &chunk.dataset,
-            chunk_id: &chunk.id,
-            size: chunk.size,
-            weight: *weight,
-            minimum_worker_version: mwv.as_ref(),
+        .map(|(chunk, weight, mwv)| {
+            let key = (chunk.dataset.clone(), chunk.id.clone());
+            let minimum_worker_version = if restricted.contains(&key) {
+                Some(new_version)
+            } else {
+                mwv.as_ref()
+            };
+            ScheduledChunk {
+                dataset: &chunk.dataset,
+                chunk_id: &chunk.id,
+                size: chunk.size,
+                weight: *weight,
+                minimum_worker_version,
+            }
         })
         .collect();
 
-    let assignment = schedule(&scheduled_chunks, workers, scheduling_config.clone())
-        .context("Scheduling failed")?;
+    // Silence the default panic hook so the captured panic isn't also dumped to stderr.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        schedule(&scheduled_chunks, workers, scheduling_config.clone())
+    }));
+    std::panic::set_hook(prev_hook);
+    let assignment = match result {
+        Ok(Ok(assignment)) => Ok(assignment),
+        Ok(Err(err)) => Err(format!("scheduling error: {err}")),
+        Err(panic) => Err(panic_message(panic)),
+    };
     drop(scheduled_chunks);
 
     let filtered_chunks: Vec<Chunk> = prepared.into_iter().map(|(c, _, _)| c).collect();
 
-    Ok((filtered_chunks, assignment))
+    (filtered_chunks, assignment)
+}
+
+/// Extracts a human-readable message from a caught panic payload.
+fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "scheduler panicked".to_string()
+    }
 }
 
 // --- Assignment diffing ---
@@ -234,6 +314,15 @@ fn compute_data_movement(
     result
 }
 
+/// Keeps only the owner entries whose chunk id is in `restricted`.
+fn filter_owners(owners: &ChunkOwners, restricted: &HashSet<crate::ChunkId>) -> ChunkOwners {
+    owners
+        .iter()
+        .filter(|(id, _)| restricted.contains(*id))
+        .map(|(id, set)| (id.clone(), set.clone()))
+        .collect()
+}
+
 /// Computes all reshuffle metrics for a single simulation step.
 /// All comparisons are against the previous step (incremental).
 /// Returns the current chunk owners for use as the next step's previous.
@@ -243,8 +332,11 @@ pub fn measure_reshuffle(
     assignment: &network_scheduler::types::Assignment,
     step: u32,
     new_chunks_in_step: u32,
+    new_restricted_in_step: u32,
     num_workers: usize,
     worker_capacity: u64,
+    restricted: &HashSet<crate::ChunkId>,
+    eligible_workers: usize,
 ) -> (ReshuffleMetrics, ChunkOwners) {
     let current_chunk_owners = chunk_owners_from_assignment(chunks, assignment);
 
@@ -255,6 +347,12 @@ pub fn measure_reshuffle(
 
     let data_movement =
         compute_data_movement(previous_chunk_owners, &current_chunk_owners, &chunk_sizes);
+
+    let restricted_movement = compute_data_movement(
+        &filter_owners(previous_chunk_owners, restricted),
+        &filter_owners(&current_chunk_owners, restricted),
+        &chunk_sizes,
+    );
 
     let used_capacity_bytes: u64 = assignment
         .worker_chunks
@@ -268,12 +366,88 @@ pub fn measure_reshuffle(
     let metrics = ReshuffleMetrics {
         step,
         new_chunks_in_step,
+        new_restricted_in_step,
         total_chunks: chunks.len(),
+        total_restricted_chunks: restricted.len(),
         replication_by_weight: assignment.replication_by_weight.clone(),
         data_movement,
         total_capacity_bytes,
         used_capacity_bytes,
+        eligible_workers,
+        scheduled: true,
+        failure_reason: None,
+        restricted_movement,
     };
 
     (metrics, current_chunk_owners)
+}
+
+/// Builds a metrics record for the step at which scheduling failed. Movement is
+/// zero; the run stops after this step.
+pub fn failed_step_metrics(
+    step: u32,
+    new_chunks_in_step: u32,
+    new_restricted_in_step: u32,
+    total_chunks: usize,
+    total_restricted_chunks: usize,
+    num_workers: usize,
+    worker_capacity: u64,
+    eligible_workers: usize,
+    reason: String,
+) -> ReshuffleMetrics {
+    ReshuffleMetrics {
+        step,
+        new_chunks_in_step,
+        new_restricted_in_step,
+        total_chunks,
+        total_restricted_chunks,
+        replication_by_weight: BTreeMap::new(),
+        data_movement: DataMovement::zero(),
+        total_capacity_bytes: num_workers as u64 * worker_capacity,
+        used_capacity_bytes: 0,
+        eligible_workers,
+        scheduled: false,
+        failure_reason: Some(reason),
+        restricted_movement: DataMovement::zero(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::baseline::DatasetInfo;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    fn dataset(id: &str, count: u32) -> DatasetInfo {
+        DatasetInfo {
+            dataset_id: Arc::new(id.to_string()),
+            chunk_count: count,
+            last_block: 1000,
+            avg_block_span: 100,
+            avg_chunk_size: 1000,
+        }
+    }
+
+    #[test]
+    fn generate_tags_restricted_fraction_of_chunks() {
+        let mut datasets = vec![dataset("ds", 100)];
+        let mut rng = StdRng::seed_from_u64(42);
+        let (chunks, restricted) = generate_new_chunks(&mut datasets, 100, 0.25, None, &mut rng);
+        assert_eq!(chunks.len(), 100);
+        assert_eq!(restricted.len(), 25);
+        let ids: std::collections::HashSet<_> = chunks
+            .iter()
+            .map(|c| (c.dataset.clone(), c.id.clone()))
+            .collect();
+        assert!(restricted.iter().all(|r| ids.contains(r)));
+    }
+
+    #[test]
+    fn generate_with_zero_fraction_tags_nothing() {
+        let mut datasets = vec![dataset("ds", 10)];
+        let mut rng = StdRng::seed_from_u64(1);
+        let (chunks, restricted) = generate_new_chunks(&mut datasets, 10, 0.0, None, &mut rng);
+        assert_eq!(chunks.len(), 10);
+        assert!(restricted.is_empty());
+    }
 }

--- a/tools/reshuffle_sim/src/simulation.rs
+++ b/tools/reshuffle_sim/src/simulation.rs
@@ -1,453 +1,215 @@
-use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
-    sync::Arc,
-};
+//! Drives the simulation: advances chunk ingestion and worker upgrades step by
+//! step, schedules each step, and collects reshuffle metrics.
 
-use libp2p_identity::PeerId;
+use std::collections::HashSet;
+
 use network_scheduler::{
-    scheduling::{ScheduledChunk, SchedulingConfig, schedule},
+    cli::DatasetsConfig,
+    scheduling::SchedulingConfig,
     types::{Chunk, Worker},
-    weight::prepare_chunks,
 };
-use rand::prelude::*;
-use rand::seq::SliceRandom;
+use rand::rngs::StdRng;
 use semver::Version;
 
-use crate::{ChunkOwners, ChunkSizeIndex, baseline::DatasetInfo};
+use crate::baseline::{Baseline, DatasetInfo};
+use crate::metrics::{ReshuffleMetrics, StepStats};
+use crate::rate::ChunkRate;
+use crate::upgrade::{self, UpgradeSchedule, WorkerVersionState};
+use crate::{ChunkId, ChunkOwners, chunks, metrics, scheduler};
 
-pub struct ReshuffleMetrics {
-    pub step: u32,
-    pub new_chunks_in_step: u32,
-    /// How many of this step's new chunks are version-restricted.
-    pub new_restricted_in_step: u32,
-    pub total_chunks: usize,
-    /// Cumulative count of version-restricted chunks.
-    pub total_restricted_chunks: usize,
-    pub replication_by_weight: BTreeMap<u16, u16>,
-    pub data_movement: DataMovement,
-    pub total_capacity_bytes: u64,
-    pub used_capacity_bytes: u64,
-    // --- version-restriction additions ---
-    pub eligible_workers: usize,
-    /// False when scheduling failed (panicked) at this step; the run stops after.
-    pub scheduled: bool,
-    pub failure_reason: Option<String>,
-    pub restricted_movement: DataMovement,
+/// CLI-derived knobs controlling a run.
+pub struct SimulationParams {
+    pub steps: u32,
+    pub chunk_rate: ChunkRate,
+    pub chunk_size: Option<u32>,
+    pub restricted_fraction: f64,
+    pub initial_new_fraction: f64,
+    pub upgrade_schedule: UpgradeSchedule,
+    pub lift_restriction_at_step: Option<u32>,
 }
 
-pub struct DataMovement {
-    pub new_chunk_bytes: u64,
-    pub shuffled_bytes: u64,
-    pub shuffled_count: u32,
-    pub increased_replication_bytes: u64,
-    pub decreased_replication_bytes: u64,
-    pub workers_receiving_new: usize,
-    pub workers_losing: usize,
-    pub workers_shuffled: usize,
+/// End-of-run totals.
+pub struct Summary {
+    pub total_chunks_added: usize,
+    pub restricted_chunks: usize,
+    pub upgraded_workers: usize,
+    pub total_workers: usize,
+    pub new_worker_version: Version,
 }
 
-impl DataMovement {
-    pub fn zero() -> Self {
-        DataMovement {
-            new_chunk_bytes: 0,
-            shuffled_bytes: 0,
-            shuffled_count: 0,
-            increased_replication_bytes: 0,
-            decreased_replication_bytes: 0,
-            workers_receiving_new: 0,
-            workers_losing: 0,
-            workers_shuffled: 0,
-        }
-    }
+pub struct Simulation {
+    params: SimulationParams,
+    datasets_config: DatasetsConfig,
+    scheduling_config: SchedulingConfig,
+    new_worker_version: Version,
+
+    datasets: Vec<DatasetInfo>,
+    workers: Vec<Worker>,
+    baseline_chunks: Vec<Chunk>,
+    accumulated_new_chunks: Vec<Chunk>,
+    restricted_ids: HashSet<ChunkId>,
+    previous_owners: ChunkOwners,
+    version_state: WorkerVersionState,
+    rng: StdRng,
 }
 
-// --- Chunk generation ---
-
-fn build_cumulative_distribution(datasets: &[DatasetInfo]) -> Vec<(usize, f64)> {
-    let total: f64 = datasets.iter().map(|d| d.chunk_count as f64).sum();
-    let mut cumulative = Vec::with_capacity(datasets.len());
-    let mut acc = 0.0;
-    for (i, ds) in datasets.iter().enumerate() {
-        acc += ds.chunk_count as f64 / total;
-        cumulative.push((i, acc));
-    }
-    cumulative
-}
-
-fn sample_dataset_index(cumulative: &[(usize, f64)], rng: &mut impl Rng) -> usize {
-    let r: f64 = rng.random();
-    cumulative
-        .iter()
-        .find(|(_, threshold)| r <= *threshold)
-        .map(|(i, _)| *i)
-        .unwrap_or(cumulative.len() - 1)
-}
-
-/// Creates synthetic chunks at the head (latest blocks) of each dataset.
-/// Datasets are sampled proportionally to their existing chunk counts —
-/// a dataset with 60% of total chunks receives ~60% of new chunks.
-/// Each generated chunk extends the dataset's block range using its average block span and size.
-///
-/// Additionally tags `round(restricted_fraction * count)` of the generated
-/// chunks (selected uniformly at random) as "restricted", returning their ids
-/// alongside the chunks. Restricted chunks are later forced to require the new
-/// worker version.
-///
-/// `chunk_size` overrides the size of every generated chunk; when `None` each
-/// chunk uses its dataset's average chunk size.
-pub fn generate_new_chunks(
-    datasets: &mut Vec<DatasetInfo>,
-    chunks_to_generate: u32,
-    restricted_fraction: f64,
-    chunk_size: Option<u32>,
-    rng: &mut impl Rng,
-) -> (Vec<Chunk>, Vec<crate::ChunkId>) {
-    let cumulative_distribution = build_cumulative_distribution(datasets);
-    let mut new_chunks = Vec::with_capacity(chunks_to_generate as usize);
-
-    for _ in 0..chunks_to_generate {
-        let dataset_index = sample_dataset_index(&cumulative_distribution, rng);
-        let dataset = &mut datasets[dataset_index];
-
-        let first_block = dataset.last_block + 1;
-        let last_block = first_block + dataset.avg_block_span - 1;
-        let chunk_id = format!(
-            "{:010}/{:010}-{:010}-{:08x}",
-            first_block, first_block, last_block, first_block as u32
+impl Simulation {
+    pub fn new(
+        baseline: Baseline,
+        datasets_config: DatasetsConfig,
+        scheduling_config: SchedulingConfig,
+        params: SimulationParams,
+        mut rng: StdRng,
+    ) -> Self {
+        let new_worker_version = upgrade::new_version();
+        let version_state = WorkerVersionState::new(
+            baseline.workers.len(),
+            params.initial_new_fraction,
+            &mut rng,
         );
 
-        new_chunks.push(Chunk {
-            dataset: dataset.dataset_id.clone(),
-            id: Arc::new(chunk_id),
-            size: chunk_size.unwrap_or(dataset.avg_chunk_size),
-            blocks: first_block..=last_block,
-            files: Arc::new(vec![]),
-            summary: None,
-        });
+        let mut workers = baseline.workers;
+        version_state.apply(&mut workers, &new_worker_version);
 
-        dataset.last_block = last_block;
-        dataset.chunk_count += 1;
-    }
-
-    let restricted_count =
-        ((restricted_fraction * new_chunks.len() as f64).round() as usize).min(new_chunks.len());
-    let mut indices: Vec<usize> = (0..new_chunks.len()).collect();
-    indices.shuffle(rng);
-    let restricted: Vec<crate::ChunkId> = indices[..restricted_count]
-        .iter()
-        .map(|&i| (new_chunks[i].dataset.clone(), new_chunks[i].id.clone()))
-        .collect();
-
-    (new_chunks, restricted)
-}
-
-// --- Scheduling ---
-
-/// Merges existing and new chunks and runs the scheduler. Chunks in `restricted`
-/// require `new_version`; others keep the config's minimum_worker_version.
-///
-/// The scheduler panics on infeasible version restrictions, so it's wrapped in
-/// `catch_unwind`; the inner `Err(reason)` signals the caller to stop.
-pub fn schedule_combined_chunks(
-    existing_chunks: &[Chunk],
-    new_chunks: &[Chunk],
-    workers: &[Worker],
-    datasets_config: &network_scheduler::cli::DatasetsConfig,
-    scheduling_config: &SchedulingConfig,
-    restricted: &HashSet<crate::ChunkId>,
-    new_version: &Version,
-) -> (
-    Vec<Chunk>,
-    Result<network_scheduler::types::Assignment, String>,
-) {
-    let mut combined: Vec<Chunk> = existing_chunks.to_vec();
-    combined.extend_from_slice(new_chunks);
-    combined.sort_by(|a, b| {
-        a.dataset
-            .cmp(&b.dataset)
-            .then(a.blocks.start().cmp(b.blocks.start()))
-    });
-
-    let prepared = prepare_chunks(combined, datasets_config);
-
-    let scheduled_chunks: Vec<ScheduledChunk> = prepared
-        .iter()
-        .map(|(chunk, weight, mwv)| {
-            let key = (chunk.dataset.clone(), chunk.id.clone());
-            let minimum_worker_version = if restricted.contains(&key) {
-                Some(new_version)
-            } else {
-                mwv.as_ref()
-            };
-            ScheduledChunk {
-                dataset: &chunk.dataset,
-                chunk_id: &chunk.id,
-                size: chunk.size,
-                weight: *weight,
-                minimum_worker_version,
-            }
-        })
-        .collect();
-
-    // Silence the default panic hook so the captured panic isn't also dumped to stderr.
-    let prev_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|_| {}));
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        schedule(&scheduled_chunks, workers, scheduling_config.clone())
-    }));
-    std::panic::set_hook(prev_hook);
-    let assignment = match result {
-        Ok(Ok(assignment)) => Ok(assignment),
-        Ok(Err(err)) => Err(format!("scheduling error: {err}")),
-        Err(panic) => Err(panic_message(panic)),
-    };
-    drop(scheduled_chunks);
-
-    let filtered_chunks: Vec<Chunk> = prepared.into_iter().map(|(c, _, _)| c).collect();
-
-    (filtered_chunks, assignment)
-}
-
-/// Extracts a human-readable message from a caught panic payload.
-fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = panic.downcast_ref::<&str>() {
-        (*s).to_string()
-    } else if let Some(s) = panic.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "scheduler panicked".to_string()
-    }
-}
-
-// --- Assignment diffing ---
-
-fn chunk_owners_from_assignment(
-    chunks: &[Chunk],
-    assignment: &network_scheduler::types::Assignment,
-) -> ChunkOwners {
-    let mut owners: ChunkOwners = BTreeMap::new();
-    for (worker, indexes) in &assignment.worker_chunks {
-        for &chunk_index in indexes {
-            let chunk = &chunks[chunk_index as usize];
-            owners
-                .entry((chunk.dataset.clone(), chunk.id.clone()))
-                .or_default()
-                .insert(*worker);
+        Self {
+            params,
+            datasets_config,
+            scheduling_config,
+            new_worker_version,
+            datasets: baseline.datasets,
+            workers,
+            baseline_chunks: baseline.chunks,
+            accumulated_new_chunks: Vec::new(),
+            restricted_ids: HashSet::new(),
+            previous_owners: baseline.chunk_owners,
+            version_state,
+            rng,
         }
     }
-    owners
-}
 
-/// Classifies data movement between two assignments by cause.
-/// For each chunk in the current assignment:
-/// - New chunk (not in previous): all replicas count as new_chunk_bytes.
-/// - Existing chunk: workers gained/lost are classified as shuffle (1:1 swap)
-///   or replication change (net gain/loss of replicas).
-fn compute_data_movement(
-    previous: &ChunkOwners,
-    current: &ChunkOwners,
-    chunk_sizes: &ChunkSizeIndex,
-) -> DataMovement {
-    let mut result = DataMovement {
-        new_chunk_bytes: 0,
-        shuffled_bytes: 0,
-        shuffled_count: 0,
-        increased_replication_bytes: 0,
-        decreased_replication_bytes: 0,
-        workers_receiving_new: 0,
-        workers_losing: 0,
-        workers_shuffled: 0,
-    };
+    /// The worker fleet, reflecting the current version distribution.
+    pub fn workers(&self) -> &[Worker] {
+        &self.workers
+    }
 
-    let mut workers_receiving_new: BTreeSet<PeerId> = BTreeSet::new();
-    let mut workers_losing: BTreeSet<PeerId> = BTreeSet::new();
-    let mut workers_shuffled: BTreeSet<PeerId> = BTreeSet::new();
-
-    for (chunk_id, current_workers) in current {
-        let size = *chunk_sizes.get(chunk_id).unwrap_or(&0) as u64;
-
-        if let Some(previous_workers) = previous.get(chunk_id) {
-            let gained: usize = current_workers.difference(previous_workers).count();
-            let lost: usize = previous_workers.difference(current_workers).count();
-
-            let shuffled = gained.min(lost);
-            let replication_increase = gained.saturating_sub(lost);
-            let replication_decrease = lost.saturating_sub(gained);
-
-            if shuffled > 0 {
-                result.shuffled_count += 1;
-                result.shuffled_bytes += size * shuffled as u64;
+    /// Runs every step, invoking `on_step` with the metrics collected so far
+    /// after each one. Stops early if a step fails to schedule. Returns the
+    /// full metrics series.
+    pub fn run(&mut self, mut on_step: impl FnMut(&[ReshuffleMetrics])) -> Vec<ReshuffleMetrics> {
+        let mut all_metrics = Vec::new();
+        for step in 1..=self.params.steps {
+            let metrics = self.run_step(step);
+            let stop = !metrics.scheduled;
+            all_metrics.push(metrics);
+            on_step(&all_metrics);
+            if stop {
+                break;
             }
-            result.increased_replication_bytes += size * replication_increase as u64;
-            result.decreased_replication_bytes += size * replication_decrease as u64;
+        }
+        all_metrics
+    }
 
-            if gained > 0 {
-                for w in current_workers.difference(previous_workers) {
-                    workers_shuffled.insert(*w);
-                }
+    pub fn summary(&self) -> Summary {
+        Summary {
+            total_chunks_added: self.accumulated_new_chunks.len(),
+            restricted_chunks: self.restricted_ids.len(),
+            upgraded_workers: self.version_state.eligible_count(),
+            total_workers: self.workers.len(),
+            new_worker_version: self.new_worker_version.clone(),
+        }
+    }
+
+    fn run_step(&mut self, step: u32) -> ReshuffleMetrics {
+        self.lift_restrictions_if_due(step);
+
+        let restricted_fraction = self.restricted_fraction(step);
+        let chunks_to_generate = self.params.chunk_rate.count_at(step, self.params.steps);
+        let (new_chunks, restricted) = chunks::generate_new_chunks(
+            &mut self.datasets,
+            chunks_to_generate,
+            restricted_fraction,
+            self.params.chunk_size,
+            &mut self.rng,
+        );
+        let new_chunks_count = new_chunks.len() as u32;
+        let new_restricted_count = restricted.len() as u32;
+        self.accumulated_new_chunks.extend(new_chunks);
+        self.restricted_ids.extend(restricted);
+
+        self.version_state
+            .advance(&self.params.upgrade_schedule, step);
+        self.version_state
+            .apply(&mut self.workers, &self.new_worker_version);
+
+        let stats = StepStats {
+            step,
+            new_chunks: new_chunks_count,
+            new_restricted: new_restricted_count,
+            eligible_workers: self.version_state.eligible_count(),
+        };
+
+        let (chunks, schedule_result) = scheduler::schedule_combined_chunks(
+            &self.baseline_chunks,
+            &self.accumulated_new_chunks,
+            &self.workers,
+            &self.datasets_config,
+            &self.scheduling_config,
+            &self.restricted_ids,
+            &self.new_worker_version,
+        );
+
+        let total_capacity = self.total_capacity_bytes();
+        match schedule_result {
+            Ok(assignment) => {
+                let (metrics, owners) = metrics::measure_reshuffle(
+                    &self.previous_owners,
+                    &chunks,
+                    &assignment,
+                    &self.restricted_ids,
+                    stats,
+                    total_capacity,
+                );
+                self.previous_owners = owners;
+                metrics
             }
-            for w in previous_workers.difference(current_workers) {
-                workers_losing.insert(*w);
+            Err(reason) => {
+                eprintln!("Scheduling failed at step {step}: {reason}. Stopping simulation.");
+                metrics::failed_step_metrics(
+                    stats,
+                    chunks.len(),
+                    self.restricted_ids.len(),
+                    total_capacity,
+                    reason,
+                )
             }
+        }
+    }
+
+    /// At the lift step, remove the previously-restricted chunks; afterwards no
+    /// new chunks are tagged (see [`Self::restricted_fraction`]).
+    fn lift_restrictions_if_due(&mut self, step: u32) {
+        if self.params.lift_restriction_at_step != Some(step) {
+            return;
+        }
+        let restricted = &self.restricted_ids;
+        self.accumulated_new_chunks
+            .retain(|c| !restricted.contains(&(c.dataset.clone(), c.id.clone())));
+        self.restricted_ids.clear();
+    }
+
+    fn restricted_fraction(&self, step: u32) -> f64 {
+        let lifted = self
+            .params
+            .lift_restriction_at_step
+            .is_some_and(|n| step >= n);
+        if lifted {
+            0.0
         } else {
-            result.new_chunk_bytes += size * current_workers.len() as u64;
-            for w in current_workers {
-                workers_receiving_new.insert(*w);
-            }
+            self.params.restricted_fraction
         }
     }
 
-    for (chunk_id, previous_workers) in previous {
-        if !current.contains_key(chunk_id) {
-            let size = *chunk_sizes.get(chunk_id).unwrap_or(&0) as u64;
-            result.decreased_replication_bytes += size * previous_workers.len() as u64;
-            for w in previous_workers {
-                workers_losing.insert(*w);
-            }
-        }
-    }
-
-    result.workers_receiving_new = workers_receiving_new.len();
-    result.workers_losing = workers_losing.len();
-    result.workers_shuffled = workers_shuffled.len();
-
-    result
-}
-
-/// Keeps only the owner entries whose chunk id is in `restricted`.
-fn filter_owners(owners: &ChunkOwners, restricted: &HashSet<crate::ChunkId>) -> ChunkOwners {
-    owners
-        .iter()
-        .filter(|(id, _)| restricted.contains(*id))
-        .map(|(id, set)| (id.clone(), set.clone()))
-        .collect()
-}
-
-/// Computes all reshuffle metrics for a single simulation step.
-/// All comparisons are against the previous step (incremental).
-/// Returns the current chunk owners for use as the next step's previous.
-pub fn measure_reshuffle(
-    previous_chunk_owners: &ChunkOwners,
-    chunks: &[Chunk],
-    assignment: &network_scheduler::types::Assignment,
-    step: u32,
-    new_chunks_in_step: u32,
-    new_restricted_in_step: u32,
-    num_workers: usize,
-    worker_capacity: u64,
-    restricted: &HashSet<crate::ChunkId>,
-    eligible_workers: usize,
-) -> (ReshuffleMetrics, ChunkOwners) {
-    let current_chunk_owners = chunk_owners_from_assignment(chunks, assignment);
-
-    let chunk_sizes: ChunkSizeIndex = chunks
-        .iter()
-        .map(|c| ((c.dataset.clone(), c.id.clone()), c.size))
-        .collect();
-
-    let data_movement =
-        compute_data_movement(previous_chunk_owners, &current_chunk_owners, &chunk_sizes);
-
-    let restricted_movement = compute_data_movement(
-        &filter_owners(previous_chunk_owners, restricted),
-        &filter_owners(&current_chunk_owners, restricted),
-        &chunk_sizes,
-    );
-
-    let used_capacity_bytes: u64 = assignment
-        .worker_chunks
-        .values()
-        .flat_map(|indexes| indexes.iter())
-        .map(|&i| chunks[i as usize].size as u64)
-        .sum();
-
-    let total_capacity_bytes = num_workers as u64 * worker_capacity;
-
-    let metrics = ReshuffleMetrics {
-        step,
-        new_chunks_in_step,
-        new_restricted_in_step,
-        total_chunks: chunks.len(),
-        total_restricted_chunks: restricted.len(),
-        replication_by_weight: assignment.replication_by_weight.clone(),
-        data_movement,
-        total_capacity_bytes,
-        used_capacity_bytes,
-        eligible_workers,
-        scheduled: true,
-        failure_reason: None,
-        restricted_movement,
-    };
-
-    (metrics, current_chunk_owners)
-}
-
-/// Builds a metrics record for the step at which scheduling failed. Movement is
-/// zero; the run stops after this step.
-pub fn failed_step_metrics(
-    step: u32,
-    new_chunks_in_step: u32,
-    new_restricted_in_step: u32,
-    total_chunks: usize,
-    total_restricted_chunks: usize,
-    num_workers: usize,
-    worker_capacity: u64,
-    eligible_workers: usize,
-    reason: String,
-) -> ReshuffleMetrics {
-    ReshuffleMetrics {
-        step,
-        new_chunks_in_step,
-        new_restricted_in_step,
-        total_chunks,
-        total_restricted_chunks,
-        replication_by_weight: BTreeMap::new(),
-        data_movement: DataMovement::zero(),
-        total_capacity_bytes: num_workers as u64 * worker_capacity,
-        used_capacity_bytes: 0,
-        eligible_workers,
-        scheduled: false,
-        failure_reason: Some(reason),
-        restricted_movement: DataMovement::zero(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::baseline::DatasetInfo;
-    use rand::{SeedableRng, rngs::StdRng};
-
-    fn dataset(id: &str, count: u32) -> DatasetInfo {
-        DatasetInfo {
-            dataset_id: Arc::new(id.to_string()),
-            chunk_count: count,
-            last_block: 1000,
-            avg_block_span: 100,
-            avg_chunk_size: 1000,
-        }
-    }
-
-    #[test]
-    fn generate_tags_restricted_fraction_of_chunks() {
-        let mut datasets = vec![dataset("ds", 100)];
-        let mut rng = StdRng::seed_from_u64(42);
-        let (chunks, restricted) = generate_new_chunks(&mut datasets, 100, 0.25, None, &mut rng);
-        assert_eq!(chunks.len(), 100);
-        assert_eq!(restricted.len(), 25);
-        let ids: std::collections::HashSet<_> = chunks
-            .iter()
-            .map(|c| (c.dataset.clone(), c.id.clone()))
-            .collect();
-        assert!(restricted.iter().all(|r| ids.contains(r)));
-    }
-
-    #[test]
-    fn generate_with_zero_fraction_tags_nothing() {
-        let mut datasets = vec![dataset("ds", 10)];
-        let mut rng = StdRng::seed_from_u64(1);
-        let (chunks, restricted) = generate_new_chunks(&mut datasets, 10, 0.0, None, &mut rng);
-        assert_eq!(chunks.len(), 10);
-        assert!(restricted.is_empty());
+    fn total_capacity_bytes(&self) -> u64 {
+        self.workers.len() as u64 * self.scheduling_config.worker_capacity
     }
 }

--- a/tools/reshuffle_sim/src/upgrade.rs
+++ b/tools/reshuffle_sim/src/upgrade.rs
@@ -1,0 +1,254 @@
+use anyhow::Context;
+use network_scheduler::types::Worker;
+use rand::seq::SliceRandom;
+use semver::Version;
+
+/// Target version workers upgrade to, and which restricted chunks require.
+/// Chosen well above real worker versions so only upgraded workers serve
+/// restricted data. Workers keep their original (loaded) version until upgraded.
+pub fn new_version() -> Version {
+    Version::new(10, 0, 0)
+}
+
+/// Ascending `(step, target_fraction)` breakpoints. The fraction is held
+/// constant (piecewise-constant) from each breakpoint's step until the next.
+#[derive(Debug, Clone, Default)]
+pub struct UpgradeSchedule {
+    breakpoints: Vec<(u32, f64)>,
+}
+
+impl UpgradeSchedule {
+    /// Parses `"1:0,5:0.25,50:0.5"`. An empty string yields no breakpoints.
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        let mut breakpoints: Vec<(u32, f64)> = Vec::new();
+        for entry in s.split(',').map(str::trim).filter(|e| !e.is_empty()) {
+            let (step_str, frac_str) = entry.split_once(':').with_context(|| {
+                format!("Invalid schedule entry '{entry}', expected 'step:fraction'")
+            })?;
+            let step: u32 = step_str
+                .trim()
+                .parse()
+                .with_context(|| format!("Invalid step '{step_str}'"))?;
+            let frac: f64 = frac_str
+                .trim()
+                .parse()
+                .with_context(|| format!("Invalid fraction '{frac_str}'"))?;
+            anyhow::ensure!(
+                frac.is_finite(),
+                "Fraction '{frac_str}' is not a finite number"
+            );
+            anyhow::ensure!(
+                (0.0..=1.0).contains(&frac),
+                "Fraction {frac} out of range [0, 1]"
+            );
+            if let Some(&(last_step, _)) = breakpoints.last() {
+                anyhow::ensure!(
+                    step > last_step,
+                    "Schedule steps must be strictly ascending (got {step} after {last_step})"
+                );
+            }
+            breakpoints.push((step, frac));
+        }
+        Ok(Self { breakpoints })
+    }
+
+    /// Target fraction of workers on the new version at `step`: the fraction of
+    /// the latest breakpoint whose step is `<= step`, or 0.0 before the first.
+    pub fn target_fraction(&self, step: u32) -> f64 {
+        let mut frac = 0.0;
+        for &(bp_step, bp_frac) in &self.breakpoints {
+            if step >= bp_step {
+                frac = bp_frac;
+            } else {
+                break;
+            }
+        }
+        frac
+    }
+}
+
+/// Tracks which workers are on the new version. Upgrades are monotonic: a
+/// worker that reaches the new version never reverts. Workers are upgraded in a
+/// fixed, seed-determined shuffle order.
+pub struct WorkerVersionState {
+    order: Vec<usize>,
+    n: usize,
+    upgraded: usize,
+}
+
+fn frac_to_count(fraction: f64, n: usize) -> usize {
+    ((fraction * n as f64).round() as usize).min(n)
+}
+
+impl WorkerVersionState {
+    pub fn new(n: usize, initial_new_fraction: f64, rng: &mut impl rand::Rng) -> Self {
+        debug_assert!(
+            (0.0..=1.0).contains(&initial_new_fraction),
+            "initial_new_fraction {initial_new_fraction} out of range [0, 1]"
+        );
+        let mut order: Vec<usize> = (0..n).collect();
+        order.shuffle(rng);
+        Self {
+            order,
+            n,
+            upgraded: frac_to_count(initial_new_fraction, n),
+        }
+    }
+
+    /// Raises the upgraded count to the schedule's target for `step`, never
+    /// decreasing it (monotonic high-water mark).
+    pub fn advance(&mut self, schedule: &UpgradeSchedule, step: u32) {
+        let target = frac_to_count(schedule.target_fraction(step), self.n);
+        self.upgraded = self.upgraded.max(target);
+    }
+
+    /// Number of workers currently on the new version.
+    pub fn eligible_count(&self) -> usize {
+        self.upgraded
+    }
+
+    /// Upgrades the chosen subset of workers to `new`, leaving every other
+    /// worker on its original (loaded) version. Idempotent across steps because
+    /// the upgraded set only grows.
+    pub fn apply(&self, workers: &mut [Worker], new: &Version) {
+        debug_assert_eq!(
+            workers.len(),
+            self.n,
+            "apply: workers slice length {} != state n {}",
+            workers.len(),
+            self.n
+        );
+        for &i in &self.order[..self.upgraded] {
+            workers[i].version = Some(new.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p_identity::PeerId;
+    use network_scheduler::types::{Worker, WorkerStatus};
+    use rand::{SeedableRng, rngs::StdRng};
+
+    fn make_test_workers(n: usize) -> Vec<Worker> {
+        (0..n)
+            .map(|_| Worker {
+                id: PeerId::random(),
+                status: WorkerStatus::Online,
+                version: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn initial_fraction_sets_starting_upgraded_count() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let st = WorkerVersionState::new(100, 0.2, &mut rng);
+        assert_eq!(st.eligible_count(), 20);
+    }
+
+    #[test]
+    fn advance_is_monotonic_and_respects_initial_floor() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let mut st = WorkerVersionState::new(100, 0.2, &mut rng);
+        let sched = UpgradeSchedule::parse("1:0,5:0.5").unwrap();
+        st.advance(&sched, 1); // target 0, but floor is the initial 20
+        assert_eq!(st.eligible_count(), 20);
+        st.advance(&sched, 5); // target 50
+        assert_eq!(st.eligible_count(), 50);
+        st.advance(&sched, 6); // holds at 50 (monotonic)
+        assert_eq!(st.eligible_count(), 50);
+    }
+
+    #[test]
+    fn apply_stamps_exactly_eligible_count_with_new() {
+        let original = Version::new(2, 10, 1);
+        let mut rng = StdRng::seed_from_u64(7);
+        let st = WorkerVersionState::new(10, 0.3, &mut rng);
+        let mut workers = make_test_workers(10);
+        for w in &mut workers {
+            w.version = Some(original.clone());
+        }
+        st.apply(&mut workers, &new_version());
+        let new_count = workers
+            .iter()
+            .filter(|w| w.version.as_ref() == Some(&new_version()))
+            .count();
+        assert_eq!(new_count, 3);
+        // The rest keep their original version (not overwritten).
+        assert_eq!(
+            workers
+                .iter()
+                .filter(|w| w.version.as_ref() == Some(&original))
+                .count(),
+            7
+        );
+    }
+
+    #[test]
+    fn target_fraction_holds_between_breakpoints() {
+        let s = UpgradeSchedule::parse("1:0,5:0.25,50:0.5").unwrap();
+        assert_eq!(s.target_fraction(1), 0.0);
+        assert_eq!(s.target_fraction(4), 0.0);
+        assert_eq!(s.target_fraction(5), 0.25);
+        assert_eq!(s.target_fraction(49), 0.25);
+        assert_eq!(s.target_fraction(50), 0.5);
+        assert_eq!(s.target_fraction(1000), 0.5);
+    }
+
+    #[test]
+    fn target_fraction_before_first_breakpoint_is_zero() {
+        let s = UpgradeSchedule::parse("5:0.25").unwrap();
+        assert_eq!(s.target_fraction(1), 0.0);
+    }
+
+    #[test]
+    fn empty_schedule_is_always_zero() {
+        let s = UpgradeSchedule::parse("").unwrap();
+        assert_eq!(s.target_fraction(100), 0.0);
+    }
+
+    #[test]
+    fn rejects_descending_steps() {
+        assert!(UpgradeSchedule::parse("5:0.25,2:0.5").is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_fraction() {
+        assert!(UpgradeSchedule::parse("1:1.5").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_entry() {
+        assert!(UpgradeSchedule::parse("1-0").is_err());
+    }
+
+    #[test]
+    fn rejects_non_finite_fraction() {
+        assert!(UpgradeSchedule::parse("1:NaN").is_err());
+        assert!(UpgradeSchedule::parse("1:inf").is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_steps() {
+        assert!(UpgradeSchedule::parse("5:0.25,5:0.5").is_err());
+    }
+
+    #[test]
+    fn apply_with_zero_upgraded_leaves_originals_untouched() {
+        let original = Version::new(2, 10, 1);
+        let mut rng = StdRng::seed_from_u64(3);
+        let st = WorkerVersionState::new(5, 0.0, &mut rng);
+        let mut workers = make_test_workers(5);
+        for w in &mut workers {
+            w.version = Some(original.clone());
+        }
+        st.apply(&mut workers, &new_version());
+        assert!(
+            workers
+                .iter()
+                .all(|w| w.version.as_ref() == Some(&original))
+        );
+    }
+}

--- a/tools/reshuffle_sim/src/util.rs
+++ b/tools/reshuffle_sim/src/util.rs
@@ -1,64 +1,195 @@
+use std::collections::BTreeMap;
+use std::io::{IsTerminal, Write};
+
 use bytesize::ByteSize;
+use network_scheduler::types::Worker;
+use semver::Version;
+use tabled::builder::Builder;
+use tabled::settings::span::{ColumnSpan, RowSpan};
+use tabled::settings::{Alignment, Modify, Style};
 
 use crate::simulation::ReshuffleMetrics;
 
-pub fn print_header() {
-    println!(
-        "{:>5} | {:>12} | {:>14} | {:>30} | {:>12} | {:>17} | {:>14} | {:>14} | {:>12} | {:>12} | {:>6} | {:>10} | {:>10} | {:>10}",
-        "Step",
-        "New chunks",
-        "Total chunks",
-        "Replication",
-        "New DL",
-        "Shuffled",
-        "Shuffle DL",
-        "Repl DL change",
-        "Total DL(*)",
-        "Free cap",
-        "Used%",
-        "W new",
-        "W lost",
-        "W shuffled"
-    );
-    println!("{}", "-".repeat(230));
+/// Counts workers by version (ascending), rendering a missing version as
+/// "none". Example: `"1.0.0:50 2.0.0:17"`.
+pub fn format_version_distribution(workers: &[Worker]) -> String {
+    let mut dist: BTreeMap<Option<Version>, usize> = BTreeMap::new();
+    for worker in workers {
+        *dist.entry(worker.version.clone()).or_insert(0) += 1;
+    }
+    dist.into_iter()
+        .map(|(version, count)| match version {
+            Some(v) => format!("{v}:{count}"),
+            None => format!("none:{count}"),
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
-pub fn print_step(metrics: &ReshuffleMetrics) {
-    let replication_summary = metrics
-        .replication_by_weight
-        .iter()
-        .map(|(weight, factor)| format!("{weight}:{factor}"))
-        .collect::<Vec<_>>()
-        .join(", ");
+/// Index of the first of the three "Workers" sub-columns (new / lost / shuffled).
+const WORKERS_COL: usize = 10;
+/// Single-value columns whose header should span both header rows.
+const SINGLE_COLS: [usize; 12] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 14];
 
-    let dm = &metrics.data_movement;
-    let total_download = dm.new_chunk_bytes + dm.shuffled_bytes + dm.increased_replication_bytes;
+/// Builds the metrics table. The three worker counts sit under one spanning
+/// `Workers` header (`new / lost / shuffled`); other headers are stacked across
+/// lines so each column is only as wide as its longest word.
+fn build_table(metrics: &[ReshuffleMetrics]) -> tabled::Table {
+    let mut builder = Builder::default();
+    builder.push_record([
+        "Step",
+        "New\nchunks\n(restr)",
+        "Total\nchunks\n(restr)",
+        "Repl.",
+        "New\ndownload",
+        "Shuffled\nchunks\n(download)",
+        "Repl chg\n+gain/\n-freed",
+        "Total\ndownload",
+        "Restr.\ndownload",
+        "Free cap\n(used %)",
+        "Workers",
+        "",
+        "",
+        "Upgraded\nworkers",
+        "Sched.",
+    ]);
+    builder.push_record([
+        "", "", "", "", "", "", "", "", "", "", "new", "lost", "shuffled", "", "",
+    ]);
 
-    let free_capacity = metrics
-        .total_capacity_bytes
-        .saturating_sub(metrics.used_capacity_bytes);
-    let used_pct = if metrics.total_capacity_bytes > 0 {
-        metrics.used_capacity_bytes as f64 / metrics.total_capacity_bytes as f64 * 100.0
-    } else {
-        0.0
-    };
+    for m in metrics {
+        let dm = &m.data_movement;
+        let total_download =
+            dm.new_chunk_bytes + dm.shuffled_bytes + dm.increased_replication_bytes;
+        let free_capacity = m.total_capacity_bytes.saturating_sub(m.used_capacity_bytes);
+        let used_pct = if m.total_capacity_bytes > 0 {
+            m.used_capacity_bytes as f64 / m.total_capacity_bytes as f64 * 100.0
+        } else {
+            0.0
+        };
+        let restricted_download = m.restricted_movement.new_chunk_bytes
+            + m.restricted_movement.shuffled_bytes
+            + m.restricted_movement.increased_replication_bytes;
+        let replication = m
+            .replication_by_weight
+            .iter()
+            .map(|(weight, factor)| format!("{weight}:{factor}"))
+            .collect::<Vec<_>>()
+            .join(", ");
 
-    println!(
-        "{:>5} | {:>12} | {:>14} | {:>30} | {:>12} | {:>17} | {:>14} | {:>6}+ / {:<5}- | {:>12} | {:>12} | {:>6.1}% | {:>10} | {:>10} | {:>10}",
-        metrics.step,
-        metrics.new_chunks_in_step,
-        metrics.total_chunks,
-        replication_summary,
-        ByteSize(dm.new_chunk_bytes),
-        format!("{} chunks", dm.shuffled_count),
-        ByteSize(dm.shuffled_bytes),
-        ByteSize(dm.increased_replication_bytes),
-        ByteSize(dm.decreased_replication_bytes),
-        ByteSize(total_download),
-        ByteSize(free_capacity),
-        used_pct,
-        dm.workers_receiving_new,
-        dm.workers_losing,
-        dm.workers_shuffled,
-    );
+        builder.push_record([
+            m.step.to_string(),
+            format!("{} ({})", m.new_chunks_in_step, m.new_restricted_in_step),
+            format!("{} ({})", m.total_chunks, m.total_restricted_chunks),
+            replication,
+            ByteSize(dm.new_chunk_bytes).to_string(),
+            format!("{} ({})", dm.shuffled_count, ByteSize(dm.shuffled_bytes)),
+            format!(
+                "+{} / -{}",
+                ByteSize(dm.increased_replication_bytes),
+                ByteSize(dm.decreased_replication_bytes)
+            ),
+            ByteSize(total_download).to_string(),
+            ByteSize(restricted_download).to_string(),
+            format!("{} ({used_pct:.1}%)", ByteSize(free_capacity)),
+            dm.workers_receiving_new.to_string(),
+            dm.workers_losing.to_string(),
+            dm.workers_shuffled.to_string(),
+            m.eligible_workers.to_string(),
+            if m.scheduled { "yes" } else { "NO" }.to_string(),
+        ]);
+    }
+
+    let mut table = builder.build();
+    table.with(Style::modern()).with(Alignment::right());
+    // "Workers" spans its three sub-columns and is centered above them.
+    table.with(Modify::new((0, WORKERS_COL)).with(ColumnSpan::new(3)));
+    table.with(Modify::new((0, WORKERS_COL)).with(Alignment::center()));
+    // Single-value headers span both header rows so they aren't split.
+    for col in SINGLE_COLS {
+        table.with(Modify::new((0, col)).with(RowSpan::new(2)));
+    }
+    table
+}
+
+/// Renders the metrics table live: on a terminal it redraws the whole table in
+/// place each step (overwriting the previous render); when output is piped it
+/// renders nothing until `finish`, which prints the table once.
+pub struct LiveTable {
+    is_tty: bool,
+    last_height: usize,
+}
+
+impl Default for LiveTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveTable {
+    pub fn new() -> Self {
+        Self {
+            is_tty: std::io::stdout().is_terminal(),
+            last_height: 0,
+        }
+    }
+
+    /// Redraws the table in place for the steps collected so far. No-op when
+    /// output isn't a terminal (deferred to `finish`).
+    pub fn update(&mut self, metrics: &[ReshuffleMetrics]) {
+        if !self.is_tty {
+            return;
+        }
+        let rendered = build_table(metrics).to_string();
+        let mut stdout = std::io::stdout();
+        if self.last_height > 0 {
+            // Move to the first line of the previous render, then clear downward.
+            let _ = write!(stdout, "\x1b[{}F\x1b[0J", self.last_height);
+        }
+        let _ = writeln!(stdout, "{rendered}");
+        let _ = stdout.flush();
+        self.last_height = rendered.lines().count();
+    }
+
+    /// Prints the final table once when output isn't a terminal (it was already
+    /// drawn live otherwise).
+    pub fn finish(&self, metrics: &[ReshuffleMetrics]) {
+        if !self.is_tty {
+            println!("{}", build_table(metrics));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p_identity::PeerId;
+    use network_scheduler::types::WorkerStatus;
+
+    fn worker(version: Option<Version>) -> Worker {
+        Worker {
+            id: PeerId::random(),
+            status: WorkerStatus::Online,
+            version,
+        }
+    }
+
+    #[test]
+    fn counts_workers_per_version_ascending() {
+        let workers = vec![
+            worker(Some(Version::new(2, 0, 0))),
+            worker(Some(Version::new(1, 0, 0))),
+            worker(Some(Version::new(2, 0, 0))),
+            worker(None),
+        ];
+        assert_eq!(
+            format_version_distribution(&workers),
+            "none:1 1.0.0:1 2.0.0:2"
+        );
+    }
+
+    #[test]
+    fn empty_workers_render_empty() {
+        assert_eq!(format_version_distribution(&[]), "");
+    }
 }

--- a/tools/reshuffle_sim/src/util.rs
+++ b/tools/reshuffle_sim/src/util.rs
@@ -8,7 +8,7 @@ use tabled::builder::Builder;
 use tabled::settings::span::{ColumnSpan, RowSpan};
 use tabled::settings::{Alignment, Modify, Style};
 
-use crate::simulation::ReshuffleMetrics;
+use crate::metrics::ReshuffleMetrics;
 
 /// Counts workers by version (ascending), rendering a missing version as
 /// "none". Example: `"1.0.0:50 2.0.0:17"`.


### PR DESCRIPTION
Extend the reshuffle simulator to model version-restricted chunks and a gradual worker-version rollout, measuring the reshuffling each causes.

- Generate a configurable fraction of new chunks as version-restricted (--restricted-fraction); they require a new worker version (10.0.0).
- Model worker upgrades: each worker keeps its loaded version and is moved to the new version per an ascending step:fraction schedule (--upgrade-schedule), with an optional initial fraction (--initial-new-fraction). Upgrades are monotonic and seed-deterministic.
- Run the real scheduler under std::panic::catch_unwind: an infeasible version restriction (too few eligible workers) is recorded and the run stops cleanly instead of aborting.
- Report per-step and cumulative restricted vs non-restricted chunk counts, restricted data movement, the worker version distribution, and an end-of-run summary; HTML report gains upgrade-progress and restricted- download charts plus a stop-reason banner.
- Render the metrics as a live tabled table (redraws in place on a TTY, single render when piped) with a spanning Workers header.
- Add --lift-restriction-at-step to remove previously-restricted chunks and stop tagging new ones mid-run, for measuring restriction-removal reshuffle.


```
cargo run -p reshuffle-sim -- -c examples/testnet_config.yaml \
  --chunks-per-step 1000 --steps 20 \
  --initial-new-fraction 1.0 \
  --restricted-fraction 0.5 \
  --lift-restriction-at-step 11 \
  --report report.html 2026-05-25T09:20:03_EA5D1CA701776B3B4ECCECDEAEFECD8069F15C8F1D5C56D50903090698212136.fb.1.gz
```

```
Loading baseline assignment from "2026-05-25T09:20:03_EA5D1CA701776B3B4ECCECDEAEFECD8069F15C8F1D5C56D50903090698212136.fb.1.gz"
Loaded 95092 chunks across 8 datasets, 67 workers
Worker version distribution: 10.0.0:67
┌──────┬────────────┬───────────────┬───────────┬───────────┬─────────────────┬─────────────────┬───────────┬───────────┬───────────────────┬─────┬──────┬──────────┬──────────┬────────┐
│ Step │    New     │       Total   │     Repl. │  New      │      Shuffled   │        Repl chg │  Total    │  Restr.   │          Free cap │        Workers        │ Upgraded │ Sched. │
├      ┼    chunks  ┼       chunks  ┼           ┼  download ┼      chunks     ┼        +gain/   ┼  download ┼  download ┼          (used %) ┼─────┼──────┼──────────┼ workers  ┼        ┤
│      │    (restr) │       (restr) │           │           │      (download) │        -freed   │           │           │                   │ new │ lost │ shuffled │          │        │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    1 │ 1000 (500) │   96092 (500) │ 1:5, 3:15 │ 338.8 GiB │   242 (6.8 GiB) │     +0 B / -0 B │ 345.6 GiB │ 170.9 GiB │ 772.3 GiB (97.4%) │  67 │    2 │       66 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    2 │ 1000 (500) │  97092 (1000) │ 1:5, 3:15 │ 299.5 GiB │ 1212 (41.2 GiB) │     +0 B / -0 B │ 340.7 GiB │ 147.4 GiB │ 472.9 GiB (98.4%) │  67 │   14 │       66 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    3 │ 1000 (500) │  98092 (1500) │ 1:4, 3:14 │ 288.1 GiB │ 1162 (39.2 GiB) │ +0 B / -3.6 TiB │ 327.3 GiB │ 140.7 GiB │   3.8 TiB (87.0%) │  67 │   67 │       14 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    4 │ 1000 (500) │  99092 (2000) │ 1:4, 3:14 │ 274.1 GiB │         0 (0 B) │     +0 B / -0 B │ 274.1 GiB │ 129.7 GiB │   3.6 TiB (87.9%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    5 │ 1000 (500) │ 100092 (2500) │ 1:4, 3:14 │ 256.7 GiB │         0 (0 B) │     +0 B / -0 B │ 256.7 GiB │ 123.6 GiB │   3.3 TiB (88.8%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    6 │ 1000 (500) │ 101092 (3000) │ 1:4, 3:14 │ 269.1 GiB │         0 (0 B) │     +0 B / -0 B │ 269.1 GiB │ 135.2 GiB │   3.0 TiB (89.7%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    7 │ 1000 (500) │ 102092 (3500) │ 1:4, 3:14 │ 261.4 GiB │         0 (0 B) │     +0 B / -0 B │ 261.4 GiB │ 140.4 GiB │   2.8 TiB (90.5%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    8 │ 1000 (500) │ 103092 (4000) │ 1:4, 3:14 │ 246.7 GiB │         0 (0 B) │     +0 B / -0 B │ 246.7 GiB │ 129.8 GiB │   2.5 TiB (91.4%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│    9 │ 1000 (500) │ 104092 (4500) │ 1:4, 3:14 │ 267.6 GiB │         0 (0 B) │     +0 B / -0 B │ 267.6 GiB │ 139.5 GiB │   2.3 TiB (92.3%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   10 │ 1000 (500) │ 105092 (5000) │ 1:4, 3:13 │ 250.0 GiB │         0 (0 B) │ +0 B / -1.2 TiB │ 250.0 GiB │ 120.1 GiB │   3.2 TiB (89.2%) │  67 │   67 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   11 │   1000 (0) │    101092 (0) │ 1:4, 3:14 │ 271.6 GiB │         0 (0 B) │ +1.1 TiB / -0 B │   1.4 TiB │       0 B │   3.1 TiB (89.6%) │  67 │   67 │       67 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   12 │   1000 (0) │    102092 (0) │ 1:4, 3:14 │ 269.2 GiB │         0 (0 B) │     +0 B / -0 B │ 269.2 GiB │       0 B │   2.8 TiB (90.5%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   13 │   1000 (0) │    103092 (0) │ 1:4, 3:14 │ 270.1 GiB │         0 (0 B) │     +0 B / -0 B │ 270.1 GiB │       0 B │   2.5 TiB (91.4%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   14 │   1000 (0) │    104092 (0) │ 1:4, 3:14 │ 272.1 GiB │         0 (0 B) │     +0 B / -0 B │ 272.1 GiB │       0 B │   2.3 TiB (92.3%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   15 │   1000 (0) │    105092 (0) │ 1:4, 3:13 │ 268.0 GiB │         0 (0 B) │ +0 B / -1.2 TiB │ 268.0 GiB │       0 B │   3.2 TiB (89.2%) │  67 │   67 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   16 │   1000 (0) │    106092 (0) │ 1:4, 3:13 │ 259.9 GiB │         0 (0 B) │     +0 B / -0 B │ 259.9 GiB │       0 B │   2.9 TiB (90.1%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   17 │   1000 (0) │    107092 (0) │ 1:4, 3:13 │ 250.8 GiB │         0 (0 B) │     +0 B / -0 B │ 250.8 GiB │       0 B │   2.7 TiB (90.9%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   18 │   1000 (0) │    108092 (0) │ 1:4, 3:13 │ 238.7 GiB │         0 (0 B) │     +0 B / -0 B │ 238.7 GiB │       0 B │   2.4 TiB (91.7%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   19 │   1000 (0) │    109092 (0) │ 1:4, 3:13 │ 270.7 GiB │         0 (0 B) │     +0 B / -0 B │ 270.7 GiB │       0 B │   2.2 TiB (92.6%) │  67 │    0 │        0 │       67 │    yes │
├──────┼────────────┼───────────────┼───────────┼───────────┼─────────────────┼─────────────────┼───────────┼───────────┼───────────────────┼─────┼──────┼──────────┼──────────┼────────┤
│   20 │   1000 (0) │    110092 (0) │ 1:4, 3:13 │ 245.1 GiB │         0 (0 B) │     +0 B / -0 B │ 245.1 GiB │       0 B │   1.9 TiB (93.4%) │  67 │    0 │        0 │       67 │    yes │
└──────┴────────────┴───────────────┴───────────┴───────────┴─────────────────┴─────────────────┴───────────┴───────────┴───────────────────┴─────┴──────┴──────────┴──────────┴────────┘

Chunks added: 15000 (version-restricted: 0, non-restricted: 15000)
Workers upgraded to 10.0.0: 67 of 67
Report written to report.html
```