### PR TITLE
reshuffle-sim: model confirmation & portal catch-up lag (multistep)

### DIFF
--- a/tools/reshuffle_sim/README.md
+++ b/tools/reshuffle_sim/README.md
@@ -62,6 +62,8 @@ All fields are optional. `copy`/`replace` are lists, so a run can do several. Un
 | `upgrade_schedule` | — | `step:fraction` breakpoints for the share of upgraded workers. |
 | `initial_new_fraction` | `0.0` | Share of workers already on the new version at step 0. |
 | `lift_restriction_at_step` | — | Step at which the version restriction is dropped. |
+| `confirm_lag_steps` | `0` | Steps the fleet takes to download a published assignment before it counts as confirmed (multistep only). |
+| `portal_lag_steps` | `0` | Extra steps for the portal to route a confirmed assignment before its superseded copies may drain (multistep only). |
 | `copy` | — | List of `{ src, dst, at_step }` — see below. |
 | `replace` | — | List of `{ dataset, at_step }` — see below (multistep only). |
 
@@ -83,6 +85,33 @@ See `deploy/scenarios/` for ready-made profiles.
 - Multistep seeds the baseline and schedules it from empty, so step 1's reference is the scheduler's own placement, not the input file's; each step measures movement relative to the previous step.
 - Chunks are inserted one row per `INSERT`, so large inputs are slow against Postgres — prefer smaller `chunks_per_step` / `steps`.
 - The version-restriction and worker-upgrade modeling is config-driven (a dedicated restricted dataset carries a `minimum_worker_version`) and honored by **both** schedulers.
+
+## Confirmation and portal catch-up (multistep only)
+
+By default the simulation confirms each new assignment the instant it is published, so a superseded
+copy is cleared to drain the same step it was replaced — reshuffles look free. In production
+confirmation is not instant: workers download the new copies (confirmation), and the portal must
+route to them before the old copies are safe to remove. Both take time, during which the old and new
+copies coexist and occupy capacity.
+
+Two knobs model that lag as whole simulation steps. Both default to `0` (the confirm-immediately
+behaviour above), and both hold back the storage's confirmation watermark:
+
+- `confirm_lag_steps` — how long the fleet takes to download a published assignment. An assignment
+  published at step *S* counts as confirmed at step *S + confirm_lag_steps*.
+- `portal_lag_steps` — extra steps before the portal routes a confirmed assignment; a superseded
+  copy may only drain once its replacement clears both lags (`S + confirm_lag_steps +
+  portal_lag_steps`).
+
+While an assignment is unconfirmed its superseded copies keep occupying disk, so raising either lag
+inflates the `Stale (% cap)` and `used %` columns and can bring a capacity shortage forward — the
+transient overhang a fast ingest imposes on a slower fleet, which the zero-lag default hides.
+
+```yaml
+scheduler: multistep
+confirm_lag_steps: 3     # workers take 3 steps to download an assignment
+portal_lag_steps: 1      # portal routes it one step after that
+```
 
 ## Copying and replacing datasets
 

