### PR TITLE
perf: Improve postgres performance

### DIFF
--- a/docs/mvcc-schema.md
+++ b/docs/mvcc-schema.md
@@ -166,10 +166,12 @@ CREATE TABLE sched_worker_assignments (
     scheduler_version TEXT
 );
 
--- One row per visibility cycle. created_at anchors the M-tick drain window.
+-- One row per visibility cycle. created_at anchors the M-tick drain window; confirmed_up_to is
+-- the worker-assignment confirmation watermark the cycle saw.
 CREATE TABLE sched_portal_assignments (
-    id         BIGSERIAL PRIMARY KEY,
-    created_at BIGINT    NOT NULL
+    id              BIGSERIAL PRIMARY KEY,
+    created_at      BIGINT    NOT NULL,
+    confirmed_up_to BIGINT    NOT NULL
 );
 ```
 
@@ -211,13 +213,15 @@ every read that gathers schedulable or live chunks (see
 
 ### Removal at two granularities, one timing rule
 
-`dropped_at_portal_assignment_id` appears in two tables; in both it anchors the same M-tick drain
-(the `created_at` of the referenced portal assignment — Invariant 4). Only the scope differs:
+Both removals drain M ticks from the portal assignment that dropped them (Invariant 4); only the
+scope and the anchor's storage differ:
 
 - `sched_chunk_metadata` (keyed by `chunk_pk`) — the **whole chunk** leaves portal visibility
-  (gate A).
+  (gate A). Anchor stored: `dropped_at_portal_assignment_id`.
 - `sched_stale_mappings` (keyed by `(chunk_pk, worker_id)`) — a single **(chunk, worker) pair**
-  leaves the confirmed routing while the chunk stays visible (gate B).
+  leaves the confirmed routing while the chunk stays visible (gate B). Anchor derived: the first
+  portal assignment whose `confirmed_up_to` covers the pair's
+  `superseded_at_worker_assignment_id`.
 
 ### sched_workers
 
@@ -256,19 +260,25 @@ The two routing tables behind the two-gate model. `sched_ideal_chunk_workers` is
 scheduler currently *wants*; the scheduler serves it to workers as the download target.
 `sched_confirmed_chunk_workers` is the confirmed routing the scheduler serves to portals, lagging
 the ideal until the confirmation watermark advances. Workers and portals do not read these tables
-directly — both consume the scheduler's published assignment. Same shape:
+directly — both consume the scheduler's published assignment. Same shape, deliberately no chunks
+FK: the cycle re-stages the whole ideal via COPY, and every pk entering it is validated once,
+churn-sized, by the diffs table's FK (see the migration).
 
 ```sql
 CREATE TABLE sched_ideal_chunk_workers (
-    chunk_pk   BIGINT   PRIMARY KEY REFERENCES chunks(chunk_pk),
+    chunk_pk   BIGINT   PRIMARY KEY,
     worker_ids BIGINT[] NOT NULL
 );
 
 CREATE TABLE sched_confirmed_chunk_workers (
-    chunk_pk   BIGINT   PRIMARY KEY REFERENCES chunks(chunk_pk),
+    chunk_pk   BIGINT   PRIMARY KEY,
     worker_ids BIGINT[] NOT NULL
 );
 ```
+
+A structurally identical twin, `sched_future_ideal_chunk_workers`, stages each cycle's freshly
+computed ideal; the cycle derives its deltas by joining live vs future, then rename-swaps the two
+(the swap leaves the twin empty for the next cycle).
 
 The published worker assignment is `sched_ideal_chunk_workers ∪ sched_stale_mappings` — it does
 **not** read the confirmed routing (see [mvcc-storage.md](mvcc-storage.md), "Deferred removal").
@@ -303,17 +313,17 @@ CREATE TABLE sched_stale_mappings (
     chunk_pk                           BIGINT NOT NULL REFERENCES chunks(chunk_pk),
     worker_id                          BIGINT NOT NULL REFERENCES sched_workers(id),
     superseded_at_worker_assignment_id BIGINT NOT NULL REFERENCES sched_worker_assignments(id),
-    dropped_at_portal_assignment_id    BIGINT REFERENCES sched_portal_assignments(id),  -- NULL while pending
     PRIMARY KEY (chunk_pk, worker_id)
 );
 
 CREATE INDEX sched_stale_mappings_worker_id ON sched_stale_mappings (worker_id);
+CREATE INDEX sched_stale_mappings_superseded
+    ON sched_stale_mappings (superseded_at_worker_assignment_id);
 ```
 
 - `superseded_at_worker_assignment_id` — first worker assignment whose ideal no longer routes the
-  chunk to this worker. Activation gate: the removal is confirmed once this is `<=` the watermark.
-- `dropped_at_portal_assignment_id` — NULL while pending; stamped when the removal reaches the
-  portal, anchoring the M-tick drain (same rule as `sched_chunk_metadata`).
+  chunk to this worker. Pending vs draining is derived from it: the pair is draining once a portal
+  assignment's `confirmed_up_to` covers it, anchored at the first such assignment.
 
 Lifecycle (pending → draining → dropped) and per-cycle logic: [mvcc-storage.md](mvcc-storage.md),
 "Deferred removal". Transient — empty on stable cycles.
@@ -358,8 +368,9 @@ Phase A (GC):
      AND dropped_at_portal_assignment_id IN (
          SELECT id FROM sched_portal_assignments WHERE created_at <= $now - $m_ticks);
    ```
-2. **Expire drained stale mappings** — the per-pair equivalent (`DELETE FROM sched_stale_mappings
-   WHERE dropped_at_portal_assignment_id` references a portal assignment ≥ M ticks old).
+2. **Expire drained stale mappings** — the per-pair equivalent: delete pairs at/under the newest
+   `confirmed_up_to` among portal assignments ≥ M ticks old (exactly those whose derived drain
+   anchor has aged out; both columns are monotone over assignment ids).
 
 Phase B (placement reconcile):
 
@@ -368,16 +379,15 @@ Phase B (placement reconcile):
    (`sched_ideal_chunk_workers ∪ sched_stale_mappings`).
 4. **Compute the ideal in Rust** via the `SchedulingAlgorithm`.
 5. **Open** a new `sched_worker_assignments` row (`created_at = now`).
-6. **Mint pending stale mappings** for each `(chunk, worker)` pair the new ideal drops (skipping
-   chunks being removed at the chunk level and workers GC'd from `sched_workers`):
-   `INSERT INTO sched_stale_mappings (...) ON CONFLICT (chunk_pk, worker_id) DO NOTHING`.
-7. **Record routing diffs** into `sched_worker_assignment_diffs` (changed chunks + removals as
-   empty arrays).
-8. **Commit the new ideal** — upsert present pairs, delete absent chunks from
-   `sched_ideal_chunk_workers`.
-9. **Resolve flip-flops** — delete stale rows for pairs the new ideal re-added.
-10. **Stamp entered chunks** — `applied_at_worker_assignment_id = $new_wa_id` for newly placed
-    chunks (`WHERE applied_at_worker_assignment_id IS NULL`).
+6. **Stage the new ideal** — COPY it into the empty `sched_future_ideal_chunk_workers` twin.
+7. **Derive deltas and swap**, one batched round-trip joining live vs future ideal:
+   - mint pending stale mappings for each `(chunk, worker)` pair the new ideal drops (skipping
+     chunks being removed at the chunk level and workers GC'd from `sched_workers`);
+   - record routing diffs into `sched_worker_assignment_diffs` (changed chunks + removals as
+     empty arrays);
+   - resolve flip-flops — delete stale rows for pairs the new ideal re-added;
+   - stamp entered chunks (`applied_at_worker_assignment_id = $new_wa_id` where NULL);
+   - rename-swap the twins, so the staged ideal becomes live.
 
 The published assignment is then read post-commit as `ideal ∪ stale` over non-tombstoned chunks.
 
@@ -405,8 +415,8 @@ All in one transaction so the swap is atomic (Invariant 5):
    ```
 3. **Drop marked chunks** — `dropped_at_portal_assignment_id = $new_pa_id WHERE marked_for_removal
    IS NOT NULL AND dropped_at_portal_assignment_id IS NULL`.
-4. **Activate confirmed drains** — stamp pending stale mappings whose
-   `superseded_at_worker_assignment_id <= $confirmed_watermark` with `dropped_at_portal_assignment_id`.
+4. **Drain activation is implicit** — this cycle's portal-assignment row records the watermark
+   (`confirmed_up_to`); pending stale pairs at/under it are draining from here on.
 5. **Return** portal-visible chunks (`applied_at_portal_assignment_id IS NOT NULL AND
    dropped_at_portal_assignment_id IS NULL`) with their confirmed routing.
 

--- a/docs/mvcc-schema.md
+++ b/docs/mvcc-schema.md
@@ -9,6 +9,20 @@ drain/GC predicate is integer arithmetic (`created_at <= $now - $m_ticks`), not
 `now() - INTERVAL`. The in-memory backend uses the same `u64` tick model. "M ticks" throughout is
 a logical grace window, not minutes.
 
+**Column widths.** Three rules, since these tables are sized in the millions of rows:
+
+- **Ticks are `BIGINT`.** They carry a caller-supplied clock (wall-clock seconds in production), so
+  they get the full 64 bits.
+- **Assignment and worker ids are `INT`.** Assignment ids are minted one per cycle — a 10s cycle
+  takes ~600 years to exhaust `INT` — and worker ids only by distinct peers ever seen (which is why
+  `update_worker_set` must not burn ids on re-sync; see `postgres/workers.rs`). Both are referenced
+  far more often than they are minted: an assignment id sits in three `sched_chunk_metadata`
+  columns, in every stale mapping and every diff row, and a worker id is repeated once *per replica*
+  inside each routing row's `worker_ids`. That multiplication is what the width buys back.
+- **`chunks.chunk_pk` stays `BIGSERIAL`.** Chunk rows are never deleted, so its sequence only ever
+  climbs; narrowing it would save ~4% of what the other two do and puts an unrecoverable wrap at
+  the end of the road.
+
 **Single scheduler.** Only one scheduler instance may operate at a time, enforced by a Postgres
 advisory lock acquired at startup:
 
@@ -115,7 +129,7 @@ CREATE TABLE chunk_corrections (
     new_chunk_pk                    BIGINT   NOT NULL    REFERENCES chunks(chunk_pk),
     dataset_id                      SMALLINT NOT NULL    REFERENCES datasets(id),
     created_at                      BIGINT   NOT NULL,
-    applied_at_portal_assignment_id BIGINT   REFERENCES sched_portal_assignments(id),  -- NULL while pending
+    applied_at_portal_assignment_id INT      REFERENCES sched_portal_assignments(id),  -- NULL while pending
     CHECK (old_chunk_pk <> new_chunk_pk)
 );
 
@@ -161,17 +175,17 @@ structural and visible in the schema; ids are never compared across kinds in cod
 ```sql
 -- One row per scheduling cycle.
 CREATE TABLE sched_worker_assignments (
-    id                BIGSERIAL PRIMARY KEY,
-    created_at        BIGINT    NOT NULL,
+    id                SERIAL PRIMARY KEY,
+    created_at        BIGINT NOT NULL,
     scheduler_version TEXT
 );
 
 -- One row per visibility cycle. created_at anchors the M-tick drain window; confirmed_up_to is
 -- the worker-assignment confirmation watermark the cycle saw.
 CREATE TABLE sched_portal_assignments (
-    id              BIGSERIAL PRIMARY KEY,
-    created_at      BIGINT    NOT NULL,
-    confirmed_up_to BIGINT    NOT NULL
+    id              SERIAL PRIMARY KEY,
+    created_at      BIGINT NOT NULL,
+    confirmed_up_to INT    NOT NULL
 );
 ```
 
