### PR TITLE
Add retries for "Failed to download chunk summary" (prevent crash loop)

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,6 +22,7 @@ lazy_static::lazy_static! {
 
     pub static ref S3_REQUESTS: Gauge = Default::default();
     pub static ref S3_KEYS_LISTED: Gauge = Default::default();
+    pub static ref S3_SUMMARY_DOWNLOAD_RETRIES: Gauge = Default::default();
 
     pub static ref ASSIGNMENT_JSON_SIZE: Gauge = Default::default();
     pub static ref ASSIGNMENT_COMPRESSED_JSON_SIZE: Gauge = Default::default();
@@ -165,6 +166,11 @@ pub fn register_metrics(network: String) -> Registry {
         "s3_keys_listed",
         "Number of S3 keys listed on the last execution",
         S3_KEYS_LISTED.clone(),
+    );
+    registry.register(
+        "s3_summary_download_retries",
+        "Number of chunk summary download retries on the last execution",
+        S3_SUMMARY_DOWNLOAD_RETRIES.clone(),
     );
     registry.register_with_unit(
         "assignment_json_size",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,6 +15,16 @@ use futures::{
 
 const CONCURRENT_CHUNKS: usize = 4;
 
+/// How many times to attempt downloading a chunk's summary before giving up.
+/// The S3 endpoint occasionally stalls mid-stream (the AWS SDK reports it as
+/// "throughput of 0 B/s was observed"), which is transient and usually clears
+/// on a retry. Without this, a single stall discards the whole run's progress
+/// for the dataset, so a large new dataset can fail to ever finish indexing.
+const SUMMARY_DOWNLOAD_ATTEMPTS: u32 = 5;
+
+/// Base delay for the exponential backoff between summary download attempts.
+const SUMMARY_RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
+
 #[derive(Clone)]
 pub struct S3Storage {
     client: s3::Client,
@@ -298,6 +308,28 @@ impl DatasetStorage {
     }
 
     async fn populate_with_summary(&self, data_chunk: &mut Chunk) -> anyhow::Result<()> {
+        let mut attempt = 1;
+        loop {
+            match self.try_populate_with_summary(data_chunk).await {
+                Ok(()) => return Ok(()),
+                Err(e) if attempt < SUMMARY_DOWNLOAD_ATTEMPTS => {
+                    let delay = SUMMARY_RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                    tracing::warn!(
+                        chunk = %data_chunk,
+                        attempt,
+                        error = ?e,
+                        "Failed to download chunk summary; retrying in {delay:?}",
+                    );
+                    metrics::S3_SUMMARY_DOWNLOAD_RETRIES.inc();
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    async fn try_populate_with_summary(&self, data_chunk: &mut Chunk) -> anyhow::Result<()> {
         let key = format!("{}/blocks.parquet", data_chunk.id);
         let temp_file = tempfile::tempfile()?;
         let mut tokio_file = tokio::fs::File::from_std(temp_file);


### PR DESCRIPTION
When trying to index TRON dataset chunks (100k+ chunks) on testnet, the scheduler kept crashing with errors like:
```
ERROR 2: minimum throughput was specified at 1 B/s, but throughput of 0 B/s was observed
ERROR 1: streaming error
ERROR 0: couldn't download chunk summary for s3://tron-mainnet-1/0013893150/0013964084-0013964538-c75338f4
```

Never allowing the cron job to finish, making scheduler stuck in a crash loop.
The retries should prevent this in case the error is just a temporary issue.