### PR TITLE
Skip datasets that fail to load instead of aborting the entire scheduler run

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -37,14 +37,9 @@ impl S3Storage {
         dataset_load_timeout: Option<Duration>,
     ) -> anyhow::Result<BTreeMap<Arc<String>, Vec<Chunk>>> {
         let _timer = crate::metrics::Timer::new("load_newer_chunks");
-        // Load each dataset independently and DO NOT fail the whole run if a single
-        // dataset can't be loaded (e.g. its bucket is temporarily missing / inaccessible).
-        // A single failing dataset must not abort the assignment: aborting freezes the
-        // global `effective_from` watermark, which stops hot-block retention pruning
-        // fleet-wide and fills the hotblocks disk. Failed datasets are logged and skipped;
-        // they simply contribute no new chunks this run (their previously known chunks are
-        // retained) and recover automatically on a later run once the bucket is reachable.
-        let results: Vec<(Arc<String>, anyhow::Result<Vec<Chunk>>)> = stream::iter(datasets)
+        // Log and skip datasets that fail to load instead of aborting: one unreachable bucket
+        // must not freeze updates for all datasets.
+        let result = stream::iter(datasets)
             .map(|(dataset, last_chunk)| {
                 let storage = DatasetStorage::new(self.client.clone(), dataset);
                 async move {
@@ -55,25 +50,22 @@ impl S3Storage {
                 }
             })
             .buffer_unordered(concurrent_downloads)
-            .collect()
+            .filter_map(|(dataset, chunks)| async move {
+                match chunks {
+                    Ok(chunks) => Some((dataset, chunks)),
+                    Err(e) => {
+                        tracing::error!(
+                            dataset = %dataset,
+                            error = ?e,
+                            "Failed to load chunks for dataset; skipping it for this run"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect::<BTreeMap<_, _>>()
             .await;
-
-        let mut new_chunks = BTreeMap::new();
-        for (dataset, result) in results {
-            match result {
-                Ok(chunks) => {
-                    new_chunks.insert(dataset, chunks);
-                }
-                Err(e) => {
-                    tracing::error!(
-                        dataset = %dataset,
-                        error = ?e,
-                        "Failed to load chunks for dataset; skipping it for this run"
-                    );
-                }
-            }
-        }
-        Ok(new_chunks)
+        Ok(result)
     }
 }
 
@@ -229,8 +221,8 @@ impl ChunkStream {
     }
 
     fn ensure_chain_continuity(&mut self, chunk: &Chunk) -> anyhow::Result<()> {
-        if let Some(next_block) = self.next_expected_block {
-            if *chunk.blocks.start() != next_block {
+        if let Some(next_block) = self.next_expected_block
+            && *chunk.blocks.start() != next_block {
                 anyhow::bail!(
                     "Blocks {} to {} missing from {}",
                     next_block,
@@ -238,7 +230,6 @@ impl ChunkStream {
                     self.dataset
                 );
             }
-        }
         self.next_expected_block = Some(chunk.blocks.end() + 1);
         Ok(())
     }
@@ -285,8 +276,8 @@ impl DatasetStorage {
 
             chunks.append(&mut batch);
 
-            if let Some(deadline) = deadline {
-                if Instant::now() >= deadline && !stream.exhausted() {
+            if let Some(deadline) = deadline
+                && Instant::now() >= deadline && !stream.exhausted() {
                     tracing::warn!(
                         "Dataset {} summary population timed out after {}s. \
                          {} chunks processed. Remaining chunks will be processed on next run.",
@@ -296,7 +287,6 @@ impl DatasetStorage {
                     );
                     break;
                 }
-            }
         }
 
         tracing::debug!("Downloaded {} chunks", chunks.len());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -37,19 +37,43 @@ impl S3Storage {
         dataset_load_timeout: Option<Duration>,
     ) -> anyhow::Result<BTreeMap<Arc<String>, Vec<Chunk>>> {
         let _timer = crate::metrics::Timer::new("load_newer_chunks");
-        stream::iter(datasets)
+        // Load each dataset independently and DO NOT fail the whole run if a single
+        // dataset can't be loaded (e.g. its bucket is temporarily missing / inaccessible).
+        // A single failing dataset must not abort the assignment: aborting freezes the
+        // global `effective_from` watermark, which stops hot-block retention pruning
+        // fleet-wide and fills the hotblocks disk. Failed datasets are logged and skipped;
+        // they simply contribute no new chunks this run (their previously known chunks are
+        // retained) and recover automatically on a later run once the bucket is reachable.
+        let results: Vec<(Arc<String>, anyhow::Result<Vec<Chunk>>)> = stream::iter(datasets)
             .map(|(dataset, last_chunk)| {
                 let storage = DatasetStorage::new(self.client.clone(), dataset);
                 async move {
                     let chunks = storage
                         .list_new_chunks(last_chunk, CONCURRENT_CHUNKS, dataset_load_timeout)
-                        .await?;
-                    anyhow::Ok((storage.dataset, chunks))
+                        .await;
+                    (storage.dataset, chunks)
                 }
             })
             .buffer_unordered(concurrent_downloads)
-            .try_collect()
-            .await
+            .collect()
+            .await;
+
+        let mut new_chunks = BTreeMap::new();
+        for (dataset, result) in results {
+            match result {
+                Ok(chunks) => {
+                    new_chunks.insert(dataset, chunks);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        dataset = %dataset,
+                        error = ?e,
+                        "Failed to load chunks for dataset; skipping it for this run"
+                    );
+                }
+            }
+        }
+        Ok(new_chunks)
     }
 }
 


### PR DESCRIPTION
## Cause (proven)

On 2026-06-19, the mainnet hotblocks disk (`network-hotblocks-mainnet`, PVC `hotblocks-db-hotblocks-db-0`) filled from its normal ~550 GiB to 853 GiB / 100% full, deadlocking RocksDB (`No space left on device: While pwrite … .sst`) and firing `mainnet_hotblocks_storage`. The causal chain, newest cause → symptom:

1. The mainnet `cron-scheduler` (`secure-mainnet-control-plane`, GKE `main`) failed **every run from 16:01 UTC Jun 19 onward** with `Error: Can't load datasets → NoSuchBucket: The specified bucket does not exist.` (confirmed in Cloud Logging, severity≥ERROR, repeating 16:01→18:10 UTC and beyond).
2. Each failed run published **no assignment**, so the scheduler `status.json` `effective_from` / `assignment_timestamp_sec` watermark froze at ~14:0x UTC.
3. The `hotblocks-retain` sidecar only prunes up to `effective_from`. With it frozen it logged `effective_from unchanged` for ~16 h and pruned nothing → disk climbed monotonically to 100% → RocksDB could no longer compact → deadlock.

The trigger (one R2 bucket briefly returning `NoSuchBucket`) was external and self-healed: once the bucket was reachable again (~07:42 UTC Jun 20) the scheduler published an assignment, retention resumed (`applied retention policy` at 07:54 UTC), and the disk drained 853 → ~95 GiB. But the **blast radius is a code bug**: a single dataset's transient storage failure aborts the entire scheduler run and freezes retention for *all* datasets.

## Root code fault

`S3Storage::load_newer_chunks` (`src/storage.rs`) collected per-dataset results with `try_collect()`, which short-circuits on the **first** error. So one dataset's `NoSuchBucket` propagated up through `controller.rs` (`.context("Can't load datasets")?`) and aborted the whole run.

## Fix

Load each dataset independently and **skip** (log at `error` level) the ones that fail, returning the chunks from datasets that loaded successfully. The assignment is still published, so `effective_from` keeps advancing and retention keeps running fleet-wide. Skipped datasets contribute no *new* chunks for that run; their previously known chunks are retained (`controller.rs` extends existing chunks), and they recover automatically on a later run once the bucket is reachable. This mirrors the existing "degrade, don't panic" direction of #33 (replication back-off instead of panicking).

## Tested

- **Causal chain verified live**: scheduler ERROR logs (`Can't load datasets`/`NoSuchBucket`) align with the frozen `status.json` watermark and the retain `effective_from unchanged` loop; recovery of the bucket → assignment published → retention resumed → disk drained 853→95 GiB (Grafana `kubelet_volume_stats_used_bytes`).
- **Code change**: type-reviewed (`BTreeMap`/`Arc`/`Chunk`/`StreamExt` in scope; `TryStreamExt` still used by `list_new_chunks`). It could not be `cargo`-compiled in the investigation environment (no Rust toolchain available) — please rely on CI.

## Falsification

If, after this change, a single dataset's bucket goes missing and the scheduler **still** aborts the whole run (no assignment published, `effective_from` freezes), or if publishing an assignment while a dataset is skipped causes workers to drop that dataset's already-stored chunks, the fix is wrong. Expected behaviour: the failing dataset is logged + skipped, the run completes, and retention keeps advancing.

> Note: the underlying R2 bucket disappearance is a separate data/infra issue — an operator should still investigate which bucket vanished and why. This PR only ensures one missing bucket can no longer freeze the whole network.