@@ -182,11 +196,11 @@ Per-chunk lifecycle state, separated from immutable chunk metadata to avoid writ
 ```sql
 CREATE TABLE sched_chunk_metadata (
     chunk_pk                        BIGINT PRIMARY KEY REFERENCES chunks(chunk_pk),
-    applied_at_worker_assignment_id BIGINT REFERENCES sched_worker_assignments(id),
-    applied_at_portal_assignment_id BIGINT REFERENCES sched_portal_assignments(id),
+    applied_at_worker_assignment_id INT    REFERENCES sched_worker_assignments(id),
+    applied_at_portal_assignment_id INT    REFERENCES sched_portal_assignments(id),
     marked_for_removal              BIGINT,  -- tick when marked; NULL = not marked
     rejected                        BOOLEAN NOT NULL DEFAULT FALSE,  -- rejected at registration; terminal
-    dropped_at_portal_assignment_id BIGINT REFERENCES sched_portal_assignments(id),
+    dropped_at_portal_assignment_id INT    REFERENCES sched_portal_assignments(id),
     dropped_from_worker_assignment_at BIGINT  -- tick when tombstoned; NULL = not tombstoned
 );
 
@@ -234,10 +248,10 @@ ahead of the eventual GC of the worker row.
 
 ```sql
 CREATE TABLE sched_workers (
-    id             BIGSERIAL PRIMARY KEY,
-    peer_id        TEXT      NOT NULL UNIQUE,
-    version        TEXT,            -- semver, e.g. '2.8.0'; NULL = unknown
-    inactive_since BIGINT           -- NULL = currently active
+    id             SERIAL PRIMARY KEY,
+    peer_id        TEXT   NOT NULL UNIQUE,
+    version        TEXT,          -- semver, e.g. '2.8.0'; NULL = unknown
+    inactive_since BIGINT         -- NULL = currently active
 );
 ```
 
@@ -249,7 +263,7 @@ by the caller, not here (see [mvcc-storage.md](mvcc-storage.md), Invariant 3).
 
 ```sql
 CREATE TABLE sched_worker_confirmations (
-    assignment_id BIGINT PRIMARY KEY REFERENCES sched_worker_assignments(id),
+    assignment_id INT    PRIMARY KEY REFERENCES sched_worker_assignments(id),
     confirmed_at  BIGINT NOT NULL
 );
 ```
@@ -266,13 +280,13 @@ churn-sized, by the diffs table's FK (see the migration).
 
 ```sql
 CREATE TABLE sched_ideal_chunk_workers (
-    chunk_pk   BIGINT   PRIMARY KEY,
-    worker_ids BIGINT[] NOT NULL
+    chunk_pk   BIGINT PRIMARY KEY,
+    worker_ids INT[]  NOT NULL
 );
 
 CREATE TABLE sched_confirmed_chunk_workers (
-    chunk_pk   BIGINT   PRIMARY KEY,
-    worker_ids BIGINT[] NOT NULL
+    chunk_pk   BIGINT PRIMARY KEY,
+    worker_ids INT[]  NOT NULL
 );
 ```
 
@@ -282,8 +296,6 @@ computed ideal; the cycle derives its deltas by joining live vs future, then ren
 
 The published worker assignment is `sched_ideal_chunk_workers ∪ sched_stale_mappings` — it does
 **not** read the confirmed routing (see [mvcc-storage.md](mvcc-storage.md), "Deferred removal").
-
-Sizing: ~7M chunks × ~350 bytes ≈ 2.5 GB each.
 
 ### sched_worker_assignment_diffs
 
@@ -295,9 +307,9 @@ order and deleted. Bounded by confirmation lag — empty in steady state.
 
 ```sql
 CREATE TABLE sched_worker_assignment_diffs (
-    worker_assignment_id BIGINT   NOT NULL REFERENCES sched_worker_assignments(id),
-    chunk_pk             BIGINT   NOT NULL REFERENCES chunks(chunk_pk),
-    worker_ids           BIGINT[] NOT NULL,  -- empty = remove from confirmed routing
+    worker_assignment_id INT    NOT NULL REFERENCES sched_worker_assignments(id),
+    chunk_pk             BIGINT NOT NULL REFERENCES chunks(chunk_pk),
+    worker_ids           INT[]  NOT NULL,  -- empty = remove from confirmed routing
     PRIMARY KEY (worker_assignment_id, chunk_pk)
 );
 ```
@@ -311,8 +323,8 @@ only; newly *added* pairs ride in `sched_ideal_chunk_workers`.
 ```sql
 CREATE TABLE sched_stale_mappings (
     chunk_pk                           BIGINT NOT NULL REFERENCES chunks(chunk_pk),
-    worker_id                          BIGINT NOT NULL REFERENCES sched_workers(id),
-    superseded_at_worker_assignment_id BIGINT NOT NULL REFERENCES sched_worker_assignments(id),
+    worker_id                          INT    NOT NULL REFERENCES sched_workers(id),
+    superseded_at_worker_assignment_id INT    NOT NULL REFERENCES sched_worker_assignments(id),
     PRIMARY KEY (chunk_pk, worker_id)
 );
 

--- a/docs/mvcc-storage.md
+++ b/docs/mvcc-storage.md
@@ -56,7 +56,8 @@ two id tables, so a mix-up is caught at code-review time, not by the engine.
    - **Whole-chunk removal** (backfill/compaction): the chunk is dropped (gate A) and all its
      pairs leave together. Anchored on `sched_chunk_metadata.dropped_at_portal_assignment_id`.
    - **Single-pair removal** (reshuffle): one pair leaves the confirmed routing (gate B) while
-     the chunk stays visible. Anchored on `sched_stale_mappings.dropped_at_portal_assignment_id`.
+     the chunk stays visible. Anchor derived: the first portal assignment whose `confirmed_up_to`
+     covers the pair's `superseded_at_worker_assignment_id`.
 
 5. **A correction's drop and promote are one atomic swap.** When a correction replaces a chunk,
    the portal assignment must never contain both the original and the replacement at once. The
@@ -295,8 +296,8 @@ worker-side tables. It deliberately does **not** read the confirmed portal routi
 
 Because a stale row is minted the instant a pair leaves the ideal, `ideal ∪ stale` is always a
 **superset of the confirmed portal routing**, so the worker side never needs to consult the
-portal view. The drain anchor mirrors `sched_chunk_metadata.dropped_at_portal_assignment_id`
-exactly — one timing rule, two granularities (Invariant 4).
+portal view. The drain follows the same timing rule as the chunk-level drop (Invariant 4), with a
+derived rather than stored anchor.
 
 ### Per-cycle logic
 
@@ -311,16 +312,16 @@ anything.
 1. **Compute the ideal** (hash ring, replication factors, current worker set) — in memory.
 2. **Diff-and-patch `sched_ideal_chunk_workers`.** For each pair the ideal **removes** — for a
    chunk not being removed at the chunk level (gate A handles those) — insert a **pending**
-   `sched_stale_mappings` row (`superseded_at_worker_assignment_id = $new_worker_assignment_id`,
-   `dropped_at_portal_assignment_id = NULL`) if one does not exist. This mints even for chunks not
+   `sched_stale_mappings` row (`superseded_at_worker_assignment_id = $new_worker_assignment_id`)
+   if one does not exist. This mints even for chunks not
    yet portal-visible: a confirmed-but-not-promoted chunk can still have a pair dropped, and the
    row is what keeps `ideal ∪ stale` a superset of the confirmed routing.
 3. **Resolve flip-flops.** If a later ideal re-adds the pair, delete its stale row — the removal
    resolved itself.
-4. **Expire holdovers.** Delete any draining row whose `dropped_at_portal_assignment_id`
-   references a portal assignment older than M ticks; the worker drops it off the published
-   assignment automatically. The whole-chunk equivalent (tombstone a chunk whose portal-drop is ≥
-   M ticks old) runs here too.
+4. **Expire holdovers.** Delete rows at/under the newest `confirmed_up_to` among portal
+   assignments older than M ticks — exactly those whose derived drain anchor aged out; the worker
+   drops them off the published assignment automatically. The whole-chunk equivalent (tombstone a
+   chunk whose portal-drop is ≥ M ticks old) runs here too.
 
 **Confirmation** (a separate operation, when the caller reports a new watermark): replay the
 newly-confirmed worker-assignment diffs into `sched_confirmed_chunk_workers` — one mechanism both
@@ -329,9 +330,9 @@ what advances the confirmed routing portals read; it is **not** part of the visi
 
 **Visibility cycle** (starts the drain):
 
-5. **Start drains.** For each pending stale row whose `superseded_at_worker_assignment_id <=` the
-   confirmation watermark — i.e. whose removal the replay has already applied — stamp
-   `dropped_at_portal_assignment_id = $new_portal_assignment_id` to start the M-tick drain.
+5. **Drains start implicitly.** The cycle's portal-assignment row records the watermark it saw
+   (`confirmed_up_to`); every pending stale row at/under it — i.e. whose removal the replay has
+   already applied — is draining from this assignment on.
 
 When a chunk is removed entirely via the chunk-level mechanism (`dropped_from_worker_assignment_at`
 set — gate A), its stale rows and ideal row go too; the whole-chunk removal supersedes any per-pair
@@ -354,9 +355,9 @@ Three properties keep the scheme sound under repeated oscillation:
   ideal or stale. The stale row is deleted only when the ideal re-adds the pair, i.e. only once
   the ideal itself guarantees retention, so the worker is never instructed to delete data while
   portals may still route to it.
-- **Monotonic drain anchor.** Each re-mint anchors `dropped_at_portal_assignment_id` on the
-  current (strictly later) portal assignment, so the M-tick drain window only ever moves forward —
-  no stale-snapshot portal is under-served.
+- **Monotonic drain anchor.** Each re-mint carries the current (strictly later) worker assignment
+  id, so the derived drain anchor only ever moves forward — no stale-snapshot portal is
+  under-served.
 
 ### Capacity accounting
 

--- a/docs/mvcc-storage.md
+++ b/docs/mvcc-storage.md
@@ -22,7 +22,7 @@ The two streams are non-1:1, so each has its **own monotonic id sequence**
 kinds** — ordering is used only within a kind (e.g. the confirmation watermark over worker ids),
 and cross-kind links are always explicit foreign-key references (e.g. a drain anchored on the
 portal assignment that dropped a pair). The schema does not *enforce* the no-cross-kind-compare
-rule — both sequences are `BIGSERIAL` from 1, so the same numeric value can exist in both — but it
+rule — both sequences are `SERIAL` from 1, so the same numeric value can exist in both — but it
 makes the distinction structural and visible: every referencing column targets exactly one of the
 two id tables, so a mix-up is caught at code-review time, not by the engine.
 

