### PR TITLE
chore: Update rust version to 1.94

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://www.lpalmieri.com/posts/fast-rust-docker-builds/#cargo-chef for explanation
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-1.89-slim-bookworm AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-1.94-slim-bookworm AS chef
 WORKDIR /app
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## What is this PR about?

Updates rust version to 1.94.0 