### PR TITLE
feat: Wire the multistep (MVCC) scheduler behind --multistep-scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,6 +2974,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "futures",
+ "humantime",
  "itertools 0.14.0",
  "lazy_static",
  "libp2p-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 [features]
 default = []
 # The MVCC chunk-lifecycle storage / multi-step scheduler (Postgres backend + sim tests).
-mvcc-chunks = ["dep:sqlx", "dep:bit-vec", "sqd-assignments/mvcc-chunks"]
+mvcc-chunks = ["dep:sqlx", "dep:bit-vec", "dep:humantime", "sqd-assignments/mvcc-chunks"]
 # Exposes the Postgres testcontainer harness (`scheduler_storage::test_harness::pg_harness`) to other
 # crates — e.g. reshuffle-sim. Implies the Postgres backend. The crate's own tests get the harness via
 # `cfg(test)` + dev-dependencies, so they don't need this feature.
@@ -28,6 +28,7 @@ dotenv = "0.15.0"
 flatbuffers = "25.2.10"
 flate2 = "1.1.1"
 futures = "0.3.31"
+humantime = { version = "2.1", optional = true }
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 libp2p-identity = { version = "0.2.10", features = ["peerid", "rand", "serde"] }
@@ -39,7 +40,7 @@ rand = "0.9.1"
 rayon = "1.10.0"
 seahash = "4.1.0"
 semver = { version = "1.0.26", features = ["serde"] }
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
 serde_with = "3.12.0"
 serde_yaml = "0.9.34"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,49 @@ pub struct Args {
     /// Path to CLI mode state file containing workers and known chunks (required for cli mode)
     #[arg(long, env = "CLI_STATE_FILE", required_if_eq("mode", "cli"))]
     pub cli_state_file: Option<PathBuf>,
+
+    /// Run the multistep (MVCC) scheduling cycle instead of the ordinary scheduler.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long)]
+    pub multistep_scheduler: bool,
+
+    /// Postgres connection string for the multistep scheduler's storage backend.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(
+        long,
+        env = "DATABASE_URL",
+        required_if_eq("multistep_scheduler", "true")
+    )]
+    pub database_url: Option<String>,
+
+    /// Multistep drain window (the MVCC "M"): how long a dropped `(chunk, worker)` pair keeps being
+    /// served after leaving the portal assignment.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_DRAIN_WINDOW", default_value = "5m", value_parser = humantime::parse_duration)]
+    pub multistep_drain_window: Duration,
+
+    /// Multistep departed-worker retention: a worker inactive for longer than this is deleted from
+    /// the scheduler's worker set. Must exceed the drain window.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_WORKER_GC", default_value = "24h", value_parser = humantime::parse_duration)]
+    pub multistep_worker_gc: Duration,
+}
+
+impl Args {
+    /// Validate cross-argument invariants clap can't express declaratively.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        // A worker must be retained at least until its dropped pairs finish draining.
+        #[cfg(feature = "mvcc-chunks")]
+        if self.multistep_scheduler {
+            ensure!(
+                self.multistep_worker_gc > self.multistep_drain_window,
+                "--multistep-worker-gc ({:?}) must exceed --multistep-drain-window ({:?})",
+                self.multistep_worker_gc,
+                self.multistep_drain_window,
+            );
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,27 +62,10 @@ pub struct Args {
     pub multistep_drain_window: Duration,
 
     /// Multistep departed-worker retention: a worker inactive for longer than this is deleted from
-    /// the scheduler's worker set. Must exceed the drain window.
+    /// the scheduler's worker set.
     #[cfg(feature = "mvcc-chunks")]
     #[arg(long, env = "MULTISTEP_WORKER_GC", default_value = "24h", value_parser = humantime::parse_duration)]
     pub multistep_worker_gc: Duration,
-}
-
-impl Args {
-    /// Validate cross-argument invariants clap can't express declaratively.
-    pub fn validate(&self) -> anyhow::Result<()> {
-        // A worker must be retained at least until its dropped pairs finish draining.
-        #[cfg(feature = "mvcc-chunks")]
-        if self.multistep_scheduler {
-            ensure!(
-                self.multistep_worker_gc > self.multistep_drain_window,
-                "--multistep-worker-gc ({:?}) must exceed --multistep-drain-window ({:?})",
-                self.multistep_worker_gc,
-                self.multistep_drain_window,
-            );
-        }
-        Ok(())
-    }
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, str::FromStr, sync::Arc, time::Duration};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clickhouse::{Client, Row};
 use itertools::Itertools;
 use semver::Version;
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::{
-    cli::ClickhouseArgs,
+    cli::{ClickhouseArgs, Config},
     pool,
     types::{Chunk, ChunkSummary, Worker, WorkerStatus},
 };
@@ -112,6 +112,18 @@ impl ClickhouseClient {
 
         crate::metrics::report_workers(&results);
         Ok(results)
+    }
+
+    /// Active worker set, taking the thresholds from `config`. Shared by the ordinary and
+    /// multistep paths.
+    pub async fn active_workers(&self, config: &Config) -> Result<Vec<Worker>> {
+        self.get_active_workers(
+            config.worker_inactive_timeout,
+            config.worker_stale_bytes,
+            &config.min_supported_worker_version,
+        )
+        .await
+        .context("Can't read active workers from ClickHouse")
     }
 
     #[instrument(skip_all)]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -23,14 +23,7 @@ impl Controller {
         self,
         db: &clickhouse::ClickhouseClient,
     ) -> anyhow::Result<WithWorkers> {
-        let workers = db
-            .get_active_workers(
-                self.config.worker_inactive_timeout,
-                self.config.worker_stale_bytes,
-                &self.config.min_supported_worker_version,
-            )
-            .await
-            .context("Can't read active workers from ClickHouse")?;
+        let workers = db.active_workers(&self.config).await?;
 
         tracing::info!("Found {} workers", workers.len());
 
@@ -153,18 +146,20 @@ impl WithChunks {
     ) -> anyhow::Result<Self> {
         tracing::info!("Reading new chunks from storage");
 
-        let last_chunks = self
-            .datasets
-            .iter()
-            .map(|dataset| {
-                let last = self.chunks.get(dataset).and_then(|chunks| chunks.last());
-                (dataset.clone(), last)
-            })
-            .collect::<BTreeMap<_, _>>();
+        let watermarks = self.datasets.iter().map(|dataset| {
+            let last = self.chunks.get(dataset).and_then(|chunks| chunks.last());
+            types::DatasetWatermark {
+                dataset: types::Dataset {
+                    id: dataset.clone(),
+                    height: last.map(|c| *c.blocks.end()),
+                },
+                last_chunk_id: last.map(|c| c.id.clone()),
+            }
+        });
 
         let new_chunks = datasets_storage
             .load_newer_chunks(
-                last_chunks,
+                watermarks,
                 self.config.concurrent_dataset_downloads,
                 self.config.dataset_load_timeout,
             )
@@ -207,7 +202,7 @@ impl WithChunks {
 
             let height = chunks.last().map(|c| *c.blocks.end());
             datasets.push(types::Dataset {
-                id: dataset_name.to_string(),
+                id: dataset_name.clone(),
                 height,
             });
 

--- a/src/dataset_data_storage.rs
+++ b/src/dataset_data_storage.rs
@@ -7,13 +7,21 @@ use tokio::io::AsyncSeekExt;
 use tracing::instrument;
 
 use crate::metrics;
-use crate::types::Chunk;
+use crate::types::{BlockNumber, Chunk, ChunkId, DatasetWatermark};
 use futures::{
     TryStreamExt,
     stream::{self, StreamExt},
 };
 
 const CONCURRENT_CHUNKS: usize = 4;
+
+/// S3 `start_after` key that resumes listing right after `chunk_id`'s objects. A chunk's files all
+/// live under `{chunk_id}/`; bumping that prefix's trailing `/` (0x2F) to `0` (0x30) yields the
+/// smallest key greater than every `{chunk_id}/…` file, yet still below the next chunk's `{id}/…`
+/// (ids differ earlier, in the zero-padded block numbers). So only the id is needed — not the files.
+fn resume_after(chunk_id: &str) -> String {
+    format!("{chunk_id}0")
+}
 
 /// How many times to attempt downloading a chunk's summary before giving up.
 /// The S3 endpoint occasionally stalls mid-stream (the AWS SDK reports it as
@@ -42,7 +50,7 @@ impl S3Storage {
 
     pub async fn load_newer_chunks(
         &self,
-        datasets: impl IntoIterator<Item = (Arc<String>, Option<&Chunk>)>,
+        datasets: impl IntoIterator<Item = DatasetWatermark>,
         concurrent_downloads: usize,
         dataset_load_timeout: Option<Duration>,
     ) -> anyhow::Result<BTreeMap<Arc<String>, Vec<Chunk>>> {
@@ -50,11 +58,17 @@ impl S3Storage {
         // Log and skip datasets that fail to load instead of aborting: one unreachable bucket
         // must not freeze updates for all datasets.
         let result = stream::iter(datasets)
-            .map(|(dataset, last_chunk)| {
-                let storage = DatasetStorage::new(self.client.clone(), dataset);
+            .map(|watermark| {
+                let DatasetWatermark {
+                    dataset,
+                    last_chunk_id,
+                } = watermark;
+                let last_block = dataset.height;
+                let storage = DatasetStorage::new(self.client.clone(), dataset.id);
                 async move {
+                    let resume = last_block.zip(last_chunk_id.as_ref());
                     let chunks = storage
-                        .list_new_chunks(last_chunk, CONCURRENT_CHUNKS, dataset_load_timeout)
+                        .list_new_chunks(resume, CONCURRENT_CHUNKS, dataset_load_timeout)
                         .await;
                     (storage.dataset, chunks)
                 }
@@ -101,11 +115,10 @@ impl ChunkStream {
         client: s3::Client,
         dataset: Arc<String>,
         bucket: String,
-        last_chunk: Option<&Chunk>,
+        resume: Option<(BlockNumber, &ChunkId)>,
     ) -> Self {
-        let next_expected_block = last_chunk.as_ref().map(|chunk| chunk.blocks.end() + 1);
-        let last_key =
-            last_chunk.map(|chunk| format!("{}/{}", chunk.id, chunk.files.iter().max().unwrap()));
+        let next_expected_block = resume.map(|(block, _)| block + 1);
+        let last_key = resume.map(|(_, id)| resume_after(id));
 
         Self {
             client,
@@ -260,7 +273,7 @@ impl DatasetStorage {
     #[instrument(skip_all, level = "debug", fields(dataset = %self.dataset))]
     pub async fn list_new_chunks(
         &self,
-        last_chunk: Option<&Chunk>,
+        resume: Option<(BlockNumber, &ChunkId)>,
         concurrent_downloads: usize,
         dataset_load_timeout: Option<Duration>,
     ) -> anyhow::Result<Vec<Chunk>> {
@@ -271,7 +284,7 @@ impl DatasetStorage {
             self.client.clone(),
             self.dataset.clone(),
             self.bucket().to_string(),
-            last_chunk,
+            resume,
         );
         let mut chunks = Vec::new();
 
@@ -459,5 +472,21 @@ mod test {
         );
 
         assert_eq!(expected, have);
+    }
+
+    #[test]
+    fn resume_after_skips_chunk_and_precedes_next() {
+        let id = "0018197829/0018246541-0018248424-c7ed95c9";
+        let next = "0018197829/0018248425-0018250000-deadbeef";
+        let start = resume_after(id);
+        // Greater than every file of the chunk, even a high-sorting name.
+        for file in ["blocks.parquet", "transactions.parquet", "~~~.parquet"] {
+            assert!(
+                start.as_str() > format!("{id}/{file}").as_str(),
+                "must skip {file}"
+            );
+        }
+        // Still below the next chunk's objects, so listing resumes exactly at it.
+        assert!(start.as_str() < format!("{next}/blocks.parquet").as_str());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod controller;
 pub mod dataset_data_storage;
 pub mod metrics;
 #[cfg(feature = "mvcc-chunks")]
+pub mod multistep_controller;
+#[cfg(feature = "mvcc-chunks")]
 pub mod multistep_scheduler;
 pub mod parquet;
 pub mod pool;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,41 +11,37 @@ async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
     let args = cli::Args::parse();
     setup_tracing(&args);
+    args.validate()?;
     let config = cli::Config::load(&args.config).context("Can't parse config")?;
     tracing::info!(
         "Scheduler configuration:\n{}",
         serde_yaml::to_string(&config)
             .unwrap_or_else(|e| format!("<failed to serialize config: {e}>"))
     );
-    let metrics_registry = metrics::register_metrics(config.network.clone());
 
-    let controller = match args.mode {
-        cli::RunMode::Prod => run_prod_mode(&args, config.clone()).await?,
-        cli::RunMode::Cli => run_cli_mode(&args, config.clone()).await?,
-    };
-
-    let uploader = upload::Uploader::new(config, &args.s3.config().await);
-    #[cfg(not(feature = "mvcc-chunks"))]
-    controller.serialize_assignment().upload(&uploader).await?;
-    #[cfg(feature = "mvcc-chunks")]
-    controller.serialize_assignments().upload(&uploader).await?;
-
-    drop(_timer);
-    let metrics = metrics::encode_metrics(&metrics_registry)?;
-    controller.upload_metadata(&uploader, metrics).await?;
+    match args.mode {
+        cli::RunMode::Prod => run_prod_mode(&args, config).await?,
+        cli::RunMode::Cli => run_cli_mode(&args, config).await?,
+    }
 
     tracing::info!("Done");
     Ok(())
 }
 
-async fn run_prod_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<WithAssignment> {
+async fn run_prod_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<()> {
     let db = network_scheduler::clickhouse::ClickhouseClient::new(&args.clickhouse)
         .await
         .context("Can't connect to ClickHouse")?;
 
+    #[cfg(feature = "mvcc-chunks")]
+    if args.multistep_scheduler {
+        let workers = db.active_workers(&config).await?;
+        return network_scheduler::multistep_controller::run(args, &config, workers).await;
+    }
+
     let datasets_storage = dataset_data_storage::S3Storage::new(&args.s3.config().await);
 
-    Controller::new(config.clone())
+    let controller = Controller::new(config.clone())
         .load_workers(&db)
         .await?
         .load_known_chunks(&db)
@@ -54,10 +50,12 @@ async fn run_prod_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<
         .await?
         .prepare_chunks()
         // blocking the async executor is ok here because no other tasks are running
-        .schedule()
+        .schedule()?;
+
+    publish_assignments(args, config, controller).await
 }
 
-async fn run_cli_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<WithAssignment> {
+async fn run_cli_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<()> {
     let state_file = args
         .cli_state_file
         .as_ref()
@@ -65,6 +63,12 @@ async fn run_cli_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<W
 
     let cli_state = network_scheduler::cli_state::CliState::load(state_file)
         .context("Failed to load CLI state file")?;
+
+    #[cfg(feature = "mvcc-chunks")]
+    if args.multistep_scheduler {
+        return network_scheduler::multistep_controller::run(args, &config, cli_state.workers)
+            .await;
+    }
 
     let known_chunks = cli_state.to_chunks()?;
     let workers = cli_state.workers;
@@ -77,14 +81,36 @@ async fn run_cli_mode(args: &cli::Args, config: cli::Config) -> anyhow::Result<W
 
     let datasets_storage = dataset_data_storage::S3Storage::new(&args.s3.config().await);
 
-    Controller::new(config.clone())
+    let controller = Controller::new(config.clone())
         .load_workers_from_config(workers)
         .load_known_chunks_from_config(known_chunks)?
         .load_new_chunks(None, &datasets_storage, CacheAccess::_ReadOnly)
         .await?
         .prepare_chunks()
         // blocking the async executor is ok here because no other tasks are running
-        .schedule()
+        .schedule()?;
+
+    publish_assignments(args, config, controller).await
+}
+
+/// Serialize and upload the scheduled assignment, then the worker/dataset status and metrics.
+async fn publish_assignments(
+    args: &cli::Args,
+    config: cli::Config,
+    controller: WithAssignment,
+) -> anyhow::Result<()> {
+    let metrics_registry = metrics::register_metrics(config.network.clone());
+    let uploader = upload::Uploader::new(config, &args.s3.config().await);
+
+    #[cfg(not(feature = "mvcc-chunks"))]
+    controller.serialize_assignment().upload(&uploader).await?;
+    #[cfg(feature = "mvcc-chunks")]
+    controller.serialize_assignments().upload(&uploader).await?;
+
+    let metrics = metrics::encode_metrics(&metrics_registry)?;
+    controller.upload_metadata(&uploader, metrics).await?;
+
+    Ok(())
 }
 
 fn setup_tracing(_args: &cli::Args) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
     let args = cli::Args::parse();
     setup_tracing(&args);
-    args.validate()?;
     let config = cli::Config::load(&args.config).context("Can't parse config")?;
     tracing::info!(
         "Scheduler configuration:\n{}",

--- a/src/multistep_controller.rs
+++ b/src/multistep_controller.rs
@@ -159,6 +159,8 @@ fn register_chunks(
     Ok(())
 }
 
+/// This path's clock: a tick is one wall-clock unix second (elsewhere, e.g. the sim, it's an
+/// abstract counter), which is why the drain-window and worker-GC durations convert via `as_secs`.
 fn now_ticks() -> Tick {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/multistep_controller.rs
+++ b/src/multistep_controller.rs
@@ -1,0 +1,167 @@
+//! Multistep (MVCC) scheduling entry point (requires the `mvcc-chunks` feature): runs one
+//! scheduling cycle against Postgres instead of the ordinary `Controller` pipeline.
+//!
+//! Only [`SchedulerStorage::run_scheduling_cycle`] runs — no confirmation or visibility cycle yet
+//! (see `docs/README.md`). The resulting assignment is only computed and logged, not published.
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+    time::SystemTime,
+};
+
+use anyhow::Context;
+
+use crate::{
+    cli, dataset_data_storage, metrics,
+    scheduler_storage::{
+        NewChunk, SchedulerStorage, Tick, algorithm::MultistepAlgorithm, postgres::PostgresStorage,
+    },
+    types::{Chunk, Dataset, DatasetSchema, DatasetWatermark, Worker},
+};
+
+/// Runs one multistep scheduling cycle; the resulting `WorkerAssignment` is only computed and
+/// logged, not published. `workers` is the active set the caller already loaded for the run mode.
+pub async fn run(
+    args: &cli::Args,
+    config: &cli::Config,
+    workers: Vec<Worker>,
+) -> anyhow::Result<()> {
+    let database_url = args
+        .database_url
+        .as_deref()
+        .context("--database-url is required with --multistep-scheduler")?;
+
+    tracing::info!("Multistep: scheduling for {} workers", workers.len());
+
+    let mut storage = PostgresStorage::connect(database_url).context("connect to Postgres")?;
+    storage.migrate().context("run Postgres migrations")?;
+
+    let watermarks = bootstrap_datasets(&mut storage, config)?;
+
+    let s3_storage = dataset_data_storage::S3Storage::new(&args.s3.config().await);
+    let discovered = s3_storage
+        .load_newer_chunks(
+            watermarks,
+            config.concurrent_dataset_downloads,
+            config.dataset_load_timeout,
+        )
+        .await
+        .context("load datasets from S3")?;
+    tracing::info!(
+        "Multistep: discovered {} new chunks across {} datasets",
+        discovered.values().map(Vec::len).sum::<usize>(),
+        discovered.len(),
+    );
+
+    register_chunks(&mut storage, discovered)?;
+
+    let now = now_ticks();
+    storage
+        .update_worker_set(&workers, now, args.multistep_worker_gc.as_secs())
+        .context("update worker set")?;
+
+    let algorithm = MultistepAlgorithm::new(config.datasets.clone());
+    let multistep_config = crate::multistep_scheduler::SchedulingConfig {
+        worker_capacity: config.worker_storage_bytes,
+        saturation: config.saturation,
+        min_replication: config.min_replication,
+        ignore_reliability: config.ignore_reliability,
+    };
+    let assignment = {
+        let _timer = metrics::Timer::new("multistep:schedule");
+        storage
+            .run_scheduling_cycle(
+                &algorithm,
+                &multistep_config,
+                now,
+                args.multistep_drain_window.as_secs(),
+            )
+            .context("run multistep scheduling cycle")?
+    };
+
+    tracing::info!(
+        "Multistep scheduling cycle done: assignment {}, {} chunks placed, replication_by_weight={:?}",
+        assignment.id,
+        assignment.chunk_workers.len(),
+        assignment.replication_by_weight,
+    );
+
+    Ok(())
+}
+
+/// Ensure every configured dataset exists, returning the discovery watermark for every known
+/// dataset.
+///
+/// FIXME: temporary cold-start bootstrap — a missing dataset is created on the fly with an empty
+/// schema. Real provisioning (dataset + its read schema) should happen out of band.
+fn bootstrap_datasets(
+    storage: &mut PostgresStorage,
+    config: &cli::Config,
+) -> anyhow::Result<Vec<DatasetWatermark>> {
+    let _timer = metrics::Timer::new("multistep:bootstrap");
+    let mut watermarks = storage.datasets_with_last_chunk()?;
+    let missing: Vec<String> = {
+        let existing: HashSet<&str> = watermarks.iter().map(|w| w.dataset.id.as_str()).collect();
+        config
+            .datasets
+            .keys()
+            .map(|bucket| format!("s3://{bucket}"))
+            .filter(|name| !existing.contains(name.as_str()))
+            .collect()
+    };
+    for name in missing {
+        storage
+            .insert_new_datasets(vec![(name.clone(), DatasetSchema::default())])
+            .with_context(|| format!("bootstrap dataset {name}"))?;
+        watermarks.push(DatasetWatermark {
+            dataset: Dataset {
+                id: Arc::new(name),
+                height: None,
+            },
+            last_chunk_id: None,
+        });
+    }
+    Ok(watermarks)
+}
+
+/// Insert the freshly discovered chunks (all genuinely new — discovery resumes past what Postgres
+/// already holds) and register them for scheduling.
+fn register_chunks(
+    storage: &mut PostgresStorage,
+    discovered: BTreeMap<Arc<String>, Vec<Chunk>>,
+) -> anyhow::Result<()> {
+    let _timer = metrics::Timer::new("multistep:register_chunks");
+    for (dataset, chunks) in discovered {
+        if chunks.is_empty() {
+            continue;
+        }
+        // Move fields out instead of cloning; a dataset can hold millions of chunks.
+        let new_chunks: Vec<NewChunk> = chunks
+            .into_iter()
+            .map(|c| NewChunk {
+                dataset: c.dataset,
+                id: c.id,
+                size: c.size,
+                blocks: c.blocks,
+                schema_id: None,
+                tables_present: None,
+            })
+            .collect();
+        storage
+            .insert_new_chunks(new_chunks)
+            .with_context(|| format!("insert new chunks for {dataset}"))?;
+    }
+
+    storage
+        .register_new_chunks()
+        .context("register new chunks")?;
+    Ok(())
+}
+
+fn now_ticks() -> Tick {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs()
+}

--- a/src/scheduler_storage/ids.rs
+++ b/src/scheduler_storage/ids.rs
@@ -16,7 +16,7 @@ pub struct WorkerPk(pub i64);
 /// Primary key of a dataset row.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, sqlx::Type)]
 #[sqlx(transparent)]
-pub struct DatasetId(pub i16);
+pub struct DatasetPk(pub i16);
 
 /// Primary key of a schema row (`schemas.id`, a 32-bit `SERIAL`).
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, sqlx::Type)]
@@ -35,7 +35,7 @@ impl std::fmt::Display for WorkerPk {
     }
 }
 
-impl std::fmt::Display for DatasetId {
+impl std::fmt::Display for DatasetPk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use crate::types::{BlockNumber, DatasetSchema, Worker};
+use crate::types::{BlockNumber, ChunkId, DatasetId, DatasetSchema, Worker};
 use crate::weight::SchedulingChunk;
 
 /// Logical integer timestamp; the caller supplies the clock (test ticks, or a monotonic clock
@@ -47,7 +47,7 @@ impl From<anyhow::Error> for StorageError {
 
 pub mod algorithm;
 pub mod ids;
-pub use ids::{ChunkPk, DatasetId, SchemaId, WorkerPk};
+pub use ids::{ChunkPk, DatasetPk, SchemaId, WorkerPk};
 #[cfg(test)]
 pub(crate) mod in_memory;
 pub mod postgres;
@@ -58,8 +58,8 @@ pub mod test_harness;
 /// The scheduling algorithms' input view of a chunk.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AlgoChunk {
-    pub dataset: Arc<String>,
-    pub id: Arc<String>,
+    pub dataset: DatasetId,
+    pub id: ChunkId,
     pub size: u32,
     pub blocks: RangeInclusive<BlockNumber>,
 }
@@ -82,8 +82,8 @@ impl SchedulingChunk for AlgoChunk {
 /// A chunk to insert ([`SchedulerStorage::insert_new_chunks`] / corrections).
 #[derive(Debug, Clone, PartialEq)]
 pub struct NewChunk {
-    pub dataset: Arc<String>,
-    pub id: Arc<String>,
+    pub dataset: DatasetId,
+    pub id: ChunkId,
     pub size: u32,
     pub blocks: RangeInclusive<BlockNumber>,
     /// `None` = stamp with the dataset's current schema.
@@ -96,8 +96,8 @@ pub struct NewChunk {
 /// (`schema_id` + `tables_present`) at assignment construction.
 #[derive(Debug, Clone, PartialEq)]
 pub struct WorkerAssignmentChunk {
-    pub dataset: Arc<String>,
-    pub id: Arc<String>,
+    pub dataset: DatasetId,
+    pub id: ChunkId,
     pub size: u32,
     pub blocks: RangeInclusive<BlockNumber>,
     /// The schema the chunk was written under (stamped at insert).

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -35,10 +35,10 @@ use sqlx::postgres::PgConnection;
 use crate::metrics::{PhaseTimer, Timer};
 use crate::scheduler_storage::algorithm::{ScheduleOutput, SchedulingAlgorithm};
 use crate::scheduler_storage::{
-    AssignmentId, ChunkPk, DatasetId, NewChunk, PortalAssignment, SchedulerStorage, StorageError,
+    AssignmentId, ChunkPk, DatasetPk, NewChunk, PortalAssignment, SchedulerStorage, StorageError,
     Tick, WorkerAssignment,
 };
-use crate::types::{DatasetSchema, Worker};
+use crate::types::{Dataset, DatasetSchema, DatasetWatermark, Worker};
 
 use nonoverlap::Candidate;
 use rows::tick_to_i64;
@@ -115,6 +115,39 @@ impl PostgresStorage {
         })
     }
 
+    /// Existing datasets, each with the S3-discovery watermark for its last chunk (its id and end
+    /// block), or `None` when the dataset has no chunks yet. A dataset absent from the result has no
+    /// row yet and must be created before its chunks can be registered.
+    pub fn datasets_with_last_chunk(&self) -> Result<Vec<DatasetWatermark>, StorageError> {
+        self.with_conn_ref(async move |conn| {
+            let rows: Vec<(String, Option<String>, Option<i64>)> = sqlx::query_as(
+                "SELECT d.name, lc.chunk_id, lc.last_block
+                 FROM datasets d
+                 LEFT JOIN LATERAL (
+                     SELECT c.chunk_id, c.first_block + c.last_block_delta AS last_block
+                     FROM chunks c
+                     LEFT JOIN sched_chunk_metadata m ON m.chunk_pk = c.chunk_pk
+                     WHERE c.dataset_id = d.id AND m.rejected IS NOT TRUE
+                     ORDER BY c.first_block DESC
+                     LIMIT 1
+                 ) lc ON true",
+            )
+            .fetch_all(&mut *conn)
+            .await
+            .context("fetch dataset watermarks")?;
+            Ok(rows
+                .into_iter()
+                .map(|(name, chunk_id, last_block)| DatasetWatermark {
+                    dataset: Dataset {
+                        id: std::sync::Arc::new(name),
+                        height: last_block.map(|b| b as u64),
+                    },
+                    last_chunk_id: chunk_id.map(std::sync::Arc::new),
+                })
+                .collect())
+        })
+    }
+
     /// Run an async query closure on the owned runtime with exclusive
     /// connection access. The `AsyncFnOnce` bound lets the future borrow the
     /// `&mut PgConnection` argument, which `FnOnce(_) -> Fut` cannot express.
@@ -166,7 +199,7 @@ impl SchedulerStorage for PostgresStorage {
             let mut timer = PhaseTimer::new("insert_new_datasets");
             let mut tx = conn.begin().await.context("insert_new_datasets: begin")?;
             for (name, dataset_schema) in &datasets {
-                let dataset_id: DatasetId =
+                let dataset_id: DatasetPk =
                     sqlx::query_scalar("INSERT INTO datasets (name) VALUES ($1) RETURNING id")
                         .bind(name)
                         .fetch_one(&mut *tx)
@@ -187,7 +220,7 @@ impl SchedulerStorage for PostgresStorage {
     ) -> Result<(), StorageError> {
         self.with_conn(async move |conn| -> Result<(), StorageError> {
             let mut tx = conn.begin().await.context("set_dataset_schema: begin")?;
-            let dataset_id: Option<DatasetId> =
+            let dataset_id: Option<DatasetPk> =
                 sqlx::query_scalar("SELECT id FROM datasets WHERE name = $1")
                     .bind(dataset)
                     .fetch_optional(&mut *tx)

--- a/src/scheduler_storage/postgres/nonoverlap.rs
+++ b/src/scheduler_storage/postgres/nonoverlap.rs
@@ -17,12 +17,12 @@ use anyhow::{Context, Result};
 use sqlx::Row;
 use sqlx::postgres::{PgConnection, PgRow};
 
-use crate::scheduler_storage::{ChunkPk, DatasetId};
+use crate::scheduler_storage::{ChunkPk, DatasetPk};
 
 /// A chunk being considered for admission or promotion, with its inclusive block range.
 pub(super) struct Candidate {
     pub pk: ChunkPk,
-    pub dataset_id: DatasetId,
+    pub dataset_id: DatasetPk,
     pub dataset_name: String,
     pub first_block: i64,
     pub last_block: i64,
@@ -68,7 +68,7 @@ pub(super) fn settle_within_batch(mut clear: Vec<Candidate>) -> (Vec<ChunkPk>, V
     let mut rejected = Vec::new();
     // Sorted by start within a dataset, accepted ranges are non-overlapping with rising ends, so a
     // candidate need only be checked against the last accepted chunk in its dataset.
-    let mut last: Option<(DatasetId, i64)> = None; // (dataset_id, last_block of last accepted)
+    let mut last: Option<(DatasetPk, i64)> = None; // (dataset_id, last_block of last accepted)
     for c in clear {
         match last {
             Some((dataset_id, end)) if dataset_id == c.dataset_id && c.first_block <= end => {
@@ -127,7 +127,7 @@ async fn overlapping(
     let mut timer = crate::metrics::PhaseTimer::new("nonoverlap:overlap_probe");
     let n = candidates.len();
     let mut pks: Vec<ChunkPk> = Vec::with_capacity(n);
-    let mut datasets: Vec<DatasetId> = Vec::with_capacity(n);
+    let mut datasets: Vec<DatasetPk> = Vec::with_capacity(n);
     let mut firsts: Vec<i64> = Vec::with_capacity(n);
     let mut lasts: Vec<i64> = Vec::with_capacity(n);
     for c in candidates {

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -5,13 +5,13 @@ use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use sqlx::{Postgres, Transaction, postgres::PgConnection};
 
-use crate::scheduler_storage::{DatasetId, SchemaId};
+use crate::scheduler_storage::{DatasetPk, SchemaId};
 use crate::types::DatasetSchema;
 
 /// Make `schema` the current read schema for `dataset_id`, reusing a canonically identical row.
 pub(super) async fn ensure_current_schema(
     tx: &mut Transaction<'_, Postgres>,
-    dataset_id: DatasetId,
+    dataset_id: DatasetPk,
     schema: &DatasetSchema,
 ) -> Result<SchemaId> {
     schema.validate().context("invalid dataset schema")?;

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -2,12 +2,12 @@ use std::{ops::RangeInclusive, str::FromStr, sync::Arc};
 
 use crate::{pool, types::ChunkSummary};
 
-use super::BlockNumber;
+use super::{BlockNumber, ChunkId, DatasetId};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Chunk {
-    pub dataset: Arc<String>,
-    pub id: Arc<String>,
+    pub dataset: DatasetId,
+    pub id: ChunkId,
     pub size: u32,
     pub blocks: RangeInclusive<BlockNumber>,
     pub files: Arc<Vec<String>>,
@@ -16,7 +16,7 @@ pub struct Chunk {
 
 impl Chunk {
     pub fn new(
-        dataset: Arc<String>,
+        dataset: DatasetId,
         id: String,
         size: u32,
         mut files: Vec<String>,

--- a/src/types/dataset.rs
+++ b/src/types/dataset.rs
@@ -1,5 +1,16 @@
+use super::{ChunkId, DatasetId};
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Dataset {
-    pub id: String,
+    pub id: DatasetId,
     pub height: Option<u64>,
+}
+
+/// A dataset paired with where S3 discovery should resume for it: `dataset.height` is the last
+/// indexed block (the chain-continuity anchor) and `last_chunk_id` is that chunk's id (the resume
+/// key). Both are absent for a dataset with no chunks yet — discovery then lists from the start.
+#[derive(Debug, Clone)]
+pub struct DatasetWatermark {
+    pub dataset: Dataset,
+    pub last_chunk_id: Option<ChunkId>,
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -6,15 +6,25 @@ mod status;
 mod summary;
 mod worker;
 
+use std::sync::Arc;
+
 pub type WorkerIndex = u16;
 pub type ChunkIndex = u32;
 pub type ChunkWeight = u16;
 pub type ReplicationFactor = u16;
 pub type BlockNumber = u64;
 
+/// A dataset's id, e.g. `s3://ethereum-mainnet-1`. Shared (`Arc`) — the same id rides along with
+/// every chunk of the dataset.
+pub type DatasetId = Arc<String>;
+
+/// A chunk's id, e.g. `0018197829/0018246541-0018248424-c7ed95c9`. Shared (`Arc`) for the same
+/// reason as [`DatasetId`].
+pub type ChunkId = Arc<String>;
+
 pub use assignment::{Assignment, FbVersion};
 pub use chunk::Chunk;
-pub use dataset::Dataset;
+pub use dataset::{Dataset, DatasetWatermark};
 pub use dataset_schema::{DatasetSchema, TableSchema};
 pub use status::{SchedulingStatus, SchedulingStatusConfig};
 pub use summary::ChunkSummary;


### PR DESCRIPTION
## What

  Adds an opt-in path that runs the multistep (MVCC) scheduler against Postgres instead of the ordinary one-shot `Controller` pipeline. Enabled by the `mvcc-chunks` build feature **and** the `--multistep-scheduler` flag; otherwise the scheduler behaves exactly as before.

  When enabled, one run performs: **bootstrap datasets → discover new chunks  register them → update the worker set → run one scheduling cycle**, reusing the  existing `MultistepAlgorithm` + `PostgresStorage`.

  ## Highlights

  - **Incremental discovery from Postgres.** The multistep path resumes S3 listing     after each dataset's last known chunk (watermark read from Postgres) - the same     incremental model the ordinary ClickHouse path already uses. The shared S3 layer     is unified onto an id-only prefix-successor `start_after` key (only the chunk id
    is needed, not its file list).
  - **New CLI args** (`mvcc-chunks` only): `--database-url`,     `--multistep-drain-window` (default `5m`), `--multistep-worker-gc`     (default `24h`), all humantime-valued.
  -  Per-phase timing (`multistep:bootstrap` / `:register_chunks` / `:schedule`).

  ## Scope / not included (yet)

  - **Scheduling cycle only** — no confirmation or visibility cycle, and the     resulting assignment is **computed, not published**.
  - **New chunks only** — no corrections/removals. 
  - Cold start bootstraps configured datasets on the fly with an empty schema  (marked `FIXME`; real provisioning belongs out of band).