--- a/migrations/0001_sched_tables.sql
+++ b/migrations/0001_sched_tables.sql
@@ -63,7 +63,7 @@ CREATE INDEX IF NOT EXISTS chunks_dataset_range_gist ON chunks USING gist (
 
 -- One row per scheduling cycle.
 CREATE TABLE IF NOT EXISTS sched_worker_assignments (
-    id                BIGSERIAL   PRIMARY KEY,
+    id                SERIAL PRIMARY KEY,
     created_at        BIGINT NOT NULL,
     scheduler_version TEXT
 );
@@ -72,13 +72,13 @@ CREATE TABLE IF NOT EXISTS sched_worker_assignments (
 -- the worker-assignment confirmation watermark the cycle saw (drain derivation: see
 -- sched_stale_mappings).
 CREATE TABLE IF NOT EXISTS sched_portal_assignments (
-    id               BIGSERIAL   PRIMARY KEY,
+    id               SERIAL PRIMARY KEY,
     created_at       BIGINT NOT NULL,
-    confirmed_up_to  BIGINT NOT NULL
+    confirmed_up_to  INT    NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS sched_workers (
-    id             BIGSERIAL   PRIMARY KEY,
+    id             SERIAL      PRIMARY KEY,
     peer_id        TEXT        NOT NULL UNIQUE,
     version        TEXT,               -- semver e.g. '2.8.0'; NULL = unknown
     inactive_since BIGINT              -- NULL = currently active
@@ -86,20 +86,20 @@ CREATE TABLE IF NOT EXISTS sched_workers (
 
 -- Highest worker assignment confirmed by workers.
 CREATE TABLE IF NOT EXISTS sched_worker_confirmations (
-    assignment_id  BIGINT      PRIMARY KEY REFERENCES sched_worker_assignments(id),
+    assignment_id  INT    PRIMARY KEY REFERENCES sched_worker_assignments(id),
     confirmed_at   BIGINT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS sched_chunk_metadata (
     chunk_pk                        BIGINT PRIMARY KEY REFERENCES chunks(chunk_pk),
-    applied_at_worker_assignment_id BIGINT REFERENCES sched_worker_assignments(id),
-    applied_at_portal_assignment_id BIGINT REFERENCES sched_portal_assignments(id),
-    marked_for_removal              BIGINT,
+    applied_at_worker_assignment_id INT    REFERENCES sched_worker_assignments(id),
+    applied_at_portal_assignment_id INT    REFERENCES sched_portal_assignments(id),
+    marked_for_removal              BIGINT,  -- a tick, not an id: stays 64-bit
     -- True if the chunk was rejected at registration for overlapping a live chunk in its dataset;
     -- such a chunk is never scheduled or reconsidered. (A bool, not a tick: registration has no
     -- clock.)
     rejected                        BOOLEAN NOT NULL DEFAULT FALSE,
-    dropped_at_portal_assignment_id BIGINT REFERENCES sched_portal_assignments(id),
+    dropped_at_portal_assignment_id INT    REFERENCES sched_portal_assignments(id),
     -- Tick at which the chunk was tombstoned (pulled from the worker layer), m_ticks after its
     -- portal drop. NULL = not tombstoned.
     dropped_from_worker_assignment_at BIGINT
@@ -112,8 +112,8 @@ CREATE TABLE IF NOT EXISTS sched_chunk_metadata (
 -- diffs it into that table, whose chunks FK validates it once per pk. The parent side never fires;
 -- chunks rows are never deleted (sched_chunk_metadata's FK pins them).
 CREATE TABLE IF NOT EXISTS sched_ideal_chunk_workers (
-    chunk_pk    BIGINT   PRIMARY KEY,
-    worker_ids  BIGINT[] NOT NULL
+    chunk_pk    BIGINT PRIMARY KEY,
+    worker_ids  INT[]  NOT NULL
 );
 
 -- Twin of sched_ideal_chunk_workers. run_scheduling_cycle stages the freshly computed ideal here,
@@ -122,21 +122,21 @@ CREATE TABLE IF NOT EXISTS sched_ideal_chunk_workers (
 -- to sched_ideal_chunk_workers: after a swap this table *is* the old ideal (and vice versa), so both
 -- need the same bare PK to remain a valid drop-in.
 CREATE TABLE IF NOT EXISTS sched_future_ideal_chunk_workers (
-    chunk_pk    BIGINT   PRIMARY KEY,
-    worker_ids  BIGINT[] NOT NULL
+    chunk_pk    BIGINT PRIMARY KEY,
+    worker_ids  INT[]  NOT NULL
 );
 
 -- What portals route by; lags the ideal until the confirmation watermark advances.
 CREATE TABLE IF NOT EXISTS sched_confirmed_chunk_workers (
-    chunk_pk    BIGINT   PRIMARY KEY, -- deliberately do not reference chunks
-    worker_ids  BIGINT[] NOT NULL
+    chunk_pk    BIGINT PRIMARY KEY, -- deliberately do not reference chunks
+    worker_ids  INT[]  NOT NULL
 );
 
 -- Per-cycle routing deltas waiting to be replayed into sched_confirmed_chunk_workers.
 CREATE TABLE IF NOT EXISTS sched_worker_assignment_diffs (
-    worker_assignment_id  BIGINT   NOT NULL REFERENCES sched_worker_assignments(id),
-    chunk_pk              BIGINT   NOT NULL REFERENCES chunks(chunk_pk),
-    worker_ids            BIGINT[] NOT NULL,  -- empty array = remove from confirmed routing
+    worker_assignment_id  INT    NOT NULL REFERENCES sched_worker_assignments(id),
+    chunk_pk              BIGINT NOT NULL REFERENCES chunks(chunk_pk),
+    worker_ids            INT[]  NOT NULL,  -- empty array = remove from confirmed routing
     PRIMARY KEY (worker_assignment_id, chunk_pk)
 );
 
@@ -144,8 +144,8 @@ CREATE TABLE IF NOT EXISTS sched_worker_assignment_diffs (
 -- once a portal assignment's confirmed_up_to covers superseded_at_worker_assignment_id.
 CREATE TABLE IF NOT EXISTS sched_stale_mappings (
     chunk_pk                            BIGINT NOT NULL REFERENCES chunks(chunk_pk),
-    worker_id                           BIGINT NOT NULL REFERENCES sched_workers(id),
-    superseded_at_worker_assignment_id  BIGINT NOT NULL REFERENCES sched_worker_assignments(id),
+    worker_id                           INT    NOT NULL REFERENCES sched_workers(id),
+    superseded_at_worker_assignment_id  INT    NOT NULL REFERENCES sched_worker_assignments(id),
     PRIMARY KEY (chunk_pk, worker_id)
 );
 
@@ -205,8 +205,8 @@ CREATE TABLE chunk_corrections (
     old_chunk_pk                    BIGINT   PRIMARY KEY REFERENCES chunks(chunk_pk),
     new_chunk_pk                    BIGINT   NOT NULL    REFERENCES chunks(chunk_pk),
     dataset_id                      SMALLINT NOT NULL    REFERENCES datasets(id),
-    created_at                      BIGINT   NOT NULL,
-    applied_at_portal_assignment_id BIGINT   REFERENCES sched_portal_assignments(id),
+    created_at                      BIGINT   NOT NULL,  -- a tick, not an id: stays 64-bit
+    applied_at_portal_assignment_id INT      REFERENCES sched_portal_assignments(id),
     CHECK (old_chunk_pk <> new_chunk_pk)
 );
 

--- a/migrations/0001_sched_tables.sql
+++ b/migrations/0001_sched_tables.sql
@@ -103,20 +103,23 @@ CREATE TABLE IF NOT EXISTS sched_chunk_metadata (
 );
 
 -- What the scheduler currently wants; published worker assignment = this ∪ sched_stale_mappings.
+-- No chunks FK, same as the twin below: the cycle re-stages the whole ideal via COPY, and an FK
+-- would cost a per-row check on every staged row. Integrity comes from sched_worker_assignment_diffs
+-- instead — a pk new to the ideal always differs from the live ideal, so the same cycle transaction
+-- diffs it into that table, whose chunks FK validates it once per pk. The parent side never fires;
+-- chunks rows are never deleted (sched_chunk_metadata's FK pins them).
 CREATE TABLE IF NOT EXISTS sched_ideal_chunk_workers (
-    chunk_pk    BIGINT   PRIMARY KEY REFERENCES chunks(chunk_pk),
+    chunk_pk    BIGINT   PRIMARY KEY,
     worker_ids  BIGINT[] NOT NULL
 );
 
 -- Twin of sched_ideal_chunk_workers. run_scheduling_cycle stages the freshly computed ideal here,
 -- derives the per-cycle stale/diff/flip-flop deltas by set-joining the live ideal against it
--- (server-side, no app-side diffing), then rename-swaps the two tables. The swap leaves this table
--- empty and sched_ideal_chunk_workers holding the new placement, ready for the next cycle.
---
--- Structure must stay identical to sched_ideal_chunk_workers: after a swap this table *is* the old
--- ideal (and vice versa), so both need the same PK + chunks FK to remain a valid drop-in.
+-- (server-side, no app-side diffing), then rename-swaps the two tables. Structure must stay identical
+-- to sched_ideal_chunk_workers: after a swap this table *is* the old ideal (and vice versa), so both
+-- need the same bare PK to remain a valid drop-in.
 CREATE TABLE IF NOT EXISTS sched_future_ideal_chunk_workers (
-    chunk_pk    BIGINT   PRIMARY KEY, -- deliberately do not reference chunks
+    chunk_pk    BIGINT   PRIMARY KEY,
     worker_ids  BIGINT[] NOT NULL
 );
 
@@ -146,6 +149,19 @@ CREATE TABLE IF NOT EXISTS sched_stale_mappings (
 CREATE INDEX IF NOT EXISTS sched_stale_mappings_worker_id
     ON sched_stale_mappings (worker_id);
 
+-- activate_confirmed_drains flips every pending stale mapping at/under the confirmation watermark
+-- each visibility cycle; keying the watermark column lets the <= bound prune. Rows leave the index
+-- when their portal drop is stamped.
+CREATE INDEX IF NOT EXISTS sched_stale_mappings_pending_drain
+    ON sched_stale_mappings (superseded_at_worker_assignment_id)
+    WHERE dropped_at_portal_assignment_id IS NULL;
+
+-- expire_drained_stale_mappings deletes drained mappings whose portal drop aged out m_ticks ago;
+-- this bounds that DELETE to the drained rolling window instead of the whole holdover table.
+CREATE INDEX IF NOT EXISTS sched_stale_mappings_drained
+    ON sched_stale_mappings (dropped_at_portal_assignment_id)
+    WHERE dropped_at_portal_assignment_id IS NOT NULL;
+
 CREATE INDEX IF NOT EXISTS sched_chunk_metadata_portal_drop
     ON sched_chunk_metadata (dropped_at_portal_assignment_id)
     WHERE dropped_at_portal_assignment_id IS NOT NULL
@@ -165,18 +181,24 @@ CREATE INDEX IF NOT EXISTS sched_chunk_metadata_tombstoned
     ON sched_chunk_metadata (dropped_from_worker_assignment_at)
     WHERE dropped_from_worker_assignment_at IS NOT NULL;
 
--- Serves the promotion gate (visibility cycle): chunks confirmed by a worker assignment, not yet
--- portal-visible, not dropped, not marked for removal, not rejected. The partial predicate keeps it
--- to the small promotable frontier rather than the whole table. `NOT rejected` excludes
--- registration-rejected rows: they never get an applied_at_worker_assignment_id (so the query already
--- skips them via IS NOT NULL), but they do satisfy the other partial conditions — without this they'd
--- sit in the index as dead NULL-key entries.
+-- Serves the promotion gate (visibility cycle): the small frontier of chunks confirmed by a worker
+-- assignment but not yet portal-visible. `NOT rejected` is the non-obvious term — rejected rows never
+-- get an applied_at_worker_assignment_id so the query already skips them, but they satisfy the other
+-- predicates, and without it they'd sit in the index as dead NULL-key entries.
 CREATE INDEX IF NOT EXISTS sched_chunk_metadata_promotable
     ON sched_chunk_metadata (applied_at_worker_assignment_id)
     WHERE NOT rejected
       AND applied_at_portal_assignment_id IS NULL
       AND dropped_at_portal_assignment_id IS NULL
       AND marked_for_removal IS NULL;
+
+-- The scheduling cycle stamps applied_at_worker_assignment_id onto chunks new to the ideal. The
+-- stamp is first-touch (never reset), so the unapplied set is the new-chunk frontier plus the
+-- never-placed/rejected residue — without this index the stamp joins the full future ideal
+-- against metadata every cycle to change a few thousand rows.
+CREATE INDEX IF NOT EXISTS sched_chunk_metadata_unapplied
+    ON sched_chunk_metadata (chunk_pk)
+    WHERE applied_at_worker_assignment_id IS NULL;
 
 -- 1-to-1 chunk swap mechanism; applied_at_portal_assignment_id NULL = pending.
 CREATE TABLE chunk_corrections (

--- a/migrations/0001_sched_tables.sql
+++ b/migrations/0001_sched_tables.sql
@@ -68,10 +68,13 @@ CREATE TABLE IF NOT EXISTS sched_worker_assignments (
     scheduler_version TEXT
 );
 
--- One row per visibility cycle. created_at anchors the M-tick drain window.
+-- One row per visibility cycle. created_at anchors the M-tick drain window; confirmed_up_to is
+-- the worker-assignment confirmation watermark the cycle saw (drain derivation: see
+-- sched_stale_mappings).
 CREATE TABLE IF NOT EXISTS sched_portal_assignments (
-    id         BIGSERIAL   PRIMARY KEY,
-    created_at BIGINT NOT NULL
+    id               BIGSERIAL   PRIMARY KEY,
+    created_at       BIGINT NOT NULL,
+    confirmed_up_to  BIGINT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS sched_workers (
@@ -137,30 +140,27 @@ CREATE TABLE IF NOT EXISTS sched_worker_assignment_diffs (
     PRIMARY KEY (worker_assignment_id, chunk_pk)
 );
 
--- Grace-period holdovers for (chunk, worker) pairs removed from the ideal.
+-- Grace-period holdovers for (chunk, worker) pairs removed from the ideal; draining (not stored)
+-- once a portal assignment's confirmed_up_to covers superseded_at_worker_assignment_id.
 CREATE TABLE IF NOT EXISTS sched_stale_mappings (
     chunk_pk                            BIGINT NOT NULL REFERENCES chunks(chunk_pk),
     worker_id                           BIGINT NOT NULL REFERENCES sched_workers(id),
     superseded_at_worker_assignment_id  BIGINT NOT NULL REFERENCES sched_worker_assignments(id),
-    dropped_at_portal_assignment_id     BIGINT REFERENCES sched_portal_assignments(id),
     PRIMARY KEY (chunk_pk, worker_id)
 );
 
 CREATE INDEX IF NOT EXISTS sched_stale_mappings_worker_id
     ON sched_stale_mappings (worker_id);
 
--- activate_confirmed_drains flips every pending stale mapping at/under the confirmation watermark
--- each visibility cycle; keying the watermark column lets the <= bound prune. Rows leave the index
--- when their portal drop is stamped.
-CREATE INDEX IF NOT EXISTS sched_stale_mappings_pending_drain
-    ON sched_stale_mappings (superseded_at_worker_assignment_id)
-    WHERE dropped_at_portal_assignment_id IS NULL;
+-- Serves the expiry delete's watermark-cutoff range.
+CREATE INDEX IF NOT EXISTS sched_stale_mappings_superseded
+    ON sched_stale_mappings (superseded_at_worker_assignment_id);
 
--- expire_drained_stale_mappings deletes drained mappings whose portal drop aged out m_ticks ago;
--- this bounds that DELETE to the drained rolling window instead of the whole holdover table.
-CREATE INDEX IF NOT EXISTS sched_stale_mappings_drained
-    ON sched_stale_mappings (dropped_at_portal_assignment_id)
-    WHERE dropped_at_portal_assignment_id IS NOT NULL;
+-- Reshuffles mint and expire millions of stale rows at once; reclaim dead tuples promptly.
+ALTER TABLE sched_stale_mappings SET (
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_cost_delay = 0
+);
 
 CREATE INDEX IF NOT EXISTS sched_chunk_metadata_portal_drop
     ON sched_chunk_metadata (dropped_at_portal_assignment_id)

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -529,7 +529,7 @@ impl<D: SimStorage> SimUnderTest<D> {
             .iter()
             .copied()
             .enumerate()
-            .map(|(i, worker)| (WorkerPk(i as i64 + 1), worker.clone()))
+            .map(|(i, worker)| (WorkerPk(i as i32 + 1), worker.clone()))
             .collect();
         let excluded = self.chunks_excluded_from_floor();
         let mut chunk_pairs: Vec<(ChunkPk, AlgoChunk)> = self

--- a/src/multistep_scheduler/sim/sut/observers.rs
+++ b/src/multistep_scheduler/sim/sut/observers.rs
@@ -150,7 +150,7 @@ impl Portal {
 mod tests {
     use super::*;
 
-    fn w(id: i64) -> WorkerPk {
+    fn w(id: i32) -> WorkerPk {
         WorkerPk(id)
     }
 

--- a/src/multistep_scheduler/sim/sut/placement_oracles.rs
+++ b/src/multistep_scheduler/sim/sut/placement_oracles.rs
@@ -322,14 +322,14 @@ fn can_host_after_dropping_bonuses(
 mod tests {
     use super::*;
 
-    fn wk(ids: &[i64]) -> Vec<WorkerPk> {
+    fn wk(ids: &[i32]) -> Vec<WorkerPk> {
         ids.iter().map(|&w| WorkerPk(w)).collect()
     }
 
     /// Hand-built snapshot: `sizes[i]` is chunk `i`'s byte size; `ideal[i]` / `stale[i]` are its
     /// holders.
-    fn snap(sizes: &[u32], ideal: &[&[i64]], stale: &[&[i64]]) -> Snapshot {
-        let holders = |sets: &[&[i64]]| -> Vec<BTreeSet<WorkerPk>> {
+    fn snap(sizes: &[u32], ideal: &[&[i32]], stale: &[&[i32]]) -> Snapshot {
+        let holders = |sets: &[&[i32]]| -> Vec<BTreeSet<WorkerPk>> {
             sets.iter()
                 .map(|workers| workers.iter().map(|&w| WorkerPk(w)).collect())
                 .collect()
@@ -344,14 +344,14 @@ mod tests {
         }
     }
 
-    fn held(entries: &[(i64, &[i64])]) -> BTreeMap<ChunkPk, BTreeSet<WorkerPk>> {
+    fn held(entries: &[(i64, &[i32])]) -> BTreeMap<ChunkPk, BTreeSet<WorkerPk>> {
         entries
             .iter()
             .map(|(pk, workers)| (ChunkPk(*pk), workers.iter().map(|&w| WorkerPk(w)).collect()))
             .collect()
     }
 
-    fn portal(routing: &[(i64, &[i64])]) -> PortalAssignment {
+    fn portal(routing: &[(i64, &[i32])]) -> PortalAssignment {
         PortalAssignment {
             id: 1,
             chunk_workers: routing
@@ -363,7 +363,7 @@ mod tests {
         }
     }
 
-    fn worker_assignment(routing: &[(i64, &[i64])]) -> WorkerAssignment {
+    fn worker_assignment(routing: &[(i64, &[i32])]) -> WorkerAssignment {
         WorkerAssignment {
             id: 1,
             chunk_workers: routing

--- a/src/scheduler_storage/algorithm.rs
+++ b/src/scheduler_storage/algorithm.rs
@@ -334,7 +334,7 @@ mod tests {
             .enumerate()
             .map(|(i, id)| {
                 (
-                    WorkerPk(i as i64 + 1),
+                    WorkerPk(i as i32 + 1),
                     Worker {
                         id: *id,
                         status: WorkerStatus::Online,
@@ -378,7 +378,7 @@ mod tests {
             .enumerate()
             .map(|(i, id)| {
                 (
-                    WorkerPk(i as i64 + 1),
+                    WorkerPk(i as i32 + 1),
                     Worker {
                         id,
                         status: WorkerStatus::Online,

--- a/src/scheduler_storage/ids.rs
+++ b/src/scheduler_storage/ids.rs
@@ -1,17 +1,20 @@
 //! Storage primary-key newtypes shared by every backend.
 //!
-//! Both wrap an `i64` surrogate (Postgres `SERIAL`, in-memory counter); the newtypes keep chunk
-//! and worker keys from being swapped while staying plain integers on the wire.
+//! Each wraps the surrogate its column stores (Postgres `SERIAL`/`BIGSERIAL`, in-memory counter);
+//! the newtypes keep chunk and worker keys from being swapped while staying plain integers on the
+//! wire.
 
-/// Primary key of a chunk row.
+/// Primary key of a chunk row (`chunks.chunk_pk`, a 64-bit `BIGSERIAL`: chunk rows are never
+/// deleted, so the sequence only climbs).
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, sqlx::Type)]
 #[sqlx(transparent)]
 pub struct ChunkPk(pub i64);
 
-/// Primary key of a worker row.
+/// Primary key of a worker row (`sched_workers.id`, a 32-bit `SERIAL`). Narrow on purpose: every
+/// routing row carries one of these per replica in its `worker_ids` array.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, sqlx::Type)]
 #[sqlx(transparent)]
-pub struct WorkerPk(pub i64);
+pub struct WorkerPk(pub i32);
 
 /// Primary key of a dataset row.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, sqlx::Type)]

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -880,7 +880,7 @@ impl SchedulerStorage for InMemoryStorage {
                     .get(pk)
                     .is_none_or(|m| m.worker_servable())
             })
-            .map(|(pk, chunk)| (*pk, chunk.algo_view()))
+            .map(|(pk, chunk)| (*pk, chunk.into()))
             .collect();
         let workers: Vec<(WorkerPk, Worker)> = self
             .sched_workers

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -836,7 +836,7 @@ impl SchedulerStorage for InMemoryStorage {
         }
 
         for (peer_id, worker) in remaining {
-            let id = WorkerPk(self.counters.worker_id.next() as i64);
+            let id = WorkerPk(self.counters.worker_id.next() as i32);
             self.sched_workers.insert(
                 id,
                 WorkerEntry {

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -168,17 +168,21 @@ pub enum CorrectionRejected {
     },
 }
 
+/// One visibility cycle: when it ran, and the confirmation watermark it saw (drain derivation).
+#[derive(Debug, Clone, Copy)]
+struct PortalAssignmentEntry {
+    created_at: TimeUnit,
+    confirmed_up_to: WorkerAssignmentId,
+}
+
 /// Grace-period holdover for a `(chunk, worker)` pair removed from the ideal assignment
-/// while the chunk is still portal-visible. Pending until the superseding worker
-/// assignment is confirmed and the pair leaves the portal assignment; draining
-/// (M-tick window) after.
+/// while the chunk is still portal-visible. Pending vs draining is derived: draining once a
+/// portal assignment's `confirmed_up_to` covers `superseded_at_worker_assignment_id`,
+/// anchored at the first such assignment.
 #[derive(Debug, Clone)]
 struct StaleMapping {
-    /// First worker assignment whose ideal no longer routes the chunk to this
-    /// worker; the drain activates once `<=` the confirmation watermark.
+    /// First worker assignment whose ideal no longer routes the chunk to this worker.
     superseded_at_worker_assignment_id: WorkerAssignmentId,
-    /// `None` while pending; once set, anchors the M-tick drain.
-    dropped_at_portal_assignment_id: Option<PortalAssignmentId>,
 }
 
 #[derive(Debug, Clone)]
@@ -240,7 +244,7 @@ pub(crate) struct InMemoryStorage {
 
     sched_chunk_metadata: BTreeMap<ChunkPk, SchedulerChunkMetadata>,
     sched_worker_assignments: BTreeMap<WorkerAssignmentId, TimeUnit>,
-    sched_portal_assignments: BTreeMap<PortalAssignmentId, TimeUnit>,
+    sched_portal_assignments: BTreeMap<PortalAssignmentId, PortalAssignmentEntry>,
 
     // The highest worker assignment confirmed by the workers
     sched_worker_assignment_confirmation: WorkerAssignmentId,
@@ -509,7 +513,7 @@ impl InMemoryStorage {
     ) -> bool {
         dropped_at_portal
             .and_then(|aid| self.sched_portal_assignments.get(&aid))
-            .is_some_and(|created_at| *created_at <= cutoff)
+            .is_some_and(|entry| entry.created_at <= cutoff)
     }
 
     /// Tombstone chunks whose portal-removal happened at least `m_ticks` ago.
@@ -547,17 +551,19 @@ impl InMemoryStorage {
         let Some(cutoff) = now.checked_sub(m_ticks) else {
             return;
         };
-        let expired: Vec<(ChunkPk, WorkerPk)> = self
-            .sched_stale_mappings
-            .iter()
-            .filter_map(|(key, mapping)| {
-                self.portal_drop_elapsed(mapping.dropped_at_portal_assignment_id, cutoff)
-                    .then_some(*key)
-            })
-            .collect();
-        for key in expired {
-            self.sched_stale_mappings.remove(&key);
-        }
+        // Newest watermark among aged portal assignments; pairs at/under it are exactly those
+        // whose derived drain anchor aged out (both columns monotone over assignment ids).
+        let Some(watermark) = self
+            .sched_portal_assignments
+            .values()
+            .filter(|e| e.created_at <= cutoff)
+            .map(|e| e.confirmed_up_to)
+            .max()
+        else {
+            return;
+        };
+        self.sched_stale_mappings
+            .retain(|_, m| m.superseded_at_worker_assignment_id > watermark);
     }
 
     /// Mint a pending stale mapping for each `(chunk, worker)` pair dropped from
@@ -587,7 +593,6 @@ impl InMemoryStorage {
                         .entry((*pk, worker_id))
                         .or_insert(StaleMapping {
                             superseded_at_worker_assignment_id: new_worker_aid,
-                            dropped_at_portal_assignment_id: None,
                         });
                 }
             }
@@ -983,16 +988,20 @@ impl SchedulerStorage for InMemoryStorage {
     }
 
     /// Produce a new portal assignment. Atomically: apply ready corrections,
-    /// promote confirmed chunks (skipping pending correction targets), drop
-    /// chunks marked for removal, and start the M-tick drain for stale mappings
-    /// whose superseding worker assignment is now confirmed. Returns the
+    /// promote confirmed chunks (skipping pending correction targets), and drop
+    /// chunks marked for removal. Recording the watermark on the assignment is
+    /// what activates drains (derived; see [`StaleMapping`]). Returns the
     /// portal-visible chunks routed by the confirmed routing.
     fn run_visibility_cycle(&mut self, now: Tick) -> Result<PortalAssignment, StorageError> {
-        let portal_assignment_id = self.counters.portal_assignment_id.next();
-        self.sched_portal_assignments
-            .insert(portal_assignment_id, now);
-
         let confirmed_up_to = self.sched_worker_assignment_confirmation;
+        let portal_assignment_id = self.counters.portal_assignment_id.next();
+        self.sched_portal_assignments.insert(
+            portal_assignment_id,
+            PortalAssignmentEntry {
+                created_at: now,
+                confirmed_up_to,
+            },
+        );
 
         // Before the promote/drop pass so corrections fired this cycle take
         // effect immediately.
@@ -1004,17 +1013,6 @@ impl SchedulerStorage for InMemoryStorage {
         for meta in self.sched_chunk_metadata.values_mut() {
             if meta.marked_for_removal && meta.dropped_at_portal_assignment_id.is_none() {
                 meta.dropped_at_portal_assignment_id = Some(portal_assignment_id);
-            }
-        }
-
-        // Activate drains: once the superseding assignment is confirmed, this is
-        // the portal assignment that drops the pair — stamp it to start the
-        // M-tick drain.
-        for mapping in self.sched_stale_mappings.values_mut() {
-            if mapping.dropped_at_portal_assignment_id.is_none()
-                && mapping.superseded_at_worker_assignment_id <= confirmed_up_to
-            {
-                mapping.dropped_at_portal_assignment_id = Some(portal_assignment_id);
             }
         }
 

--- a/src/scheduler_storage/in_memory/tests/inspect.rs
+++ b/src/scheduler_storage/in_memory/tests/inspect.rs
@@ -37,11 +37,17 @@ impl StorageInspect for InMemoryStorage {
         self.sched_stale_mappings
             .iter()
             .filter_map(|((pk, worker_id), mapping)| {
+                // Derived drain anchor: first covering portal assignment.
+                let dropped_at_portal_assignment_id = self
+                    .sched_portal_assignments
+                    .iter()
+                    .find(|(_, e)| e.confirmed_up_to >= mapping.superseded_at_worker_assignment_id)
+                    .map(|(id, _)| *id);
                 let view = StaleMappingView {
                     chunk_pk: *pk,
                     worker_id: *worker_id,
                     superseded_at_worker_assignment_id: mapping.superseded_at_worker_assignment_id,
-                    dropped_at_portal_assignment_id: mapping.dropped_at_portal_assignment_id,
+                    dropped_at_portal_assignment_id,
                 };
                 filter(&view).then_some(view)
             })
@@ -116,7 +122,7 @@ impl StorageInspect for InMemoryStorage {
     }
 
     fn get_portal_assignment_created_at(&self, id: u64) -> Option<Tick> {
-        self.sched_portal_assignments.get(&id).copied()
+        self.sched_portal_assignments.get(&id).map(|e| e.created_at)
     }
 
     fn get_worker_assignment_confirmation(&self) -> u64 {

--- a/src/scheduler_storage/in_memory/tests/mod.rs
+++ b/src/scheduler_storage/in_memory/tests/mod.rs
@@ -223,7 +223,6 @@ fn update_worker_set_cleans_stale_mappings_for_departed() {
         (ChunkPk(1), worker_id),
         StaleMapping {
             superseded_at_worker_assignment_id: 1,
-            dropped_at_portal_assignment_id: None,
         },
     );
 
@@ -242,9 +241,13 @@ fn setup_for_tombstone(portal_drop_tick: TimeUnit) -> (InMemoryStorage, ChunkPk)
     let pk = storage.pk_of(&chunk);
 
     let portal_aid = 7;
-    storage
-        .sched_portal_assignments
-        .insert(portal_aid, portal_drop_tick);
+    storage.sched_portal_assignments.insert(
+        portal_aid,
+        PortalAssignmentEntry {
+            created_at: portal_drop_tick,
+            confirmed_up_to: 0,
+        },
+    );
     storage.sched_chunk_metadata.insert(
         pk,
         SchedulerChunkMetadata {
@@ -309,7 +312,6 @@ fn tombstone_clears_stale_mappings_for_chunk() {
     let (mut storage, pk) = setup_for_tombstone(100);
     let pending = |w_aid: u64| StaleMapping {
         superseded_at_worker_assignment_id: w_aid,
-        dropped_at_portal_assignment_id: None,
     };
     storage
         .sched_stale_mappings
@@ -403,7 +405,6 @@ fn build_worker_assignment_unions_ideal_and_stale() {
         (pk_1, WorkerPk(99)),
         StaleMapping {
             superseded_at_worker_assignment_id: 1,
-            dropped_at_portal_assignment_id: None,
         },
     ); // grace-period holdover
 
@@ -557,9 +558,8 @@ fn run_visibility_cycle_uses_ideal_not_stale() {
     storage.sched_stale_mappings.insert(
         (pk, WorkerPk(99)),
         StaleMapping {
-            // > watermark: stays pending so activation doesn't drain it
+            // > watermark: stays pending, never drains
             superseded_at_worker_assignment_id: 999,
-            dropped_at_portal_assignment_id: None,
         },
     );
 

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -106,14 +106,13 @@ pub struct WorkerAssignmentChunk {
     pub tables_present: Option<bit_vec::BitVec>,
 }
 
-impl WorkerAssignmentChunk {
-    /// Project the chunk down to what the scheduling algorithms may see.
-    pub fn algo_view(&self) -> AlgoChunk {
+impl From<&WorkerAssignmentChunk> for AlgoChunk {
+    fn from(chunk: &WorkerAssignmentChunk) -> Self {
         AlgoChunk {
-            dataset: self.dataset.clone(),
-            id: self.id.clone(),
-            size: self.size,
-            blocks: self.blocks.clone(),
+            dataset: chunk.dataset.clone(),
+            id: chunk.id.clone(),
+            size: chunk.size,
+            blocks: chunk.blocks.clone(),
         }
     }
 }

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -11,7 +11,7 @@ use crate::weight::SchedulingChunk;
 pub type Tick = u64;
 
 /// Monotonic assignment version (matches sched_worker_assignments.id / sched_portal_assignments.id).
-pub type AssignmentId = i64;
+pub type AssignmentId = i32;
 
 /// Errors returned across the [`SchedulerStorage`] boundary.
 #[derive(Debug, thiserror::Error)]

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -409,13 +409,13 @@ impl SchedulerStorage for PostgresStorage {
             let _timer = Timer::new("run_visibility_cycle");
             let mut tx = conn.begin().await.context("run_visibility_cycle: begin")?;
 
-            let new_pa_id = phase::open_portal_assignment(&mut tx, now).await?;
+            // Watermark read first so the portal assignment records it (activates drains).
             let confirmed_up_to = phase::confirmation_watermark(&mut tx).await?;
+            let new_pa_id = phase::open_portal_assignment(&mut tx, now, confirmed_up_to).await?;
 
             phase::apply_ready_corrections(&mut tx, new_pa_id, confirmed_up_to, now).await?;
             phase::promote_eligible_chunks(&mut tx, new_pa_id, confirmed_up_to).await?;
             phase::drop_marked_chunks(&mut tx, new_pa_id).await?;
-            phase::activate_confirmed_drains(&mut tx, new_pa_id, confirmed_up_to).await?;
 
             tx.commit().await.context("run_visibility_cycle: commit")?;
 

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -314,10 +314,13 @@ impl SchedulerStorage for PostgresStorage {
             // Phase B — placement reconcile; rolls back on shortage, leaving Phase A committed.
             let mut tx = conn.begin().await.context("run_scheduling_cycle: begin")?;
 
-            // One streamed round-trip for the algorithm's inputs; build_worker_assignment
-            // re-fetches the (much smaller) placed subset itself.
-            let (chunks_for_algo, current_placement) =
-                phase::fetch_active_chunks_with_placement(&mut tx).await?;
+            // One streamed round-trip decoding the algorithm's inputs and the published chunk
+            // columns together, so the post-commit assignment build needn't re-read them.
+            let phase::ActiveChunks {
+                for_algo: chunks_for_algo,
+                current_placement,
+                published: published_chunks,
+            } = phase::fetch_active_chunks_with_placement(&mut tx).await?;
 
             let worker_rows = phase::fetch_workers(&mut tx).await?;
             let phase::DecodedWorkers {
@@ -343,14 +346,10 @@ impl SchedulerStorage for PostgresStorage {
                 out
             };
 
-            // Open the assignment the diffs and stamps below record under.
             let new_wa_id = phase::open_worker_assignment(&mut tx, now).await?;
 
-            // Stage the new ideal into the empty future twin (the only app-side marshalling left),
-            // then derive every per-cycle delta — stale mint, routing diffs, flip-flop resolution,
-            // entered stamps — and promote the twin, all as one simple-query round-trip joining the
-            // live ideal (prev) against the future ideal (new). The swap runs last in that batch, so
-            // the diffs still read the still-live prev ideal.
+            // Stage the new ideal into the future twin, then diff it against the live ideal to
+            // derive the cycle's deltas and swap the twins.
             phase::write_future_ideal(&mut tx, &ideal_mappings, batch_size).await?;
             phase::apply_deltas_and_swap(&mut tx, new_wa_id).await?;
 
@@ -359,8 +358,10 @@ impl SchedulerStorage for PostgresStorage {
             let wa = phase::build_worker_assignment(
                 conn,
                 new_wa_id,
-                &workers_map,
+                workers_map,
                 replication_by_weight,
+                ideal_mappings,
+                published_chunks,
             )
             .await?;
             Ok::<_, StorageError>(wa)

--- a/src/scheduler_storage/postgres/rows.rs
+++ b/src/scheduler_storage/postgres/rows.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use libp2p_identity::PeerId;
 
 use crate::scheduler_storage::{
-    AlgoChunk, AssignmentWorker, ChunkPk, NewChunk, SchemaId, WorkerAssignmentChunk, WorkerPk,
+    AssignmentWorker, ChunkPk, NewChunk, SchemaId, WorkerAssignmentChunk, WorkerPk,
 };
 use crate::types::{BlockNumber, WorkerStatus};
 
@@ -26,19 +26,6 @@ pub(super) struct ChunkRow {
     pub(super) first_block: i64,
     /// last_block - first_block; add to `first_block` to recover the inclusive end.
     pub(super) last_block_delta: i32,
-}
-
-/// Slim row for the hot scheduling-cycle read (no schema columns), decoding into [`AlgoChunk`]
-/// plus the chunk's placement. `worker_ids` is `None` for a never-placed chunk.
-#[derive(sqlx::FromRow)]
-pub(super) struct AlgoChunkRow {
-    pub(super) chunk_pk: ChunkPk,
-    pub(super) dataset_name: String,
-    pub(super) chunk_id: String,
-    pub(super) size: i32,
-    pub(super) first_block: i64,
-    pub(super) last_block_delta: i32,
-    pub(super) worker_ids: Option<Vec<WorkerPk>>,
 }
 
 #[derive(sqlx::FromRow)]
@@ -90,15 +77,6 @@ pub(super) fn chunk_from_row(row: ChunkRow, dataset: Arc<String>) -> WorkerAssig
         blocks: block_range_from_columns(row.first_block, row.last_block_delta),
         schema_id: row.schema_id,
         tables_present: row.tables_present,
-    }
-}
-
-pub(super) fn algo_chunk_from_row(row: AlgoChunkRow, dataset: Arc<String>) -> AlgoChunk {
-    AlgoChunk {
-        dataset,
-        id: Arc::new(row.chunk_id),
-        size: row.size as u32,
-        blocks: block_range_from_columns(row.first_block, row.last_block_delta),
     }
 }
 

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -2,9 +2,12 @@
 //! cycle's transaction, plus the post-commit [`build_worker_assignment`] read.
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 
 use anyhow::{Context, Result};
 use futures::TryStreamExt;
+use itertools::Itertools as _;
+use rustc_hash::FxHashMap;
 use semver::Version;
 use sqlx::postgres::PgConnection;
 use sqlx::{Postgres, Transaction};
@@ -18,8 +21,8 @@ use crate::scheduler_storage::{
 use crate::types::Worker;
 
 use super::rows::{
-    ActiveChunkRow, AlgoChunkRow, DatasetInterner, WorkerRow, algo_chunk_from_row,
-    assignment_worker_from_row, chunk_from_row, tick_to_i64,
+    ActiveChunkRow, DatasetInterner, WorkerRow, assignment_worker_from_row, chunk_from_row,
+    tick_to_i64,
 };
 
 /// Per-chunk stale holders aggregated once, for `LEFT JOIN stale_agg st` — pairs with
@@ -128,17 +131,30 @@ pub(super) async fn expire_drained_stale_mappings(
     Ok(())
 }
 
-/// Active (not tombstoned/rejected) chunks decoded straight into the algorithm's inputs: the
-/// chunks in (dataset, block) order plus the placement map (ideal ∪ stale; entries only for
-/// placed chunks). Streamed — a buffered row Vec was ~1 GB at 6M chunks.
+/// The scheduling cycle's one streamed read of the active (not tombstoned/rejected) chunk set,
+/// decoded into every in-memory form the rest of the cycle needs.
+pub(super) struct ActiveChunks {
+    /// The algorithm's chunk input, in (dataset, block) order.
+    pub(super) for_algo: Vec<(ChunkPk, AlgoChunk)>,
+    /// ideal ∪ stale; entries only for placed chunks.
+    pub(super) current_placement: CurrentPlacement,
+    /// Full-column decode of the active rows, reused by the post-commit
+    /// [`build_worker_assignment`] so it needn't re-read the chunks; shares `for_algo`'s `Arc`s.
+    pub(super) published: FxHashMap<ChunkPk, WorkerAssignmentChunk>,
+}
+
+/// Reads every active chunk — registered, and neither `rejected` nor removed (tombstoned) — spanning
+/// the lifecycle from **pending** (registered but not yet placed) through **marked-for-removal**.
+/// Pending chunks are included so the algorithm can place them; they carry no `current_placement` entry.
 pub(super) async fn fetch_active_chunks_with_placement(
     tx: &mut Transaction<'_, Postgres>,
-) -> Result<(Vec<(ChunkPk, AlgoChunk)>, CurrentPlacement)> {
+) -> Result<ActiveChunks> {
     let mut timer = PhaseTimer::new("run_scheduling_cycle:fetch_active_chunks_with_placement");
     let sql = format!(
         r#"
         {STALE_AGG_CTE}
         SELECT c.chunk_pk, d.name AS dataset_name, c.chunk_id, c.size,
+               c.schema_id, c.tables_present,
                c.first_block, c.last_block_delta,
                {PLACEMENT_MERGE}
         FROM chunks c
@@ -148,30 +164,35 @@ pub(super) async fn fetch_active_chunks_with_placement(
         LEFT JOIN stale_agg st ON st.chunk_pk = c.chunk_pk
         WHERE s.dropped_from_worker_assignment_at IS NULL
           AND NOT s.rejected
-        ORDER by (d.name, c.first_block)
+        ORDER BY d.name, c.first_block
         "#
     );
-    let mut stream = sqlx::query_as::<_, AlgoChunkRow>(sqlx::AssertSqlSafe(sql)).fetch(&mut **tx);
+    let mut stream = sqlx::query_as::<_, ActiveChunkRow>(sqlx::AssertSqlSafe(sql)).fetch(&mut **tx);
 
     let mut datasets = DatasetInterner::new();
-    let mut chunks_for_algo: Vec<(ChunkPk, AlgoChunk)> = Vec::new();
-    let mut current_placement = CurrentPlacement::default();
+    let mut out = ActiveChunks {
+        for_algo: Vec::new(),
+        current_placement: CurrentPlacement::default(),
+        published: FxHashMap::default(),
+    };
     let mut count = 0u64;
     while let Some(mut row) = stream
         .try_next()
         .await
         .context("run_scheduling_cycle: fetch active chunks with placement")?
     {
-        let dataset = datasets.intern(&row.dataset_name);
-        let pk = row.chunk_pk;
+        let dataset = datasets.intern(&row.chunk.dataset_name);
+        let pk = row.chunk.chunk_pk;
         if let Some(holders) = row.worker_ids.take() {
-            current_placement.insert(pk, holders);
+            out.current_placement.insert(pk, holders);
         }
-        chunks_for_algo.push((pk, algo_chunk_from_row(row, dataset)));
+        let chunk = chunk_from_row(row.chunk, dataset);
+        out.for_algo.push((pk, AlgoChunk::from(&chunk)));
+        out.published.insert(pk, chunk);
         count += 1;
     }
     timer.stmt(count);
-    Ok((chunks_for_algo, current_placement))
+    Ok(out)
 }
 
 pub(super) async fn fetch_workers(tx: &mut Transaction<'_, Postgres>) -> Result<Vec<WorkerRow>> {
@@ -214,9 +235,10 @@ pub(super) async fn apply_deltas_and_swap(
 ///   1. Mint superseded stale: holders the future ideal drops that still hold a draining copy —
 ///      known workers only (a GC'd worker holds nothing, and its stale row would break the FK), and
 ///      not chunks mid portal-drop. `DO NOTHING` keeps any pre-existing stale row.
-///   2. Record routing diffs: chunks whose holder set changed (emit future holders) or were dropped
-///      (emit `'{}'`). Canonical arrays make `IS DISTINCT FROM` an exact set test; the arms are
-///      disjoint, so no PK conflict.
+///   2. Record routing diffs in one FULL JOIN pass (both PKs merge-join): chunks whose holder set
+///      changed or entered (emit future holders) or were dropped (emit `'{}'` via the COALESCE).
+///      Canonical arrays make `IS DISTINCT FROM` an exact set test, and it also covers the
+///      one-sided rows: a NULL side is distinct from any holder set.
 ///   3. Resolve flip-flops: a pair back in the new ideal is no longer stale.
 ///   4. Stamp entered chunks: first-touch the assignment id onto chunks new to the ideal.
 ///   5. Swap: truncate the old ideal, then 3-way rename so the future twin becomes live and the old
@@ -237,15 +259,10 @@ WHERE u.worker_id <> ALL (COALESCE(f.worker_ids, '{}'::bigint[]))
 ON CONFLICT (chunk_pk, worker_id) DO NOTHING;
 
 INSERT INTO sched_worker_assignment_diffs (worker_assignment_id, chunk_pk, worker_ids)
-SELECT $WA, f.chunk_pk, f.worker_ids
+SELECT $WA, COALESCE(f.chunk_pk, c.chunk_pk), COALESCE(f.worker_ids, '{}'::bigint[])
 FROM sched_future_ideal_chunk_workers f
-LEFT JOIN sched_ideal_chunk_workers c ON c.chunk_pk = f.chunk_pk
-WHERE f.worker_ids IS DISTINCT FROM c.worker_ids
-UNION ALL
-SELECT $WA, c.chunk_pk, '{}'::bigint[]
-FROM sched_ideal_chunk_workers c
-LEFT JOIN sched_future_ideal_chunk_workers f ON f.chunk_pk = c.chunk_pk
-WHERE f.chunk_pk IS NULL;
+FULL JOIN sched_ideal_chunk_workers c ON c.chunk_pk = f.chunk_pk
+WHERE f.worker_ids IS DISTINCT FROM c.worker_ids;
 
 DELETE FROM sched_stale_mappings s
 USING sched_future_ideal_chunk_workers f
@@ -264,20 +281,34 @@ ALTER TABLE sched_future_ideal_chunk_workers RENAME TO sched_ideal_chunk_workers
 ALTER TABLE sched_ideal_chunk_workers__swap RENAME TO sched_future_ideal_chunk_workers;
 "#;
 
-/// Stage the freshly computed ideal into the (empty) future twin via one `COPY … FROM STDIN`: one
-/// text row per chunk. Holders arrive canonical from `invert_worker_chunks` (sorted by worker_pk,
-/// distinct), so each stored array stays canonical for next cycle's `IS DISTINCT FROM` diff against
-/// the live ideal. (The algorithm emits a chunk only once a worker holds it, so there are no
-/// empty-holder rows.)
+/// Stage the freshly computed ideal into the empty future twin via one `COPY … FROM STDIN`. The PK
+/// is dropped before the COPY and rebuilt after, so the load does a single sorted index build rather
+/// than a per-row btree insert per chunk.
 pub(super) async fn write_future_ideal(
     tx: &mut Transaction<'_, Postgres>,
     ideal_mappings: &[(ChunkPk, Vec<WorkerPk>)],
     batch_size: usize,
 ) -> Result<()> {
-    use itertools::Itertools as _;
-    use std::fmt::Write as _;
-
     let mut timer = PhaseTimer::new("run_scheduling_cycle:write_future_ideal");
+    // Drop the PK by catalog lookup, not by name: a swap renames the twins and carries their
+    // constraint names along, so this table's PK name isn't predictable. (The rebuild re-adds it
+    // unnamed for the same reason.)
+    sqlx::raw_sql(
+        r#"
+        DO $$
+        DECLARE c name;
+        BEGIN
+            SELECT conname INTO c FROM pg_constraint
+            WHERE conrelid = 'sched_future_ideal_chunk_workers'::regclass AND contype = 'p';
+            IF c IS NOT NULL THEN
+                EXECUTE format('ALTER TABLE sched_future_ideal_chunk_workers DROP CONSTRAINT %I', c);
+            END IF;
+        END $$;
+        "#,
+    )
+    .execute(&mut **tx)
+    .await
+    .context("run_scheduling_cycle: drop future ideal pk")?;
     let mut copy = tx
         .copy_in_raw("COPY sched_future_ideal_chunk_workers (chunk_pk, worker_ids) FROM STDIN")
         .await
@@ -312,6 +343,10 @@ pub(super) async fn write_future_ideal(
         .finish()
         .await
         .context("run_scheduling_cycle: finish COPY future ideal")?;
+    sqlx::raw_sql("ALTER TABLE sched_future_ideal_chunk_workers ADD PRIMARY KEY (chunk_pk)")
+        .execute(&mut **tx)
+        .await
+        .context("run_scheduling_cycle: rebuild future ideal pk")?;
     timer.stmt(rows);
     Ok(())
 }
@@ -351,57 +386,53 @@ pub(super) fn decode_workers(worker_rows: &[WorkerRow]) -> Result<DecodedWorkers
     })
 }
 
-/// Post-commit read building the published WorkerAssignment: ideal ∪ stale,
-/// excluding tombstoned chunks.
+/// Post-commit assembly of the published WorkerAssignment: ideal ∪ stale, excluding tombstoned
+/// chunks.
 pub(super) async fn build_worker_assignment(
     conn: &mut PgConnection,
     id: AssignmentId,
-    workers: &BTreeMap<WorkerPk, AssignmentWorker>,
+    workers: BTreeMap<WorkerPk, AssignmentWorker>,
     replication_by_weight: BTreeMap<u16, u16>,
+    ideal_mappings: Vec<(ChunkPk, Vec<WorkerPk>)>,
+    mut active_chunks: FxHashMap<ChunkPk, WorkerAssignmentChunk>,
 ) -> Result<WorkerAssignment> {
     let mut timer = PhaseTimer::new("run_scheduling_cycle:build_worker_assignment");
-    // The `(i … OR st …)` guard keeps only placed chunks (an active chunk the algorithm left
-    // unplaced is not published).
-    let sql = format!(
-        r#"
-        {STALE_AGG_CTE}
-        SELECT c.chunk_pk, d.name AS dataset_name, c.chunk_id, c.size,
-               c.schema_id, c.tables_present,
-               c.first_block, c.last_block_delta,
-               {PLACEMENT_MERGE}
-        FROM sched_chunk_metadata m
-        JOIN chunks c ON c.chunk_pk = m.chunk_pk
-        JOIN datasets d ON d.id = c.dataset_id
-        LEFT JOIN sched_ideal_chunk_workers i ON i.chunk_pk = m.chunk_pk
-        LEFT JOIN stale_agg st ON st.chunk_pk = m.chunk_pk
-        WHERE m.dropped_from_worker_assignment_at IS NULL
-          AND NOT m.rejected
-          AND (i.chunk_pk IS NOT NULL OR st.chunk_pk IS NOT NULL)
-        "#
-    );
-    let rows: Vec<ActiveChunkRow> = sqlx::query_as(sqlx::AssertSqlSafe(sql))
-        .fetch_all(&mut *conn)
-        .await
-        .context("build_worker_assignment: fetch placement and chunks")?;
-    timer.stmt(rows.len() as u64);
+    // Post-delta stale holders: pre-existing rows plus this cycle's mint, minus resolved
+    // flip-flops and phase-A drops — i.e. exactly what the committed table now holds.
+    let stale: Vec<(ChunkPk, Vec<WorkerPk>)> = sqlx::query_as(
+        "SELECT chunk_pk, array_agg(worker_id) FROM sched_stale_mappings GROUP BY chunk_pk",
+    )
+    .fetch_all(&mut *conn)
+    .await
+    .context("build_worker_assignment: fetch stale holders")?;
+    timer.stmt(stale.len() as u64);
 
-    let mut datasets = DatasetInterner::new();
-    let mut chunk_workers: BTreeMap<ChunkPk, Vec<WorkerPk>> = BTreeMap::new();
-    let mut chunks_out: BTreeMap<ChunkPk, WorkerAssignmentChunk> = BTreeMap::new();
-    for ActiveChunkRow { chunk, worker_ids } in rows {
-        let pk = chunk.chunk_pk;
-        let dataset = datasets.intern(&chunk.dataset_name);
-        chunks_out.insert(pk, chunk_from_row(chunk, dataset));
-        // Placement drives the join, so worker_ids is always present; the default just guards a
-        // NULL we never expect instead of panicking.
-        chunk_workers.insert(pk, worker_ids.unwrap_or_default());
+    let mut chunk_workers: BTreeMap<ChunkPk, Vec<WorkerPk>> = ideal_mappings.into_iter().collect();
+    for (pk, extra) in stale {
+        // Keep holder sets canonical (sorted, distinct), as the SQL merge did.
+        let holders = chunk_workers.entry(pk).or_default();
+        holders.extend(extra);
+        holders.sort_unstable();
+        holders.dedup();
     }
+
+    // Publish only placed chunks (an active chunk the algorithm left unplaced is not published).
+    // A placed pk absent from the active set is a stale row for a chunk tombstoned in an earlier
+    // GC — its holders must not be published either.
+    let mut chunks_out: BTreeMap<ChunkPk, WorkerAssignmentChunk> = BTreeMap::new();
+    chunk_workers.retain(|pk, _| match active_chunks.remove(pk) {
+        Some(chunk) => {
+            chunks_out.insert(*pk, chunk);
+            true
+        }
+        None => false,
+    });
 
     Ok(WorkerAssignment {
         id,
         chunk_workers,
         chunks: chunks_out,
-        workers: workers.clone(),
+        workers,
         replication_by_weight,
     })
 }

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -105,7 +105,8 @@ pub(super) async fn tombstone_expired_chunks(
     Ok(())
 }
 
-/// Expire stale mappings whose portal-drop landed at least `m_ticks` ago.
+/// Expire stale mappings whose drain activated at least `m_ticks` ago: those at/under the newest
+/// watermark among aged portal assignments (exact: both monotone over assignment ids).
 pub(super) async fn expire_drained_stale_mappings(
     tx: &mut Transaction<'_, Postgres>,
     now: u64,
@@ -115,11 +116,11 @@ pub(super) async fn expire_drained_stale_mappings(
     let res = sqlx::query(
         r#"
         DELETE FROM sched_stale_mappings
-        WHERE dropped_at_portal_assignment_id IS NOT NULL
-          AND dropped_at_portal_assignment_id IN (
-              SELECT id FROM sched_portal_assignments
-              WHERE created_at <= $1 - $2
-          )
+        WHERE superseded_at_worker_assignment_id <= (
+            SELECT COALESCE(MAX(confirmed_up_to), 0)
+            FROM sched_portal_assignments
+            WHERE created_at <= $1 - $2
+        )
         "#,
     )
     .bind(tick_to_i64(now))

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -250,7 +250,7 @@ SELECT c.chunk_pk, u.worker_id, $WA
 FROM sched_ideal_chunk_workers c
 LEFT JOIN sched_future_ideal_chunk_workers f ON f.chunk_pk = c.chunk_pk
 CROSS JOIN LATERAL UNNEST(c.worker_ids) AS u(worker_id)
-WHERE u.worker_id <> ALL (COALESCE(f.worker_ids, '{}'::bigint[]))
+WHERE u.worker_id <> ALL (COALESCE(f.worker_ids, '{}'::int[]))
   AND EXISTS (SELECT 1 FROM sched_workers sw WHERE sw.id = u.worker_id)
   AND NOT EXISTS (
       SELECT 1 FROM sched_chunk_metadata m
@@ -260,7 +260,7 @@ WHERE u.worker_id <> ALL (COALESCE(f.worker_ids, '{}'::bigint[]))
 ON CONFLICT (chunk_pk, worker_id) DO NOTHING;
 
 INSERT INTO sched_worker_assignment_diffs (worker_assignment_id, chunk_pk, worker_ids)
-SELECT $WA, COALESCE(f.chunk_pk, c.chunk_pk), COALESCE(f.worker_ids, '{}'::bigint[])
+SELECT $WA, COALESCE(f.chunk_pk, c.chunk_pk), COALESCE(f.worker_ids, '{}'::int[])
 FROM sched_future_ideal_chunk_workers f
 FULL JOIN sched_ideal_chunk_workers c ON c.chunk_pk = f.chunk_pk
 WHERE f.worker_ids IS DISTINCT FROM c.worker_ids;

--- a/src/scheduler_storage/postgres/tests/correction_tests.rs
+++ b/src/scheduler_storage/postgres/tests/correction_tests.rs
@@ -68,7 +68,7 @@ fn anchor_metadata_column(
         format!("UPDATE sched_chunk_metadata SET {metadata_column} = $2 WHERE chunk_pk = $1");
     storage
         .with_conn(async move |conn| {
-            let anchor_id: i64 = sqlx::query_scalar(insert_sql)
+            let anchor_id: i32 = sqlx::query_scalar(insert_sql)
                 .fetch_one(&mut *conn)
                 .await
                 .unwrap();

--- a/src/scheduler_storage/postgres/tests/correction_tests.rs
+++ b/src/scheduler_storage/postgres/tests/correction_tests.rs
@@ -88,7 +88,7 @@ fn set_dropped_at_portal(storage: &mut PostgresStorage, chunk_pk: ChunkPk) {
     anchor_metadata_column(
         storage,
         chunk_pk,
-        "INSERT INTO sched_portal_assignments (created_at) VALUES (1) RETURNING id",
+        "INSERT INTO sched_portal_assignments (created_at, confirmed_up_to) VALUES (1, 0) RETURNING id",
         "dropped_at_portal_assignment_id",
     );
 }

--- a/src/scheduler_storage/postgres/tests/inspect.rs
+++ b/src/scheduler_storage/postgres/tests/inspect.rs
@@ -47,10 +47,10 @@ impl StorageInspect for PostgresStorage {
         #[allow(clippy::type_complexity)]
         let rows: Vec<(
             i64,
-            Option<i64>,
-            Option<i64>,
+            Option<i32>,
+            Option<i32>,
             bool,
-            Option<i64>,
+            Option<i32>,
             Option<i64>,
             bool,
         )> = self
@@ -103,7 +103,7 @@ impl StorageInspect for PostgresStorage {
         F: FnMut(&StaleMappingView) -> bool,
     {
         // Derived drain anchor: the first portal assignment whose watermark covers the row.
-        let rows: Vec<(i64, i64, i64, Option<i64>)> = self
+        let rows: Vec<(i64, i32, i32, Option<i32>)> = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_as(
                     "SELECT s.chunk_pk, s.worker_id, \
@@ -143,7 +143,7 @@ impl StorageInspect for PostgresStorage {
     where
         F: FnMut(&WorkerView) -> bool,
     {
-        let rows: Vec<(i64, String, Option<String>, Option<i64>)> = self
+        let rows: Vec<(i32, String, Option<String>, Option<i64>)> = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_as(
                     "SELECT id, peer_id, version, inactive_since \
@@ -169,7 +169,7 @@ impl StorageInspect for PostgresStorage {
     where
         F: FnMut(&ChunkPk, &[WorkerPk]) -> bool,
     {
-        let rows: Vec<(i64, Vec<i64>)> = self
+        let rows: Vec<(i64, Vec<i32>)> = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_as(
                     "SELECT chunk_pk, worker_ids \
@@ -195,7 +195,7 @@ impl StorageInspect for PostgresStorage {
     where
         F: FnMut(&WorkerAssignmentDiffView) -> bool,
     {
-        let rows: Vec<(i64, i64, Vec<i64>)> = self
+        let rows: Vec<(i32, i64, Vec<i32>)> = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_as(
                     "SELECT worker_assignment_id, chunk_pk, worker_ids \
@@ -222,7 +222,7 @@ impl StorageInspect for PostgresStorage {
     where
         F: FnMut(&CorrectionView) -> bool,
     {
-        let rows: Vec<(i64, i64, String, i64, Option<i64>)> = self
+        let rows: Vec<(i64, i64, String, i64, Option<i32>)> = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_as(
                     "SELECT cc.old_chunk_pk, cc.new_chunk_pk, d.name, cc.created_at, \
@@ -252,7 +252,7 @@ impl StorageInspect for PostgresStorage {
         let result: Option<i64> = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_scalar("SELECT created_at FROM sched_portal_assignments WHERE id = $1")
-                    .bind(i64::try_from(id).expect("portal assignment id overflows i64"))
+                    .bind(i32::try_from(id).expect("portal assignment id overflows i32"))
                     .fetch_optional(conn)
                     .await
             })
@@ -261,7 +261,7 @@ impl StorageInspect for PostgresStorage {
     }
 
     fn get_worker_assignment_confirmation(&self) -> u64 {
-        let result: i64 = self
+        let result: i32 = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_scalar(
                     "SELECT COALESCE(MAX(assignment_id), 0) FROM sched_worker_confirmations",

--- a/src/scheduler_storage/postgres/tests/inspect.rs
+++ b/src/scheduler_storage/postgres/tests/inspect.rs
@@ -102,14 +102,16 @@ impl StorageInspect for PostgresStorage {
     where
         F: FnMut(&StaleMappingView) -> bool,
     {
+        // Derived drain anchor: the first portal assignment whose watermark covers the row.
         let rows: Vec<(i64, i64, i64, Option<i64>)> = self
             .with_conn_ref(async move |conn| {
                 sqlx::query_as(
-                    "SELECT chunk_pk, worker_id, \
-                            superseded_at_worker_assignment_id, \
-                            dropped_at_portal_assignment_id \
-                     FROM sched_stale_mappings \
-                     ORDER BY chunk_pk, worker_id",
+                    "SELECT s.chunk_pk, s.worker_id, \
+                            s.superseded_at_worker_assignment_id, \
+                            (SELECT MIN(p.id) FROM sched_portal_assignments p \
+                             WHERE p.confirmed_up_to >= s.superseded_at_worker_assignment_id) \
+                     FROM sched_stale_mappings s \
+                     ORDER BY s.chunk_pk, s.worker_id",
                 )
                 .fetch_all(conn)
                 .await

--- a/src/scheduler_storage/postgres/tests/mod.rs
+++ b/src/scheduler_storage/postgres/tests/mod.rs
@@ -6,6 +6,7 @@ mod drain_tests;
 mod inspect;
 mod registration_tests;
 mod schema;
+mod worker_tests;
 
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/src/scheduler_storage/postgres/tests/worker_tests.rs
+++ b/src/scheduler_storage/postgres/tests/worker_tests.rs
@@ -1,0 +1,49 @@
+//! How many ids the PG worker-set sync spends. Its behaviour is covered by the in-memory suite.
+
+use super::fresh_storage;
+use crate::scheduler_storage::postgres::PostgresStorage;
+use crate::scheduler_storage::test_harness::inspect::StorageInspect;
+use crate::scheduler_storage::test_harness::utils::worker;
+use crate::scheduler_storage::{SchedulerStorage, StorageError};
+use crate::types::Worker;
+
+/// Last value handed out by `sched_workers.id`'s sequence — i.e. how many ids the syncs consumed.
+fn ids_consumed(storage: &mut PostgresStorage) -> i64 {
+    storage
+        .with_conn(async move |conn| {
+            let used: i64 =
+                sqlx::query_scalar("SELECT COALESCE(last_value, 0) FROM sched_workers_id_seq")
+                    .fetch_one(&mut *conn)
+                    .await
+                    .unwrap();
+            Ok::<_, StorageError>(used)
+        })
+        .unwrap()
+}
+
+/// `sched_workers.id` is a 32-bit SERIAL, so ids must be spent per distinct worker, not per sync. An
+/// `ON CONFLICT DO UPDATE` upsert breaks this invisibly — the rows it writes are correct, only the
+/// sequence runs away — so nothing else in the suite would catch it.
+#[test]
+fn resyncing_an_unchanged_worker_set_consumes_no_ids() {
+    let mut storage = fresh_storage("worker_seq");
+    let active: Vec<Worker> = (1..=8).map(|seed| worker(seed, Some("2.8.0"))).collect();
+
+    storage
+        .update_worker_set(&active, 1, 100)
+        .expect("first sync");
+    let after_first = ids_consumed(&mut storage);
+    assert_eq!(after_first, 8, "one id per worker on first registration");
+
+    for tick in 2..=10 {
+        storage
+            .update_worker_set(&active, tick, 100)
+            .expect("re-sync");
+    }
+    assert_eq!(
+        ids_consumed(&mut storage),
+        after_first,
+        "re-syncing the same active set must not consume ids",
+    );
+    assert_eq!(storage.get_workers(|_| true).len(), 8, "no duplicate rows");
+}

--- a/src/scheduler_storage/postgres/visibility.rs
+++ b/src/scheduler_storage/postgres/visibility.rs
@@ -62,48 +62,37 @@ pub(super) async fn replay_confirmed_diffs(
     // in (prev, assignment_id] (one per cycle it changed). Keep the newest per chunk — both because
     // it's the current routing and because one INSERT can't hit the same ON CONFLICT row twice:
     // `DISTINCT ON (chunk_pk) ... ORDER BY worker_assignment_id DESC`. Empty final set = removed.
+    //
+    // One statement: `final` has two consumers, so it materializes once instead of the window's
+    // scan+sort running twice. The upsert and delete rows are disjoint (empty vs non-empty final
+    // holder set); `rows_affected` reports only the DELETE.
     let mut timer = PhaseTimer::new("confirm_worker_assignment:replay_confirmed_diffs");
-    let upserted = sqlx::query(
+    let res = sqlx::query(
         r#"
-        INSERT INTO sched_confirmed_chunk_workers (chunk_pk, worker_ids)
-        SELECT chunk_pk, worker_ids
-        FROM (
+        WITH final AS (
             SELECT DISTINCT ON (chunk_pk) chunk_pk, worker_ids
             FROM sched_worker_assignment_diffs
             WHERE worker_assignment_id > $1
               AND worker_assignment_id <= $2
             ORDER BY chunk_pk, worker_assignment_id DESC
-        ) final
-        WHERE cardinality(worker_ids) > 0
-        ON CONFLICT (chunk_pk) DO UPDATE SET worker_ids = EXCLUDED.worker_ids
-        "#,
-    )
-    .bind(prev)
-    .bind(assignment_id)
-    .execute(&mut **tx)
-    .await?;
-    timer.stmt(upserted.rows_affected());
-
-    let deleted = sqlx::query(
-        r#"
-        DELETE FROM sched_confirmed_chunk_workers
-        WHERE chunk_pk IN (
-            SELECT chunk_pk FROM (
-                SELECT DISTINCT ON (chunk_pk) chunk_pk, worker_ids
-                FROM sched_worker_assignment_diffs
-                WHERE worker_assignment_id > $1
-                  AND worker_assignment_id <= $2
-                ORDER BY chunk_pk, worker_assignment_id DESC
-            ) final
-            WHERE cardinality(worker_ids) = 0
+        ),
+        upsert AS (
+            INSERT INTO sched_confirmed_chunk_workers (chunk_pk, worker_ids)
+            SELECT chunk_pk, worker_ids FROM final
+            WHERE cardinality(worker_ids) > 0
+            ON CONFLICT (chunk_pk) DO UPDATE SET worker_ids = EXCLUDED.worker_ids
         )
+        DELETE FROM sched_confirmed_chunk_workers ccw
+        USING final
+        WHERE ccw.chunk_pk = final.chunk_pk
+          AND cardinality(final.worker_ids) = 0
         "#,
     )
     .bind(prev)
     .bind(assignment_id)
     .execute(&mut **tx)
     .await?;
-    timer.stmt(deleted.rows_affected());
+    timer.stmt(res.rows_affected());
     Ok(())
 }
 

--- a/src/scheduler_storage/postgres/visibility.rs
+++ b/src/scheduler_storage/postgres/visibility.rs
@@ -244,12 +244,13 @@ pub(super) async fn apply_ready_corrections(
     Ok(())
 }
 
-/// Promote every eligible chunk to portal-visible in one UPDATE: confirmed by a worker assignment
-/// at/under the watermark, not yet visible, not dropped, not marked for removal, and not a pending
-/// correction's replacement (those promote via the correction path). No `rejected` check — rejected
-/// chunks never reach a worker assignment, so the first condition already excludes them. The
-/// non-overlap gate now lives in [`evict_portal_overlaps`], which settles overlaps in memory over the
-/// visible set we fetch anyway — so this neither fetches the candidates nor probes per chunk.
+/// Promote every chunk eligible at/under the confirmation watermark to portal-visible in one UPDATE
+/// Pending corrections' replacements are excluded — they promote via the
+/// correction path. `NOT rejected` is redundant for correctness (rejected chunks never reach a worker
+/// assignment) but the planner can't prove that; it's the conjunct that lets the UPDATE ride the
+/// `sched_chunk_metadata_promotable` partial index instead of seq-scanning the table every cycle. The
+/// non-overlap gate now lives in [`evict_portal_overlaps`], settling overlaps in memory over the
+/// visible set we already fetch — so this neither fetches candidates nor probes per chunk.
 pub(super) async fn promote_eligible_chunks(
     tx: &mut Transaction<'_, Postgres>,
     new_pa_id: AssignmentId,
@@ -259,7 +260,8 @@ pub(super) async fn promote_eligible_chunks(
     let res = sqlx::query(
         r#"
         UPDATE sched_chunk_metadata SET applied_at_portal_assignment_id = $1
-        WHERE applied_at_worker_assignment_id IS NOT NULL
+        WHERE NOT rejected
+          AND applied_at_worker_assignment_id IS NOT NULL
           AND applied_at_worker_assignment_id <= $2
           AND applied_at_portal_assignment_id IS NULL
           AND dropped_at_portal_assignment_id IS NULL
@@ -440,8 +442,7 @@ pub(super) async fn fetch_portal_visible_chunks(
 
 /// Confirmed routing for the portal-visible chunks. The visible set is re-derived server-side —
 /// the same predicate `fetch_portal_visible_chunks` reads and `evict_portal_overlaps` has already
-/// written its un-promotions to — instead of shipping the ~6M-pk array back as a parameter
-/// (~50 MB serialized and a server-side hash of every element, ~3x the join's cost).
+/// written its un-promotions.
 pub(super) async fn fetch_confirmed_routing(
     conn: &mut PgConnection,
 ) -> Result<BTreeMap<ChunkPk, Vec<WorkerPk>>> {

--- a/src/scheduler_storage/postgres/visibility.rs
+++ b/src/scheduler_storage/postgres/visibility.rs
@@ -121,15 +121,20 @@ pub(super) async fn drop_replayed_diffs(
 // run_visibility_cycle phases
 // ---------------------------------------------------------------------------
 
+/// Open the cycle's portal assignment. Recording the watermark is what activates drains
+/// (see the migration).
 pub(super) async fn open_portal_assignment(
     tx: &mut Transaction<'_, Postgres>,
     now: u64,
+    confirmed_up_to: AssignmentId,
 ) -> Result<AssignmentId> {
     let mut timer = PhaseTimer::new("run_visibility_cycle:open_portal_assignment");
     let id = sqlx::query_scalar(
-        "INSERT INTO sched_portal_assignments (created_at) VALUES ($1) RETURNING id",
+        "INSERT INTO sched_portal_assignments (created_at, confirmed_up_to) \
+         VALUES ($1, $2) RETURNING id",
     )
     .bind(tick_to_i64(now))
+    .bind(confirmed_up_to)
     .fetch_one(&mut **tx)
     .await
     .context("run_visibility_cycle: insert portal assignment")?;
@@ -369,30 +374,6 @@ pub(super) async fn drop_marked_chunks(
         "#,
     )
     .bind(new_pa_id)
-    .execute(&mut **tx)
-    .await?;
-    timer.stmt(res.rows_affected());
-    Ok(())
-}
-
-/// Activate drains: stamp pending stale mappings whose superseding worker
-/// assignment is now confirmed.
-pub(super) async fn activate_confirmed_drains(
-    tx: &mut Transaction<'_, Postgres>,
-    new_pa_id: AssignmentId,
-    confirmed_up_to: AssignmentId,
-) -> Result<()> {
-    let mut timer = PhaseTimer::new("run_visibility_cycle:activate_confirmed_drains");
-    let res = sqlx::query(
-        r#"
-        UPDATE sched_stale_mappings
-        SET dropped_at_portal_assignment_id = $1
-        WHERE dropped_at_portal_assignment_id IS NULL
-          AND superseded_at_worker_assignment_id <= $2
-        "#,
-    )
-    .bind(new_pa_id)
-    .bind(confirmed_up_to)
     .execute(&mut **tx)
     .await?;
     timer.stmt(res.rows_affected());

--- a/src/scheduler_storage/postgres/workers.rs
+++ b/src/scheduler_storage/postgres/workers.rs
@@ -9,29 +9,53 @@ use crate::scheduler_storage::WorkerPk;
 
 use super::rows::tick_to_i64;
 
-/// Upsert the active workers: clear `inactive_since` and refresh `version`.
+/// Register the active workers: insert the unseen ones, reactivate and refresh the rest.
+///
+/// Two statements, not one `ON CONFLICT DO UPDATE`: Postgres evaluates the `id` sequence default
+/// before it detects the conflict, so an upsert burns an id per already-registered worker on every
+/// sync — enough to exhaust the 32-bit sequence within a year.
+///
+/// NOTE: the `NOT EXISTS` screen is not atomic — it leans on the single-scheduler advisory lock. A
+/// racing insert would still land correct (`DO NOTHING`, then the UPDATE reactivates it), at the
+/// cost of one id.
 pub(super) async fn upsert_active(
     tx: &mut Transaction<'_, Postgres>,
     peer_ids: &[String],
     versions: &[Option<String>],
 ) -> Result<()> {
-    // peer_ids must be unique within the batch or ON CONFLICT errors on a repeated row; the active
-    // set is keyed by PeerId upstream, so they are.
     let mut timer = PhaseTimer::new("update_worker_set:upsert_active");
     let res = sqlx::query(
         r#"
         INSERT INTO sched_workers (peer_id, version)
-        SELECT peer_id, version FROM UNNEST($1::text[], $2::text[]) AS w(peer_id, version)
-        ON CONFLICT (peer_id) DO UPDATE
-            SET inactive_since = NULL,
-                version = EXCLUDED.version
+        SELECT w.peer_id, w.version
+        FROM UNNEST($1::text[], $2::text[]) AS w(peer_id, version)
+        WHERE NOT EXISTS (SELECT 1 FROM sched_workers s WHERE s.peer_id = w.peer_id)
+        ON CONFLICT (peer_id) DO NOTHING
         "#,
     )
     .bind(peer_ids)
     .bind(versions)
     .execute(&mut **tx)
     .await
-    .context("update_worker_set: upsert")?;
+    .context("update_worker_set: insert new workers")?;
+    timer.stmt(res.rows_affected());
+
+    // Skipping rows already in the wanted state keeps a steady active set from rewriting every
+    // worker row each sync.
+    let res = sqlx::query(
+        r#"
+        UPDATE sched_workers s
+        SET inactive_since = NULL, version = w.version
+        FROM UNNEST($1::text[], $2::text[]) AS w(peer_id, version)
+        WHERE s.peer_id = w.peer_id
+          AND (s.inactive_since IS NOT NULL OR s.version IS DISTINCT FROM w.version)
+        "#,
+    )
+    .bind(peer_ids)
+    .bind(versions)
+    .execute(&mut **tx)
+    .await
+    .context("update_worker_set: reactivate returning workers")?;
     timer.stmt(res.rows_affected());
     Ok(())
 }

--- a/tools/reshuffle_sim/src/multistep.rs
+++ b/tools/reshuffle_sim/src/multistep.rs
@@ -633,7 +633,7 @@ mod tests {
         }
     }
 
-    fn worker(pk: i64) -> (WorkerPk, AssignmentWorker) {
+    fn worker(pk: i32) -> (WorkerPk, AssignmentWorker) {
         (
             WorkerPk(pk),
             AssignmentWorker {


### PR DESCRIPTION
### What is this PR about

Each scheduling/visibility cycle was doing several independent O(~6M-row) full-table passes over the chunk and routing tables — sequential scans, whole-table sorts, per-row MVCC rewrites, and post-commit re-reads — regardless of how few rows actually changed. Under a 2K-chunk step the baseline paid ~267s of SQL per cycle, and a single reshuffle triggered a ~245s, ~6M-row `UPDATE`. This branch reshapes those operations so each one
touches the churn-sized frontier (or is O(1)), while leaving the placement output and the two-gate visibility semantics byte-for-byte identical.

### What changed

**1. Cut the per-cycle full-table passes**
- **Unlock the promotable partial index** — the promote `UPDATE` never constrained `rejected`, so the planner couldn't prove `sched_chunk_metadata_promotable`'s predicate and seq-scanned the whole table every cycle. Added a redundant `NOT rejected` conjunct purely to unlock the index.
- **Frontier-sized cycle scans** — new partial indexes (`sched_chunk_metadata_unapplied` and friends) so the stamp / activation / expiry scans hit only the small frontier they modify instead of a full ~6M-row pass.
- **`fetch_active`** — sort by two scalar keys instead of a `ROW()` constructor (record sort via `record_cmp` measured ~2.5× slower and spilled to disk); row order is identical. 
- **Diff recording** — one `FULL JOIN` pass over the ideal twins instead of two `LEFT JOIN` passes; `IS DISTINCT FROM` covers the one-sided rows and both PKs merge-join.
- **`write_future_ideal`** — drop the PK before the COPY and rebuild it after, so it's one sorted index build instead of ~6M incremental btree inserts. Constraint is found by catalog, not name.
- **`build_worker_assignment`** — assemble in memory from the algorithm output plus the already-decoded active read and one churn-sized stale query, instead of re-reading all ~6M chunk rows post-commit (~39s/cycle).
- **Drop the chunks FK from the ideal twins** — the rename-swap made the FK ping-pong between twins, so COPY paid ~6M per-row FK checks every other cycle for a guarantee held only half the time. Integrity now comes from `sched_worker_assignment_diffs` (every pk entering the ideal is validated once, churn-sized, by that table's FK); chunk rows are never deleted, so the parent side never fires.

**2. Single-statement confirmed-diff replay**
The confirmation replay's upsert and delete arms each ran the identical `DISTINCT ON` scan+sort over the diff window (7–14M rows under confirmation lag). A data-modifying CTE computes the frontier once; the arms touch disjoint `chunk_pk` sets, so folding them changes nothing else. `rows_affected` now reports only the delete arm.

**3. O(1) drain activation via recorded watermarks**
`activate_confirmed_drains` stamped `dropped_at_portal_assignment_id` onto every covered stale row — a ~6M-row, ~245s full-table `UPDATE` after a reshuffle. The stamp is derivable, so instead each portal-assignment row records `(created_at, confirmed_up_to)` — one O(1) insert per visibility cycle — and the per-row stamp is dropped:
- expiry deletes mappings at/under the newest watermark among aged assignments (exact,   since watermarks and `created_at` are both monotone over assignment ids);
- `sched_stale_mappings` loses the `dropped_at_portal_assignment_id` column, and its two drain partial indexes collapse into one plain index;
- autovacuum tightened on `sched_stale_mappings` (reshuffles mint/expire millions of rows at once).
The `StorageInspect` API and the in-memory oracle are untouched — the harness derives the old stamp exactly (MIN covering assignment id).

**4. Narrow assignment and worker ids to 32-bit**
Assignment and worker ids move from `BIGINT`/`BIGSERIAL` to `INT`/`SERIAL`. These ids are referenced far more than minted (an assignment id sits in three `sched_chunk_metadata` columns, every stale mapping, and every diff row; a worker id repeats once per replica in each routing row's `worker_ids`), so narrowing them shrinks the largest tables. Ticks stay `BIGINT` (caller-supplied clock) and `chunks.chunk_pk` stays `BIGSERIAL` (never deleted, so
its sequence only climbs). To keep the 32-bit assignment sequence from exhausting, `update_worker_set` no longer upserts with `ON CONFLICT DO UPDATE` (which burns an id per already-registered worker every sync); it now inserts only unseen peers and updates the rest in a second statement.

### Correctness

Placement output and the two-gate drain timing are unchanged. The single-scheduler advisory lock is what makes the non-atomic `NOT EXISTS` worker screen safe (a race would still land correct, at the cost of one id). Covered by the existing Postgres storage tests plus the in-memory-oracle diff, with a new `worker_tests` case pinning that re-sync doesn't consume ids.

### Performance

Measured on a production-scale copy/replace workload (~6.4M chunks, 10 churn steps; p90 over the steps). The `baseline` column is the initial bulk cycle where every chunk is new — it approximates the full-table cost the old code paid *every* cycle; the step columns are steady-state incremental cycles, which the branch reduces to frontier-sized work.

Per-cycle full-table passes now run at churn size:

| Phase | Bulk cycle | Steady step (p90) |
|---|---|---|
| `apply_deltas_and_swap` | 254 s | 70 s |
| `promote_eligible_chunks` | 107 s | 0.3 s |
| `replay_confirmed_diffs` | 45 s | 5 s |
| `drop_replayed_diffs` | 13 s | 0.4 s |
| `fetch_portal_visible_chunks` | 38 s | 21 s |

Last round of hot-path fixes (FK drop + in-memory assembly + O(1) drain), p90 over steps:

| Phase | Before | After |
|---|---|---|
| `write_future_ideal` | 89 s (alternating ~20/85 s) | 17 s (steady) |
| `build_worker_assignment` | 53 s | 5 s |
| `activate_confirmed_drains` | 8 s (spikes to 21 s) | phase removed (O(1) insert) |
| **Total per step** | **540 s** | **312 s** |

`fetch_active_chunks_with_placement` stays ~50 s — it reads the full active set by design;
the `ROW()`→scalar-key sort fix keeps that read from spilling to disk, but the scan itself
is inherent.

### Benchmark details

Scenario:
```
chunks_per_step: 2000
steps: 10
scheduler: multistep
copy:
  - { src: base-mainnet, dst: base-mainnet-2, at_step: 3 }
replace:
  - { dataset: binance-mainnet, at_step: 5 }
```

Timing
```
timings in ms
phase                                                       seed  baseline  step 1  step 2  step 3  step 4  step 5  step 6  step 7  step 8  step 9  step 10     p90
insert_new_datasets                                          736         -       -       -      21       -       -       -       -       -       -        -      21
update_worker_set:upsert_active                               68         -       9      10      10      12      78      19      19      19      24       38      42
update_worker_set:mark_departed                                9         -      17       4       3       3      12       3       3       3       4        6      12
update_worker_set:gc_inactive                                  3         -       1       1       1       1       2       1       1       1       1        1       1
insert_new_chunks                                         661668         -     498     279     323     268     300     353     244     270     292      239     367
register_new_chunks:fetch_candidates                       13446         -    4364    4441    5138    5264    4633    5922    9146    4447    5555     4482    6244
nonoverlap:overlap_probe                                   22607         -     128      95     655      97      85      89      91      94      95       95     181
register_new_chunks:admit                                 119160         -      56      36     571      40     283      37      38      35      39       39     312
run_scheduling_cycle:tombstone_expired_chunks                  -        12       2       3       3       2       2     164       4       2       2        2      20
run_scheduling_cycle:expire_drained_stale_mappings             -         3       1      26      47     618      35     161      29      26      31       26     207
run_scheduling_cycle:fetch_active_chunks_with_placement        -     43555   51437   50772   49329   51802   54274   55219   54015   51127   55445    53785   55242
run_scheduling_cycle:fetch_workers                             -         4       3       3       3       3       3       3       4       3       3        3       3
run_scheduling_cycle:schedule                                  -    106286  115888  114124  112686  114049  112687  124406  116799  112604  113604   111329  117560
run_scheduling_cycle:open_worker_assignment                    -         7       5       3       3       5       7       4       6       3       3        3       6
run_scheduling_cycle:write_future_ideal                        -     15271   13994   14467   17304   14881   17828   16370   15155   14598   15318    15038   17356
run_scheduling_cycle:apply_deltas_and_swap                     -    254144   57098   43766   93846   51193   67563   49350   42299   53081   51963    43019   70191
run_scheduling_cycle:build_worker_assignment                   -      5080    4756    4696    7788    4731    5129    4932    5071    4713    5184     4716    5444
visibility:confirmation_watermark                              -         6       3       0       0       1       0       1       0       0       0        1       1
confirm_worker_assignment:advance_confirmation_watermark       -         4       1       1       1       1       1       0       0       0       1        1       1
confirm_worker_assignment:replay_confirmed_diffs               -     44547      87      33    9014     151    4283    3144      34      31      39       36    4756
confirm_worker_assignment:drop_replayed_diffs                  -     13491       5       3     622      10     352     195       4       3       4        3     379
run_visibility_cycle:open_portal_assignment                    -         6       5       0       1       0       1       2       0       0       0        1       2
run_visibility_cycle:apply_ready_corrections                   -         4       3       0       0       0     514       1       0       0       0        0      54
run_visibility_cycle:promote_eligible_chunks                   -    107073     140      27     333      53     248      37      31      26      30       27     256
run_visibility_cycle:drop_marked_chunks                        -         8       2       1       1       0     664       6       1       0       1        1      72
run_visibility_cycle:fetch_portal_visible_chunks               -     38030   19050   17208   19695   20450   19516   18565   19788   18827   21781    18212   20583
run_visibility_cycle:portal_overlap_sweep                      -       923     975     993     968     956     960     987     970     990     971      999     994
run_visibility_cycle:fetch_confirmed_routing                   -     16746   18653   17998   16903   15164   16210   16938   18162   14821   15093    16544   18211
run_visibility_cycle:fetch_portal_workers                      -         8       5       6       5       5       5       5       5       5       5        5       5
copy_dataset_chunks                                            -         -       -       -    1689       -       -       -       -       -       -        -    1689
register_corrections                                           -         -       -       -       -       -    3294       -       -       -       -        -    3294
TOTAL                                                     817697    645208  287186  268996  336963  279760  308969  296914  281919  275729  285488   268651  311768
```