--- a/tools/reshuffle_sim/src/main.rs
+++ b/tools/reshuffle_sim/src/main.rs
@@ -213,6 +213,8 @@ fn main() -> anyhow::Result<()> {
             (run.restricted_fraction > 0.0).then(|| format!("s3://{}", run.restricted_dataset)),
             run.replaces,
             run.copies,
+            run.confirm_lag_steps,
+            run.portal_lag_steps,
             ingestion,
         )? {
             Some(scheduler) => Box::new(scheduler),
@@ -258,6 +260,12 @@ fn main() -> anyhow::Result<()> {
         "Worker version distribution: {}",
         util::format_version_distribution(simulation.workers())
     );
+    if run.scheduler == Scheduler::Multistep {
+        println!(
+            "Confirmation lag: {} worker step(s) + {} portal step(s) before superseded copies drain",
+            run.confirm_lag_steps, run.portal_lag_steps
+        );
+    }
 
     let all_metrics = simulation.run(|metrics| {
         if let Some(m) = metrics.last() {
@@ -289,6 +297,8 @@ struct RunConfig {
     upgrade_schedule: String,
     initial_new_fraction: f64,
     lift_restriction_at_step: Option<u32>,
+    confirm_lag_steps: u32,
+    portal_lag_steps: u32,
     copies: Vec<CopyPlan>,
     replaces: Vec<ReplacePlan>,
 }
@@ -328,6 +338,8 @@ impl RunConfig {
             upgrade_schedule: p.upgrade_schedule.unwrap_or_default(),
             initial_new_fraction: p.initial_new_fraction.unwrap_or(0.0),
             lift_restriction_at_step: p.lift_restriction_at_step,
+            confirm_lag_steps: p.confirm_lag_steps.unwrap_or(0),
+            portal_lag_steps: p.portal_lag_steps.unwrap_or(0),
             copies,
             replaces,
         };
@@ -365,6 +377,12 @@ impl RunConfig {
         anyhow::ensure!(
             self.replaces.is_empty() || self.scheduler == Scheduler::Multistep,
             "replace requires the multistep scheduler"
+        );
+        anyhow::ensure!(
+            (self.confirm_lag_steps == 0 && self.portal_lag_steps == 0)
+                || self.scheduler == Scheduler::Multistep,
+            "confirm_lag_steps/portal_lag_steps require the multistep scheduler (the stateless \
+             path rebuilds the placement each step and has no confirmation watermark)"
         );
         for r in &self.replaces {
             anyhow::ensure!(

--- a/tools/reshuffle_sim/src/multistep.rs
+++ b/tools/reshuffle_sim/src/multistep.rs
@@ -14,8 +14,8 @@ use network_scheduler::{
     cli::{Config, DatasetsConfig},
     multistep_scheduler::SchedulingConfig as MultistepConfig,
     scheduler_storage::{
-        ChunkPk, NewChunk, SchedulerStorage, StorageError, WorkerAssignment, WorkerAssignmentChunk,
-        WorkerPk,
+        AssignmentId, ChunkPk, NewChunk, SchedulerStorage, StorageError, WorkerAssignment,
+        WorkerAssignmentChunk, WorkerPk,
         algorithm::MultistepAlgorithm,
         postgres::PostgresStorage,
         test_harness::pg_harness::{self, PgData},
@@ -102,6 +102,14 @@ pub struct MultistepScheduler {
     initial_owners: ChunkOwners,
     replace: Vec<ReplacePlan>,
     copy: Vec<CopyPlan>,
+    /// Cycles a published assignment waits before the fleet has downloaded it (uniform latency).
+    confirm_lag_steps: u32,
+    /// Extra cycles before the portal routes a confirmed assignment, gating when its superseded
+    /// copies may drain.
+    portal_lag_steps: u32,
+    /// Worker-assignment ids in publication order (index 0 = baseline). The confirmation watermark
+    /// trails the newest publication by `confirm_lag_steps + portal_lag_steps` entries.
+    published_ids: Vec<AssignmentId>,
     /// 1-based step counter, advanced once per `step`.
     current_step: u32,
     /// Placed chunks of datasets still awaiting a replace — a same-cycle replace reads its target's
@@ -115,6 +123,7 @@ pub struct MultistepScheduler {
 }
 
 impl MultistepScheduler {
+    #[allow(clippy::too_many_arguments)]
     pub fn build(
         config: &Config,
         baseline: &mut Baseline,
@@ -122,6 +131,8 @@ impl MultistepScheduler {
         restricted_dataset: Option<String>,
         replace: Vec<ReplacePlan>,
         copy: Vec<CopyPlan>,
+        confirm_lag_steps: u32,
+        portal_lag_steps: u32,
         ingestion: Ingestion,
     ) -> anyhow::Result<Option<Self>> {
         let mut backend = match database_url {
@@ -203,6 +214,9 @@ impl MultistepScheduler {
             initial_owners: ChunkOwners::new(),
             replace,
             copy,
+            confirm_lag_steps,
+            portal_lag_steps,
+            published_ids: Vec::new(),
             current_step: 0,
             latest_chunks: BTreeMap::new(),
             worker_index: WorkerIndex::default(),
@@ -238,31 +252,47 @@ impl MultistepScheduler {
     }
 
     /// Run one scheduling cycle. Advances the clock by the removal delay (so earlier steps' removed
-    /// copies age out), then confirms the assignment fleet-wide and runs visibility, so the copies
-    /// it replaces start their removal timer.
+    /// copies age out), then confirms the fleet up to the lagged watermark and runs visibility, so
+    /// only assignments the fleet+portal have caught up to let their superseded copies drain.
     fn run_cycle(&mut self) -> anyhow::Result<CycleResult> {
-        let storage = &mut self.backend.storage;
         self.clock += M_TICKS;
         let started = Instant::now();
-        let assignment =
-            match storage.run_scheduling_cycle(&self.algo, &self.config, self.clock, M_TICKS) {
-                Ok(assignment) => assignment,
-                Err(StorageError::Shortage) => {
-                    return Ok(CycleResult::Shortage(
+        let assignment = match self.backend.storage.run_scheduling_cycle(
+            &self.algo,
+            &self.config,
+            self.clock,
+            M_TICKS,
+        ) {
+            Ok(assignment) => assignment,
+            Err(StorageError::Shortage) => {
+                return Ok(CycleResult::Shortage(
                     "scheduling shortage: worker capacity cannot satisfy all replication floors \
                      (lower min_replication, raise worker_storage_bytes, or add workers)"
                         .to_string(),
                 ));
-                }
-                Err(e) => return Err(anyhow!("scheduling cycle failed: {e}")),
-            };
+            }
+            Err(e) => return Err(anyhow!("scheduling cycle failed: {e}")),
+        };
         let schedule_duration = started.elapsed();
         // Before confirm/visibility expire or drain stale, so the snapshot matches `assignment`.
-        let stale = storage.stale_mappings()?;
+        let stale = self.backend.storage.stale_mappings()?;
         self.clock += CLOCK_STEP;
-        storage.confirm_worker_assignment(assignment.id, self.clock)?;
-        storage.run_visibility_cycle(self.clock)?;
+        // Confirm only up to the lagged watermark: the copies this cycle superseded keep occupying
+        // capacity until the assignment that replaced them clears both lags. Both lags 0 confirms
+        // the just-published assignment — the previous confirm-immediately behaviour.
+        self.published_ids.push(assignment.id);
+        let watermark = self.confirmation_watermark();
+        self.backend
+            .storage
+            .confirm_worker_assignment(watermark, self.clock)?;
+        self.backend.storage.run_visibility_cycle(self.clock)?;
         Ok(CycleResult::Scheduled(assignment, stale, schedule_duration))
+    }
+
+    /// The publication `confirm_lag_steps + portal_lag_steps` cycles back.
+    fn confirmation_watermark(&self) -> AssignmentId {
+        let lag = (self.confirm_lag_steps + self.portal_lag_steps) as usize;
+        lagged_watermark(&self.published_ids, lag)
     }
 
     /// Supersede every chunk of `bucket` with a same-range correction, sourced from `latest_chunks`
@@ -417,6 +447,12 @@ impl StepScheduler for MultistepScheduler {
     }
 }
 
+/// The id `lag` publications before the newest, clamped to the baseline (index 0).
+fn lagged_watermark(published_ids: &[AssignmentId], lag: usize) -> AssignmentId {
+    let latest = published_ids.len() - 1;
+    published_ids[latest.saturating_sub(lag)]
+}
+
 fn log_table_sizes(storage: &PostgresStorage) {
     if !tracing::enabled!(tracing::Level::DEBUG) {
         return;
@@ -524,6 +560,25 @@ mod tests {
                 status: WorkerStatus::Online,
             },
         )
+    }
+
+    #[test]
+    fn lagged_watermark_trails_publications_and_clamps_to_baseline() {
+        // Publication history: baseline (id 10), then steps publishing 11, 12, 13.
+        let ids = [10, 11, 12, 13];
+
+        // Zero lag confirms the newest publication immediately (the prior behaviour).
+        assert_eq!(lagged_watermark(&ids, 0), 13);
+        // Lag 1/2 trail by that many publications.
+        assert_eq!(lagged_watermark(&ids, 1), 12);
+        assert_eq!(lagged_watermark(&ids, 2), 11);
+        // A lag past the start clamps to the baseline, never underflows.
+        assert_eq!(lagged_watermark(&ids, 3), 10);
+        assert_eq!(lagged_watermark(&ids, 99), 10);
+
+        // Early in the run only the baseline exists, so every lag resolves to it.
+        assert_eq!(lagged_watermark(&[10], 0), 10);
+        assert_eq!(lagged_watermark(&[10], 5), 10);
     }
 
     #[test]

--- a/tools/reshuffle_sim/src/profile.rs
+++ b/tools/reshuffle_sim/src/profile.rs
@@ -26,6 +26,8 @@ pub(crate) struct Profile {
     pub(crate) upgrade_schedule: Option<String>,
     pub(crate) initial_new_fraction: Option<f64>,
     pub(crate) lift_restriction_at_step: Option<u32>,
+    pub(crate) confirm_lag_steps: Option<u32>,
+    pub(crate) portal_lag_steps: Option<u32>,
     #[serde(default)]
     pub(crate) copy: Vec<CopyEntry>,
     #[serde(default)]


### PR DESCRIPTION
## What is this PR about?

stacked on top of https://github.com/subsquid/network-scheduler/pull/46

The reshuffle-sim's multistep path confirmed every assignment the instant it published it, so a superseded copy was cleared to drain the same step it was replaced — reshuffles looked free. That's the "0 confirmation percent" case: the scheduler never waits for workers to download the new copies, nor for the portal to route to them, before removing the old ones. In production both take time, during which old and new copies coexist and occupy capacity.

This adds two knobs (multistep only) that model that lag as whole simulation steps by holding back the storage's monotonic confirmation watermark:

* confirm_lag_steps — steps the fleet takes to download a published assignment.
* portal_lag_steps — extra steps for the portal to route a confirmed assignment before its superseded copies may drain.

run_cycle now records each publication in order and confirms only the id confirm_lag_steps + portal_lag_steps cycles back (clamped to the baseline), instead of pinning the watermark to the newest assignment. Everything else — stale accumulation, drains, capacity — falls out of the existing MVCC storage, which already handles delayed confirmation (that's what the property tests exercise).

Both knobs default to 0, which confirms the just-published assignment — the previous confirm-immediately behaviour, byte-identical. The overhang surfaces in the existing Stale (% cap) / used % columns, so no report plumbing changed. The stateless path has no watermark, so the knobs are validated as multistep-only.
