### PR TITLE
Net 682 split assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
  "flate2",
  "libp2p-identity",
  "network-scheduler",
- "sqd-assignments 0.1.0",
+ "sqd-assignments 0.1.0 (git+https://github.com/subsquid/sqd-network.git?rev=fa19681)",
 ]
 
 [[package]]
@@ -1434,7 +1434,6 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -2327,9 +2326,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -3188,7 +3187,7 @@ dependencies = [
  "network-scheduler",
  "rand 0.9.1",
  "semver",
- "sqd-assignments 0.1.0",
+ "sqd-assignments 0.1.0 (git+https://github.com/subsquid/sqd-network.git?rev=fa19681)",
  "tabled",
 ]
 
@@ -3728,7 +3727,6 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=fa19681#fa19681cb6a8bbd839ac41dbf568ff48ed2fd3b5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3743,6 +3741,22 @@ dependencies = [
  "sha2",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "sqd-assignments"
+version = "0.1.0"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=fa19681#fa19681cb6a8bbd839ac41dbf568ff48ed2fd3b5"
+dependencies = [
+ "anyhow",
+ "crypto_box",
+ "flatbuffers 25.2.10",
+ "libp2p-identity",
+ "ouroboros",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,7 +2499,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sha2",
- "sqd-assignments 0.1.0",
+ "sqd-assignments 0.1.0 (git+https://github.com/subsquid/sqd-network.git?rev=27ba3353)",
  "sqd-messages",
  "tempfile",
  "thiserror 2.0.12",
@@ -3727,6 +3727,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=27ba3353#27ba3353f09bd6dda8e44e9ed4aea1eadc906d19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,7 +2499,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sha2",
- "sqd-assignments 0.1.0 (git+https://github.com/subsquid/sqd-network.git?rev=27ba3353)",
+ "sqd-assignments 0.1.0 (git+https://github.com/subsquid/sqd-network.git?rev=d9f4125)",
  "sqd-messages",
  "tempfile",
  "thiserror 2.0.12",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "sqd-assignments"
 version = "0.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=27ba3353#27ba3353f09bd6dda8e44e9ed4aea1eadc906d19"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d9f4125#d9f4125cac2980e2f514c03486ba1ecc8f115328"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=fa19681#fa19681cb6a8bbd839ac41dbf568ff48ed2fd3b5"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=d9f4125#d9f4125cac2980e2f514c03486ba1ecc8f115328"
 dependencies = [
  "hex",
  "libp2p-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ name = "network-scheduler"
 version = "3.8.0"
 edition = "2024"
 
+[features]
+default = []
+mvcc-chunks = ["sqd-assignments/mvcc-chunks"]
+
 [dependencies]
 anyhow = "1.0.98"
 aws-config = { version = "1.6.2", features = ["behavior-version-latest"] }
@@ -34,7 +38,7 @@ serde_with = "3.12.0"
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681" }
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681", features = ["builder", "reader"] }
+sqd-assignments = { path = "../sqd-network/crates/assignments", features = ["builder", "reader"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ serde_json = "1.0.140"
 serde_with = "3.12.0"
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681" }
-sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "27ba3353", features = ["builder", "reader"] }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "d9f4125" }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "d9f4125", features = ["builder", "reader"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_with = "3.12.0"
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
 sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "fa19681" }
-sqd-assignments = { path = "../sqd-network/crates/assignments", features = ["builder", "reader"] }
+sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "27ba3353", features = ["builder", "reader"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -314,6 +314,8 @@ impl WithAssignment {
             SerializedAssignment { fb_v0, fb_v1 }
         };
 
+        // This first MVCC step only splits assignment discovery/publication.
+        // NET-683/NET-684 will make portal and worker contents diverge.
         SerializedAssignments {
             legacy: serialize_one(),
             worker: serialize_one(),

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -300,6 +300,27 @@ impl WithAssignment {
         SerializedAssignment { fb_v0, fb_v1 }
     }
 
+    #[cfg(feature = "mvcc-chunks")]
+    pub fn serialize_assignments(&self) -> SerializedAssignments {
+        tracing::info!("Serializing split assignments");
+
+        let serialize_one = || {
+            let fb_v0 =
+                self.assignment
+                    .encode_fb(&self.chunks, &self.config, &self.workers, FbVersion::V0);
+            let fb_v1 =
+                self.assignment
+                    .encode_fb(&self.chunks, &self.config, &self.workers, FbVersion::V1);
+            SerializedAssignment { fb_v0, fb_v1 }
+        };
+
+        SerializedAssignments {
+            legacy: serialize_one(),
+            worker: serialize_one(),
+            portal: serialize_one(),
+        }
+    }
+
     pub fn _save_to_file(&self, filename: &str) -> anyhow::Result<()> {
         let serialized =
             self.assignment
@@ -334,6 +355,34 @@ impl SerializedAssignment {
         tracing::info!("Uploading assignment");
         let url: String = uploader.upload_assignment(self.fb_v0, self.fb_v1).await?;
         tracing::info!("Assignment uploaded to {url}");
+        Ok(())
+    }
+}
+
+#[cfg(feature = "mvcc-chunks")]
+pub struct SerializedAssignments {
+    legacy: SerializedAssignment,
+    worker: SerializedAssignment,
+    portal: SerializedAssignment,
+}
+
+#[cfg(feature = "mvcc-chunks")]
+impl SerializedAssignments {
+    pub async fn upload(self, uploader: &upload::Uploader) -> anyhow::Result<()> {
+        tracing::info!("Uploading split assignments");
+        let urls = uploader
+            .upload_assignments(
+                (self.legacy.fb_v0, self.legacy.fb_v1),
+                (self.worker.fb_v0, self.worker.fb_v1),
+                (self.portal.fb_v0, self.portal.fb_v1),
+            )
+            .await?;
+        tracing::info!(
+            "Assignments uploaded: legacy={}, worker={}, portal={}",
+            urls.legacy,
+            urls.worker,
+            urls.portal
+        );
         Ok(())
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -288,16 +288,12 @@ pub struct WithAssignment {
 impl WithAssignment {
     pub fn serialize_assignment(&self) -> SerializedAssignment {
         tracing::info!("Serializing assignment");
-        let fb_v0 =
-            self.assignment
-                .encode_fb(&self.chunks, &self.config, &self.workers, FbVersion::V0);
-        let fb_v1 =
+        let fb =
             self.assignment
                 .encode_fb(&self.chunks, &self.config, &self.workers, FbVersion::V1);
-        tracing::info!("Serialized assignment v0 size: {} bytes", fb_v0.len());
-        tracing::info!("Serialized assignment v1 size: {} bytes", fb_v1.len());
+        tracing::info!("Serialized assignment size: {} bytes", fb.len());
 
-        SerializedAssignment { fb_v0, fb_v1 }
+        SerializedAssignment { fb }
     }
 
     #[cfg(feature = "mvcc-chunks")]
@@ -305,13 +301,10 @@ impl WithAssignment {
         tracing::info!("Serializing split assignments");
 
         let serialize_one = || {
-            let fb_v0 =
-                self.assignment
-                    .encode_fb(&self.chunks, &self.config, &self.workers, FbVersion::V0);
-            let fb_v1 =
+            let fb =
                 self.assignment
                     .encode_fb(&self.chunks, &self.config, &self.workers, FbVersion::V1);
-            SerializedAssignment { fb_v0, fb_v1 }
+            SerializedAssignment { fb }
         };
 
         // This first MVCC step only splits assignment discovery/publication.
@@ -348,14 +341,13 @@ impl WithAssignment {
 }
 
 pub struct SerializedAssignment {
-    fb_v0: Vec<u8>,
-    fb_v1: Vec<u8>,
+    fb: Vec<u8>,
 }
 
 impl SerializedAssignment {
     pub async fn upload(self, uploader: &upload::Uploader) -> anyhow::Result<()> {
         tracing::info!("Uploading assignment");
-        let url: String = uploader.upload_assignment(self.fb_v0, self.fb_v1).await?;
+        let url: String = uploader.upload_assignment(self.fb).await?;
         tracing::info!("Assignment uploaded to {url}");
         Ok(())
     }
@@ -373,11 +365,7 @@ impl SerializedAssignments {
     pub async fn upload(self, uploader: &upload::Uploader) -> anyhow::Result<()> {
         tracing::info!("Uploading split assignments");
         let urls = uploader
-            .upload_assignments(
-                (self.legacy.fb_v0, self.legacy.fb_v1),
-                (self.worker.fb_v0, self.worker.fb_v1),
-                (self.portal.fb_v0, self.portal.fb_v1),
-            )
+            .upload_assignments(self.legacy.fb, self.worker.fb, self.portal.fb)
             .await?;
         tracing::info!(
             "Assignments uploaded: legacy={}, worker={}, portal={}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,10 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let uploader = upload::Uploader::new(config, &args.s3.config().await);
+    #[cfg(not(feature = "mvcc-chunks"))]
     controller.serialize_assignment().upload(&uploader).await?;
+    #[cfg(feature = "mvcc-chunks")]
+    controller.serialize_assignments().upload(&uploader).await?;
 
     drop(_timer);
     let metrics = metrics::encode_metrics(&metrics_registry)?;

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -53,7 +53,7 @@ impl Uploader {
             .await?;
 
         let network_state = legacy_network_state(self.config.network.clone(), assignment);
-        let fb_url_v1 = network_state.assignment.fb_url_v1.clone().unwrap();
+        let fb_url_v1 = assignment_fb_url_v1(&network_state.assignment)?;
         self.upload_network_state(network_state).await?;
 
         Ok(fb_url_v1)
@@ -77,9 +77,9 @@ impl Uploader {
             .await?;
 
         let urls = AssignmentUrls {
-            legacy: legacy.fb_url_v1.clone().unwrap(),
-            worker: worker.fb_url_v1.clone().unwrap(),
-            portal: portal.fb_url_v1.clone().unwrap(),
+            legacy: assignment_fb_url_v1(&legacy).context("Legacy assignment URL missing")?,
+            worker: assignment_fb_url_v1(&worker).context("Worker assignment URL missing")?,
+            portal: assignment_fb_url_v1(&portal).context("Portal assignment URL missing")?,
         };
 
         let network_state =
@@ -89,6 +89,7 @@ impl Uploader {
         Ok(urls)
     }
 
+    #[allow(deprecated)]
     async fn upload_assignment_artifact(
         &self,
         kind: Option<&str>,
@@ -161,7 +162,10 @@ impl Uploader {
         let fb_url_v0 = format!("{}/{fb_v0_filename}", self.config.network_state_url);
         let fb_url_v1 = format!("{}/{fb_v1_filename}", self.config.network_state_url);
         Ok(NetworkAssignment {
+            #[cfg(not(feature = "mvcc-chunks"))]
             url: Some(String::new()),
+            #[cfg(feature = "mvcc-chunks")]
+            url: None,
             fb_url: Some(fb_url_v0),
             fb_url_v1: Some(fb_url_v1),
             id: assignment_id,
@@ -170,7 +174,8 @@ impl Uploader {
     }
 
     async fn upload_network_state(&self, network_state: NetworkState) -> anyhow::Result<()> {
-        let contents = serde_json::to_vec(&network_state).unwrap();
+        let contents =
+            serde_json::to_vec(&network_state).context("Can't serialize network state")?;
         self.client
             .put_object()
             .bucket(&self.config.scheduler_state_bucket)
@@ -249,6 +254,13 @@ fn legacy_network_state(network: String, assignment: NetworkAssignment) -> Netwo
     }
 }
 
+fn assignment_fb_url_v1(assignment: &NetworkAssignment) -> anyhow::Result<String> {
+    assignment
+        .fb_url_v1
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("fb_url_v1 missing"))
+}
+
 #[cfg(feature = "mvcc-chunks")]
 fn split_network_state(
     network: String,
@@ -268,9 +280,13 @@ fn split_network_state(
 mod tests {
     use super::*;
 
+    #[allow(deprecated)]
     fn assignment(id: &str) -> NetworkAssignment {
         NetworkAssignment {
+            #[cfg(not(feature = "mvcc-chunks"))]
             url: Some(String::new()),
+            #[cfg(feature = "mvcc-chunks")]
+            url: None,
             fb_url: Some(format!("https://example.test/{id}.fb.0.gz")),
             fb_url_v1: Some(format!("https://example.test/{id}.fb.1.gz")),
             id: id.to_string(),
@@ -285,6 +301,10 @@ mod tests {
 
         assert_eq!(value["network"], "testnet");
         assert_eq!(value["assignment"]["id"], "legacy");
+        #[cfg(not(feature = "mvcc-chunks"))]
+        assert_eq!(value["assignment"]["url"], "");
+        #[cfg(feature = "mvcc-chunks")]
+        assert!(value["assignment"].get("url").is_none());
         assert!(value.get("worker_assignment").is_none());
         assert!(value.get("portal_assignment").is_none());
     }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -43,43 +43,35 @@ impl Uploader {
     }
 
     #[instrument(skip_all)]
-    pub async fn upload_assignment(
-        &self,
-        fb_assignment_v0: Vec<u8>,
-        fb_assignment_v1: Vec<u8>,
-    ) -> anyhow::Result<String> {
-        let assignment = self
-            .upload_assignment_artifact(None, fb_assignment_v0, fb_assignment_v1)
-            .await?;
+    pub async fn upload_assignment(&self, fb_assignment: Vec<u8>) -> anyhow::Result<String> {
+        let assignment = self.upload_assignment_artifact(None, fb_assignment).await?;
 
         let network_state = legacy_network_state(self.config.network.clone(), assignment);
-        let fb_url_v1 = assignment_fb_url_v1(&network_state.assignment)?;
+        let fb_url = assignment_fb_url(&network_state.assignment)?;
         self.upload_network_state(network_state).await?;
 
-        Ok(fb_url_v1)
+        Ok(fb_url)
     }
 
     #[cfg(feature = "mvcc-chunks")]
     pub async fn upload_assignments(
         &self,
-        legacy: (Vec<u8>, Vec<u8>),
-        worker: (Vec<u8>, Vec<u8>),
-        portal: (Vec<u8>, Vec<u8>),
+        legacy: Vec<u8>,
+        worker: Vec<u8>,
+        portal: Vec<u8>,
     ) -> anyhow::Result<AssignmentUrls> {
-        let legacy = self
-            .upload_assignment_artifact(None, legacy.0, legacy.1)
-            .await?;
+        let legacy = self.upload_assignment_artifact(None, legacy).await?;
         let worker = self
-            .upload_assignment_artifact(Some("worker"), worker.0, worker.1)
+            .upload_assignment_artifact(Some("worker"), worker)
             .await?;
         let portal = self
-            .upload_assignment_artifact(Some("portal"), portal.0, portal.1)
+            .upload_assignment_artifact(Some("portal"), portal)
             .await?;
 
         let urls = AssignmentUrls {
-            legacy: assignment_fb_url_v1(&legacy).context("Legacy assignment URL missing")?,
-            worker: assignment_fb_url_v1(&worker).context("Worker assignment URL missing")?,
-            portal: assignment_fb_url_v1(&portal).context("Portal assignment URL missing")?,
+            legacy: assignment_fb_url(&legacy).context("Legacy assignment URL missing")?,
+            worker: assignment_fb_url(&worker).context("Worker assignment URL missing")?,
+            portal: assignment_fb_url(&portal).context("Portal assignment URL missing")?,
         };
 
         let network_state =
@@ -93,30 +85,22 @@ impl Uploader {
     async fn upload_assignment_artifact(
         &self,
         kind: Option<&str>,
-        fb_assignment_v0: Vec<u8>,
-        fb_assignment_v1: Vec<u8>,
+        fb_assignment: Vec<u8>,
     ) -> anyhow::Result<NetworkAssignment> {
         tracing::debug!("Compressing assignment");
-        let compressed_fb_v0;
+        let compressed_fb;
         {
             let _timer = crate::metrics::Timer::new("compress_assignment");
             let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
-            encoder.write_all(&fb_assignment_v0)?;
-            compressed_fb_v0 = encoder.finish()?;
-        }
-        let compressed_fb_v1;
-        {
-            let _timer = crate::metrics::Timer::new("compress_assignment");
-            let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
-            encoder.write_all(&fb_assignment_v1)?;
-            compressed_fb_v1 = encoder.finish()?;
-            crate::metrics::ASSIGNMENT_FB_SIZE.set(fb_assignment_v1.len() as i64);
-            crate::metrics::ASSIGNMENT_COMPRESSED_FB_SIZE.set(compressed_fb_v1.len() as i64);
+            encoder.write_all(&fb_assignment)?;
+            compressed_fb = encoder.finish()?;
+            crate::metrics::ASSIGNMENT_FB_SIZE.set(fb_assignment.len() as i64);
+            crate::metrics::ASSIGNMENT_COMPRESSED_FB_SIZE.set(compressed_fb.len() as i64);
         }
 
         let hash = {
             let _timer = crate::metrics::Timer::new("hash_assignment");
-            Sha256::digest(&compressed_fb_v1)
+            Sha256::digest(&compressed_fb)
         };
 
         tracing::debug!("Saving assignment");
@@ -125,49 +109,34 @@ impl Uploader {
         let system_time = std::time::SystemTime::now();
         let timestamp = self.time.format("%FT%T");
         let assignment_id = format!("{timestamp}_{hash:X}");
-        let (fb_v0_filename, fb_v1_filename) = match kind {
-            Some(kind) => (
-                format!("assignments/{network}/{kind}/{assignment_id}.fb.0.gz"),
-                format!("assignments/{network}/{kind}/{assignment_id}.fb.1.gz"),
-            ),
-            None => (
-                format!("assignments/{network}/{assignment_id}.fb.0.gz"),
-                format!("assignments/{network}/{assignment_id}.fb.1.gz"),
-            ),
+        let fb_filename = match kind {
+            Some(kind) => format!("assignments/{network}/{kind}/{assignment_id}.fb.gz"),
+            None => format!("assignments/{network}/{assignment_id}.fb.gz"),
         };
         let expiration = s3::primitives::DateTime::from(system_time + self.config.assignment_ttl);
 
-        let fb_v0_fut = self
-            .client
+        self.client
             .put_object()
             .bucket(&self.config.scheduler_state_bucket)
-            .key(&fb_v0_filename)
+            .key(&fb_filename)
             .expires(expiration)
-            .body(compressed_fb_v0.into())
-            .send();
-        let fb_v1_fut = self
-            .client
-            .put_object()
-            .bucket(&self.config.scheduler_state_bucket)
-            .key(&fb_v1_filename)
-            .expires(expiration)
-            .body(compressed_fb_v1.into())
-            .send();
-        tokio::try_join!(fb_v0_fut, fb_v1_fut).context("Can't upload assignment")?;
+            .body(compressed_fb.into())
+            .send()
+            .await
+            .context("Can't upload assignment")?;
 
         let effective_from = (system_time.duration_since(std::time::UNIX_EPOCH).unwrap()
             + self.config.assignment_delay)
             .as_secs();
 
-        let fb_url_v0 = format!("{}/{fb_v0_filename}", self.config.network_state_url);
-        let fb_url_v1 = format!("{}/{fb_v1_filename}", self.config.network_state_url);
+        let fb_url = format!("{}/{fb_filename}", self.config.network_state_url);
         Ok(NetworkAssignment {
             #[cfg(not(feature = "mvcc-chunks"))]
             url: Some(String::new()),
             #[cfg(feature = "mvcc-chunks")]
             url: None,
-            fb_url: Some(fb_url_v0),
-            fb_url_v1: Some(fb_url_v1),
+            fb_url: None,
+            fb_url_v1: Some(fb_url),
             id: assignment_id,
             effective_from,
         })
@@ -254,7 +223,7 @@ fn legacy_network_state(network: String, assignment: NetworkAssignment) -> Netwo
     }
 }
 
-fn assignment_fb_url_v1(assignment: &NetworkAssignment) -> anyhow::Result<String> {
+fn assignment_fb_url(assignment: &NetworkAssignment) -> anyhow::Result<String> {
     assignment
         .fb_url_v1
         .clone()
@@ -287,8 +256,8 @@ mod tests {
             url: Some(String::new()),
             #[cfg(feature = "mvcc-chunks")]
             url: None,
-            fb_url: Some(format!("https://example.test/{id}.fb.0.gz")),
-            fb_url_v1: Some(format!("https://example.test/{id}.fb.1.gz")),
+            fb_url: None,
+            fb_url_v1: Some(format!("https://example.test/{id}.fb.gz")),
             id: id.to_string(),
             effective_from: 1781000000,
         }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -19,6 +19,13 @@ pub struct Uploader {
     time: chrono::DateTime<Utc>,
 }
 
+#[cfg(feature = "mvcc-chunks")]
+pub struct AssignmentUrls {
+    pub legacy: String,
+    pub worker: String,
+    pub portal: String,
+}
+
 impl Uploader {
     pub fn new(config: cli::Config, sdk_config: &aws_config::SdkConfig) -> Self {
         let s3_config = aws_sdk_s3::config::Builder::from(sdk_config)
@@ -41,6 +48,53 @@ impl Uploader {
         fb_assignment_v0: Vec<u8>,
         fb_assignment_v1: Vec<u8>,
     ) -> anyhow::Result<String> {
+        let assignment = self
+            .upload_assignment_artifact(None, fb_assignment_v0, fb_assignment_v1)
+            .await?;
+
+        let network_state = legacy_network_state(self.config.network.clone(), assignment);
+        let fb_url_v1 = network_state.assignment.fb_url_v1.clone().unwrap();
+        self.upload_network_state(network_state).await?;
+
+        Ok(fb_url_v1)
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    pub async fn upload_assignments(
+        &self,
+        legacy: (Vec<u8>, Vec<u8>),
+        worker: (Vec<u8>, Vec<u8>),
+        portal: (Vec<u8>, Vec<u8>),
+    ) -> anyhow::Result<AssignmentUrls> {
+        let legacy = self
+            .upload_assignment_artifact(None, legacy.0, legacy.1)
+            .await?;
+        let worker = self
+            .upload_assignment_artifact(Some("worker"), worker.0, worker.1)
+            .await?;
+        let portal = self
+            .upload_assignment_artifact(Some("portal"), portal.0, portal.1)
+            .await?;
+
+        let urls = AssignmentUrls {
+            legacy: legacy.fb_url_v1.clone().unwrap(),
+            worker: worker.fb_url_v1.clone().unwrap(),
+            portal: portal.fb_url_v1.clone().unwrap(),
+        };
+
+        let network_state =
+            split_network_state(self.config.network.clone(), legacy, worker, portal);
+        self.upload_network_state(network_state).await?;
+
+        Ok(urls)
+    }
+
+    async fn upload_assignment_artifact(
+        &self,
+        kind: Option<&str>,
+        fb_assignment_v0: Vec<u8>,
+        fb_assignment_v1: Vec<u8>,
+    ) -> anyhow::Result<NetworkAssignment> {
         tracing::debug!("Compressing assignment");
         let compressed_fb_v0;
         {
@@ -70,8 +124,16 @@ impl Uploader {
         let system_time = std::time::SystemTime::now();
         let timestamp = self.time.format("%FT%T");
         let assignment_id = format!("{timestamp}_{hash:X}");
-        let fb_v0_filename: String = format!("assignments/{network}/{assignment_id}.fb.0.gz");
-        let fb_v1_filename: String = format!("assignments/{network}/{assignment_id}.fb.1.gz");
+        let (fb_v0_filename, fb_v1_filename) = match kind {
+            Some(kind) => (
+                format!("assignments/{network}/{kind}/{assignment_id}.fb.0.gz"),
+                format!("assignments/{network}/{kind}/{assignment_id}.fb.1.gz"),
+            ),
+            None => (
+                format!("assignments/{network}/{assignment_id}.fb.0.gz"),
+                format!("assignments/{network}/{assignment_id}.fb.1.gz"),
+            ),
+        };
         let expiration = s3::primitives::DateTime::from(system_time + self.config.assignment_ttl);
 
         let fb_v0_fut = self
@@ -98,16 +160,16 @@ impl Uploader {
 
         let fb_url_v0 = format!("{}/{fb_v0_filename}", self.config.network_state_url);
         let fb_url_v1 = format!("{}/{fb_v1_filename}", self.config.network_state_url);
-        let network_state = NetworkState {
-            network,
-            assignment: NetworkAssignment {
-                url: Some(String::new()),
-                fb_url: Some(fb_url_v0),
-                fb_url_v1: Some(fb_url_v1.clone()),
-                id: assignment_id,
-                effective_from,
-            },
-        };
+        Ok(NetworkAssignment {
+            url: Some(String::new()),
+            fb_url: Some(fb_url_v0),
+            fb_url_v1: Some(fb_url_v1),
+            id: assignment_id,
+            effective_from,
+        })
+    }
+
+    async fn upload_network_state(&self, network_state: NetworkState) -> anyhow::Result<()> {
         let contents = serde_json::to_vec(&network_state).unwrap();
         self.client
             .put_object()
@@ -117,8 +179,7 @@ impl Uploader {
             .send()
             .await
             .context("Can't save link to the assignment")?;
-
-        Ok(fb_url_v1)
+        Ok(())
     }
 
     #[instrument(skip_all)]
@@ -174,5 +235,73 @@ impl Uploader {
             .await
             .context("Can't upload metrics")?;
         Ok(())
+    }
+}
+
+fn legacy_network_state(network: String, assignment: NetworkAssignment) -> NetworkState {
+    NetworkState {
+        network,
+        assignment,
+        #[cfg(feature = "mvcc-chunks")]
+        worker_assignment: None,
+        #[cfg(feature = "mvcc-chunks")]
+        portal_assignment: None,
+    }
+}
+
+#[cfg(feature = "mvcc-chunks")]
+fn split_network_state(
+    network: String,
+    legacy: NetworkAssignment,
+    worker: NetworkAssignment,
+    portal: NetworkAssignment,
+) -> NetworkState {
+    NetworkState {
+        network,
+        assignment: legacy,
+        worker_assignment: Some(worker),
+        portal_assignment: Some(portal),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assignment(id: &str) -> NetworkAssignment {
+        NetworkAssignment {
+            url: Some(String::new()),
+            fb_url: Some(format!("https://example.test/{id}.fb.0.gz")),
+            fb_url_v1: Some(format!("https://example.test/{id}.fb.1.gz")),
+            id: id.to_string(),
+            effective_from: 1781000000,
+        }
+    }
+
+    #[test]
+    fn legacy_network_state_has_compatibility_shape() {
+        let state = legacy_network_state("testnet".to_string(), assignment("legacy"));
+        let value = serde_json::to_value(state).unwrap();
+
+        assert_eq!(value["network"], "testnet");
+        assert_eq!(value["assignment"]["id"], "legacy");
+        assert!(value.get("worker_assignment").is_none());
+        assert!(value.get("portal_assignment").is_none());
+    }
+
+    #[cfg(feature = "mvcc-chunks")]
+    #[test]
+    fn split_network_state_has_worker_and_portal_assignments() {
+        let state = split_network_state(
+            "testnet".to_string(),
+            assignment("legacy"),
+            assignment("worker"),
+            assignment("portal"),
+        );
+        let value = serde_json::to_value(state).unwrap();
+
+        assert_eq!(value["assignment"]["id"], "legacy");
+        assert_eq!(value["worker_assignment"]["id"], "worker");
+        assert_eq!(value["portal_assignment"]["id"], "portal");
     }
 }


### PR DESCRIPTION
### Description

Linear: NET-682

Adds feature-gated split assignment publication to network-scheduler behind mvcc-chunks.

When mvcc-chunks is disabled, scheduler behavior remains compatible with the existing production flow:  it publishes the single legacy assignment and preserves the legacy assignment.url field.

When mvcc-chunks is enabled, scheduler publishes three assignment references:

  - assignment: legacy compatibility assignment
  - worker_assignment: worker-facing assignment reference
  - portal_assignment: portal-facing assignment reference

For this first split step, all three assignment payloads are intentionally identical. The goal of this change is to split discovery/publication first; NET-683 and NET-684 will make portal and worker assignment contents diverge later.

### Other changes:

  - Adds mvcc-chunks Cargo feature and forwards it to sqd-assignments.
  - Updates sqd-assignments dependency to sqd-network commit 27ba3353.
  - Keeps legacy assignment S3 paths unchanged.
  - Uses new worker/portal S3 subpaths only under mvcc-chunks.
  - Replaces upload-path JSON serialization and assignment URL unwraps with contextual errors.
  - Adds pure tests for legacy and split NetworkState construction.

###   Validation:

  - cargo fmt --check
  - cargo check
  - cargo check --features mvcc-chunks
  - cargo test --lib
  - cargo test --lib --features mvcc-chunks