### PR TITLE
Isolate per-dataset failures when loading new chunks

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -37,19 +37,43 @@ impl S3Storage {
         dataset_load_timeout: Option<Duration>,
     ) -> anyhow::Result<BTreeMap<Arc<String>, Vec<Chunk>>> {
         let _timer = crate::metrics::Timer::new("load_newer_chunks");
-        stream::iter(datasets)
+        let loaded = stream::iter(datasets)
             .map(|(dataset, last_chunk)| {
                 let storage = DatasetStorage::new(self.client.clone(), dataset);
                 async move {
-                    let chunks = storage
+                    let result = storage
                         .list_new_chunks(last_chunk, CONCURRENT_CHUNKS, dataset_load_timeout)
-                        .await?;
-                    anyhow::Ok((storage.dataset, chunks))
+                        .await;
+                    (storage.dataset, result)
                 }
             })
             .buffer_unordered(concurrent_downloads)
-            .try_collect()
-            .await
+            .collect::<Vec<_>>()
+            .await;
+
+        // Isolate per-dataset failures instead of aborting the whole load.
+        // A single unreadable dataset (e.g. a missing/renamed S3 bucket
+        // returning NoSuchBucket) must not prevent loading every other dataset:
+        // otherwise the scheduler can't publish any assignment and
+        // `effective_from` freezes network-wide until the bad dataset is removed
+        // by hand. Skip the failing dataset (it keeps its already-known chunks
+        // and is retried on the next run) and keep going.
+        let mut result = BTreeMap::new();
+        for (dataset, chunks) in loaded {
+            match chunks {
+                Ok(chunks) => {
+                    result.insert(dataset, chunks);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        dataset = %dataset,
+                        error = ?err,
+                        "Failed to load new chunks for dataset, skipping it for this run"
+                    );
+                }
+            }
+        }
+        Ok(result)
     }
 }
 


### PR DESCRIPTION
## Problem

A single unreadable dataset froze new-chunk discovery for the **entire** SQD network for ~14.5h on 2026-06-19/20, which cascaded into a fleet-wide hotblocks outage.

`S3Storage::load_newer_chunks` (`src/storage.rs`) lists new chunks for all datasets concurrently and collects them with `try_collect()`. `try_collect` short-circuits on the first `Err`, so when one dataset's bucket returned `NoSuchBucket` the whole call aborted:

```
Error: Can't load datasets
Caused by:
    0: service error
    1: NoSuchBucket: The specified bucket does not exist.
```

With no dataset list loaded, the scheduler could not publish a new assignment, so the published `effective_from` stopped advancing. The crash-loop ran every ~30s from 2026-06-19 16:01 UTC until the bad dataset was removed by hand at 2026-06-20 06:33 UTC (`subsquid/infra` commit `74b886ae` removed `s3://neon-mainnet-traceless`, whose real bucket is `neon-mainnet-traceless-0`).

### Downstream blast radius (why this matters)

`data-hotblocks-retain` only prunes the hotblocks DB up to the heights in the scheduler's status, and only when `effective_from` changes. With `effective_from` frozen, retention never ran, the hotblocks DB could not drop confirmed blocks, and its local PVC grew unbounded — filling `hotblocks-db-0` to 100% (`No space left on device: .../run/db/*.sst`), stalling ingestion (CPU 14→2 cores), and pushing head-monitor delay to ~28s for every dataset on that replica. That fired ~20 `Portal_Hotblocks_Avg_Processing_Time_High_<network>` alerts simultaneously.

So one missing bucket → no assignment for any dataset → no retention anywhere → disk-full → fleet-wide hotblocks stall.

## Fix

Isolate per-dataset failures instead of aborting the whole load. Collect each dataset's result, log a warning (with the dataset name) for any that fail to list, keep the chunks that loaded, and let the failed dataset retry on the next run. Skipped datasets retain their already-known chunks (from ClickHouse), so they are still assigned and only miss *new* chunks until they recover.

This keeps `effective_from` advancing whenever at least one dataset is readable, so a single bad/renamed/removed bucket can no longer freeze the whole network.

## Cause proven by
- Scheduler logs (`cron-scheduler`, GCP Logging): `Can't load datasets` / `NoSuchBucket` crash-loop 2026-06-19 16:01 → 2026-06-20 06:33 UTC.
- `hotblocks-retain` logs: `effective_from unchanged, re-checking in 5 minutes` continuously through the same window; `applied retention policy` resumed only after the scheduler recovered.
- PVC `kubelet_volume_stats`: `hotblocks-db-0` fill to 0 bytes free; `hotblocks-db` logs `No space left on device`.

## Tested / verified
- Verified call-site compatibility: the result is consumed in `controller.rs` via `new_chunks.values()` (store to ClickHouse + assignment), which is tolerant of a smaller map — a skipped dataset simply contributes no new chunks this run.
- `TryStreamExt` is still required elsewhere in the file (`try_for_each_concurrent`), so the import is unchanged.
- Not compiled in this environment (no Rust toolchain available here); change is localized to `load_newer_chunks`.

## Falsification
If a dataset's bucket is again missing/renamed, the scheduler should now log `Failed to load new chunks for dataset, skipping it for this run` for that dataset and keep publishing assignments (the status `effective_from` keeps advancing) for all other datasets. If `effective_from` still freezes when one bucket is missing, this fix is wrong.
