### PR TITLE
Tolerate per-dataset load failures so one missing bucket can't stall all scheduling

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -37,19 +37,48 @@ impl S3Storage {
         dataset_load_timeout: Option<Duration>,
     ) -> anyhow::Result<BTreeMap<Arc<String>, Vec<Chunk>>> {
         let _timer = crate::metrics::Timer::new("load_newer_chunks");
-        stream::iter(datasets)
+        let results: Vec<(Arc<String>, anyhow::Result<Vec<Chunk>>)> = stream::iter(datasets)
             .map(|(dataset, last_chunk)| {
                 let storage = DatasetStorage::new(self.client.clone(), dataset);
                 async move {
                     let chunks = storage
                         .list_new_chunks(last_chunk, CONCURRENT_CHUNKS, dataset_load_timeout)
-                        .await?;
-                    anyhow::Ok((storage.dataset, chunks))
+                        .await;
+                    (storage.dataset, chunks)
                 }
             })
             .buffer_unordered(concurrent_downloads)
-            .try_collect()
-            .await
+            .collect()
+            .await;
+
+        // A single dataset's storage failure (e.g. a deleted/relocated bucket
+        // returning `NoSuchBucket`) must not abort scheduling for the entire
+        // network. Skip the failing dataset, surface it via logs and the
+        // `scheduler_failure{target=...}` metric, and keep the rest schedulable.
+        let total = results.len();
+        let mut failed = 0;
+        let mut chunks = BTreeMap::new();
+        for (dataset, result) in results {
+            match result {
+                Ok(dataset_chunks) => {
+                    chunks.insert(dataset, dataset_chunks);
+                }
+                Err(e) => {
+                    failed += 1;
+                    tracing::warn!("Skipping dataset {dataset}: couldn't load chunks: {e:#}");
+                    crate::metrics::failure(dataset.as_str());
+                }
+            }
+        }
+
+        // Guard against a systemic outage: if every dataset failed, propagate the
+        // error rather than publishing an empty assignment that would wipe worker
+        // allocations. Partial failures (some datasets loaded) proceed normally.
+        if failed > 0 && chunks.is_empty() {
+            anyhow::bail!("Failed to load chunks for all {total} datasets");
+        }
+
+        Ok(chunks)
     }
 }
 


### PR DESCRIPTION
## Cause (proven)

The mainnet `cron-scheduler` (`network-scheduler`, runs every 20 min in
`secure-mainnet-control-plane`) has been **crashing on every run**, so it
commits no assignment and `scheduler_assignment_timestamp_seconds` freezes →
`mainnet_scheduler_stale` fires (and keeps re-firing: same alert recurred at
~14:04 and ~20:57 UTC on 2026-06-19).

Live scheduler logs (pod `cron-scheduler-29698320-l72nl`, 20:17:40 UTC):

```
DEBUG network_scheduler::storage: Downloading chunks from s3://neon-mainnet-traceless
...
DEBUG network_scheduler::metrics: load_newer_chunks finished in 1.42930075s
Error: Can't load datasets
Caused by:
    0: service error
    1: NoSuchBucket: The specified bucket does not exist.
    2: NoSuchBucket: The specified bucket does not exist.
```

The R2 bucket `neon-mainnet-traceless` (an active dataset in the mainnet
scheduler config) no longer exists. In `storage.rs::load_newer_chunks` every
dataset is loaded with `buffer_unordered(...).try_collect()`, so the **first**
dataset error aborts the **entire** load (`load_new_chunks` then bails with
`Can't load datasets`). One missing bucket therefore halts scheduling for **all
~200 mainnet datasets**.

This is a fail-closed design flaw, not a provider/config regression: the dataset
list has been unchanged for days; the trigger was an out-of-band bucket deletion.

## Fix

Make `load_newer_chunks` tolerant of a single dataset's storage failure:
`collect()` per-dataset results, **skip** a failing dataset (log a `warn!` and
emit the existing `scheduler_failure{target=...}` metric so the bad dataset is
still surfaced, not silenced), and keep the healthy datasets schedulable. A
guard preserves safety: if **every** dataset fails (systemic outage) the run
still errors instead of publishing an empty assignment that would wipe worker
allocations.

This mirrors the module's existing partial-load tolerance (the
`dataset_load_timeout` path already skips remaining chunks and continues rather
than crashing).

## Tested / verification

- Root cause confirmed from live GCP logs (above): the crash is `NoSuchBucket`
  on `s3://neon-mainnet-traceless`, reached right after that dataset is listed.
- Change is type-checked by manual review; a full `cargo` build was not run in
  the investigation environment (no Rust toolchain / C linker available) —
  please rely on CI for the compile + test gate.

## Falsification

If, after deploying a build with this change, `mainnet_scheduler_stale` still
fires while `scheduler_failure` shows only `neon-mainnet-traceless` failing (not
a network-wide storage outage), then a single dataset error is still aborting
the run and this fix is insufficient.

## Operational follow-up (not in this PR — owner decision)

This code change stops one missing bucket from stalling the whole network, but
the `neon-mainnet-traceless` bucket itself is still gone. An operator must
decide: **restore** the R2 bucket (if the deletion was accidental) or **retire**
the dataset (remove it from `iac/network-control-plane/values.mainnet.yaml`).
A new scheduler image with this fix must also be built and rolled out for the
alert to clear.
