### PR TITLE
bugfix: Keep current-placement positions valid across the worker reorder

### DIFF
--- a/src/multistep_scheduler/mod.rs
+++ b/src/multistep_scheduler/mod.rs
@@ -62,20 +62,26 @@ pub fn schedule(
     let _timer = crate::metrics::Timer::new("schedule");
     debug_assert_eq!(chunks.len(), current.len());
 
-    // Schedule the reliable subset first, then (unless reliability is ignored) overlay
-    // a pass over all workers so unreliable workers also get chunks.
-    let mut sorted = Vec::with_capacity(workers.len());
-    sorted.extend(workers.iter().filter(|w| w.reliable()));
-    let reliable = sorted.len();
-    sorted.extend(workers.iter().filter(|w| !w.reliable()));
-
     if config.ignore_reliability {
         tracing::info!(
             "Scheduling {} chunks to {} workers",
             chunks.len(),
             workers.len()
         );
-        return schedule_to_workers(chunks, &sorted, config, current, cache);
+        // Keep the caller's order: `current` positions stay valid as-is, and a stable order keeps
+        // the ring layout stable across cycles — partitioning would reshuffle it whenever any
+        // worker's status flips.
+        let workers: Vec<&Worker> = workers.iter().collect();
+        return schedule_to_workers(chunks, &workers, config, current, cache);
+    }
+
+    // Schedule the reliable subset first, then overlay a pass over all workers so unreliable
+    // workers also get chunks. The partition reorders the fleet, so `current` is translated into
+    // the partitioned position space.
+    let (sorted, reliable, translated) = partition_reliable(workers, current);
+    if reliable == workers.len() {
+        // Fully reliable fleet: the partition is the identity and one pass covers everyone.
+        return schedule_to_workers(chunks, &sorted, config, &translated, cache);
     }
 
     tracing::info!(
@@ -83,17 +89,26 @@ pub fn schedule(
         chunks.len(),
         reliable
     );
-    let mut assignment = schedule_to_workers(chunks, &sorted[..reliable], config, current, cache)?;
-    if reliable == workers.len() {
-        return Ok(assignment);
-    }
+    // Copies on unreliable workers are outside the prefix this pass schedules to; they are
+    // filtered out and become a shortfall, like copies on a departed worker.
+    let prefix_current: Vec<Vec<WorkerIndex>> = translated
+        .iter()
+        .map(|held| {
+            held.iter()
+                .copied()
+                .filter(|&w| (w as usize) < reliable)
+                .collect()
+        })
+        .collect();
+    let mut assignment =
+        schedule_to_workers(chunks, &sorted[..reliable], config, &prefix_current, cache)?;
 
     tracing::info!(
         "Scheduling {} chunks to {} total workers",
         chunks.len(),
         workers.len()
     );
-    let all = schedule_to_workers(chunks, &sorted, config, current, cache)?;
+    let all = schedule_to_workers(chunks, &sorted, config, &translated, cache)?;
     // Reliable workers keep their assignment; unreliable ones take theirs from `all`.
     for (worker_id, chunk_indexes) in all.worker_chunks {
         assignment
@@ -102,6 +117,36 @@ pub fn schedule(
             .or_insert(chunk_indexes);
     }
     Ok(assignment)
+}
+
+/// Reorder the fleet reliable-first and translate `current`'s caller positions into the reordered
+/// space, so each held copy still refers to the same worker. Returns the reordered fleet, the
+/// reliable-prefix length, and the translated placement.
+fn partition_reliable<'a>(
+    workers: &'a [Worker],
+    current: &[Vec<WorkerIndex>],
+) -> (Vec<&'a Worker>, usize, Vec<Vec<WorkerIndex>>) {
+    // `order[new] = old` — caller positions, reliable first; `partition` keeps input order.
+    let (reliable_positions, unreliable_positions): (Vec<usize>, Vec<usize>) =
+        (0..workers.len()).partition(|&i| workers[i].reliable());
+    let reliable = reliable_positions.len();
+    let order: Vec<usize> = reliable_positions
+        .into_iter()
+        .chain(unreliable_positions)
+        .collect();
+
+    // `new_pos[old] = new` — where each caller position landed.
+    let mut new_pos: Vec<WorkerIndex> = vec![0; workers.len()];
+    for (new, &old) in order.iter().enumerate() {
+        new_pos[old] = new as WorkerIndex;
+    }
+
+    let sorted = order.iter().map(|&i| &workers[i]).collect();
+    let translated = current
+        .iter()
+        .map(|held| held.iter().map(|&w| new_pos[w as usize]).collect())
+        .collect();
+    (sorted, reliable, translated)
 }
 
 fn schedule_to_workers(
@@ -119,8 +164,7 @@ fn schedule_to_workers(
 
     let rings = cache.rings(workers.iter().map(|w| w.id));
 
-    // Under `ignore_reliability = true` — the only mode this scheduler is exercised in — the
-    // reliable-first sort preserves order, so the caller's positions index `workers` directly.
+    // `current` positions index `workers` — `schedule` translates them whenever it reorders.
     let held = current;
 
     // Version-pinned chunks first: they compete for the scarcest eligible workers, so they claim

--- a/src/multistep_scheduler/mod.rs
+++ b/src/multistep_scheduler/mod.rs
@@ -48,7 +48,7 @@ pub struct ScheduledChunk<'a> {
     pub minimum_worker_version: Option<&'a Version>,
 }
 
-/// `current[i]` — **positions into `workers`** of the peers physically holding chunk `i` now,
+/// `current_placement[i]` — **positions into `workers`** of the peers physically holding chunk `i` now,
 /// draining copies included. The caller owns the PeerId↔position mapping; copies on a departed
 /// worker must be left out (they become a shortfall). Returns the full published placement
 /// (new copies plus current copies retained to hold the floor).
@@ -56,11 +56,11 @@ pub fn schedule(
     chunks: &[ScheduledChunk<'_>],
     workers: &[Worker],
     config: &SchedulingConfig,
-    current: &[Vec<WorkerIndex>],
+    current_placement: &[Vec<WorkerIndex>],
     cache: &mut WorkerRingCache,
 ) -> Result<Assignment, ReplicationError> {
     let _timer = crate::metrics::Timer::new("schedule");
-    debug_assert_eq!(chunks.len(), current.len());
+    debug_assert_eq!(chunks.len(), current_placement.len());
 
     if config.ignore_reliability {
         tracing::info!(
@@ -68,18 +68,15 @@ pub fn schedule(
             chunks.len(),
             workers.len()
         );
-        // Keep the caller's order: `current` positions stay valid as-is, and a stable order keeps
-        // the ring layout stable across cycles — partitioning would reshuffle it whenever any
-        // worker's status flips.
         let workers: Vec<&Worker> = workers.iter().collect();
-        return schedule_to_workers(chunks, &workers, config, current, cache);
+        return schedule_to_workers(chunks, &workers, config, current_placement, cache);
     }
 
     // Schedule the reliable subset first, then overlay a pass over all workers so unreliable
     // workers also get chunks. The partition reorders the fleet, so `current` is translated into
     // the partitioned position space.
-    let (sorted, reliable, translated) = partition_reliable(workers, current);
-    if reliable == workers.len() {
+    let (sorted, reliable_count, translated) = partition_reliable(workers, current_placement);
+    if reliable_count == workers.len() {
         // Fully reliable fleet: the partition is the identity and one pass covers everyone.
         return schedule_to_workers(chunks, &sorted, config, &translated, cache);
     }
@@ -87,7 +84,7 @@ pub fn schedule(
     tracing::info!(
         "Scheduling {} chunks to {} reliable workers",
         chunks.len(),
-        reliable
+        reliable_count
     );
     // Copies on unreliable workers are outside the prefix this pass schedules to; they are
     // filtered out and become a shortfall, like copies on a departed worker.
@@ -96,12 +93,17 @@ pub fn schedule(
         .map(|held| {
             held.iter()
                 .copied()
-                .filter(|&w| (w as usize) < reliable)
+                .filter(|&w| (w as usize) < reliable_count)
                 .collect()
         })
         .collect();
-    let mut assignment =
-        schedule_to_workers(chunks, &sorted[..reliable], config, &prefix_current, cache)?;
+    let mut assignment = schedule_to_workers(
+        chunks,
+        &sorted[..reliable_count],
+        config,
+        &prefix_current,
+        cache,
+    )?;
 
     tracing::info!(
         "Scheduling {} chunks to {} total workers",
@@ -119,12 +121,12 @@ pub fn schedule(
     Ok(assignment)
 }
 
-/// Reorder the fleet reliable-first and translate `current`'s caller positions into the reordered
+/// Reorder the fleet reliable-first and translate `current_placement`'s caller positions into the reordered
 /// space, so each held copy still refers to the same worker. Returns the reordered fleet, the
 /// reliable-prefix length, and the translated placement.
 fn partition_reliable<'a>(
     workers: &'a [Worker],
-    current: &[Vec<WorkerIndex>],
+    current_placement: &[Vec<WorkerIndex>],
 ) -> (Vec<&'a Worker>, usize, Vec<Vec<WorkerIndex>>) {
     // `order[new] = old` — caller positions, reliable first; `partition` keeps input order.
     let (reliable_positions, unreliable_positions): (Vec<usize>, Vec<usize>) =
@@ -142,7 +144,7 @@ fn partition_reliable<'a>(
     }
 
     let sorted = order.iter().map(|&i| &workers[i]).collect();
-    let translated = current
+    let translated = current_placement
         .iter()
         .map(|held| held.iter().map(|&w| new_pos[w as usize]).collect())
         .collect();

--- a/src/multistep_scheduler/tests.rs
+++ b/src/multistep_scheduler/tests.rs
@@ -524,3 +524,38 @@ fn version_restriction_preserved() {
         }
     }
 }
+
+/// The reliable-first partition shifts every position behind a non-Online worker, so
+/// [`partition_reliable`](super::partition_reliable) must translate `current` alongside —
+/// every translated position has to resolve to the worker the caller meant.
+#[test]
+fn partition_reliable_translates_current_positions() {
+    let mut workers = online_workers(4);
+    workers[1].status = WorkerStatus::Offline;
+
+    // chunk 0 held at caller positions {1, 3}; chunk 1 at {0}; chunk 2 unheld.
+    let current: Vec<Vec<WorkerIndex>> = vec![vec![1, 3], vec![0], vec![]];
+    let (sorted, reliable, translated) = super::partition_reliable(&workers, &current);
+
+    assert_eq!(reliable, 3);
+    assert_eq!(
+        sorted[3].id, workers[1].id,
+        "the unreliable worker moves to the back"
+    );
+    for (chunk, held) in current.iter().enumerate() {
+        assert_eq!(held.len(), translated[chunk].len());
+        for (&old, &new) in held.iter().zip(&translated[chunk]) {
+            assert_eq!(
+                sorted[new as usize].id, workers[old as usize].id,
+                "chunk {chunk}: caller position {old} resolves to a different worker after translation",
+            );
+        }
+    }
+
+    // An all-reliable fleet partitions to the identity: nothing moves, nothing translates.
+    let all_online = online_workers(3);
+    let current: Vec<Vec<WorkerIndex>> = vec![vec![2, 0]];
+    let (_, reliable, translated) = super::partition_reliable(&all_online, &current);
+    assert_eq!(reliable, 3);
+    assert_eq!(translated, current);
+}


### PR DESCRIPTION
## What is this PR about?

schedule() reorders the fleet reliable-first, but the caller's per-chunk holder positions (current) keep indexing the caller's order. Any non-Online worker shifts the positions behind it, so held copies are read against the wrong workers.

### Impact

* `ignore_reliability = true`: the current footprint is misread, so placement overfills some workers and never converges.
* `ignore_reliability = false` (production default): a mis-mapped position can point past the reliable prefix — an out-of-bounds panic in Reconcile::new.

Only the reading of the input placement is affected; the published result is always keyed by real worker id.

### Fix

Two-pass mode reorders the fleet, so the new partition_reliable builds that permutation and remaps every current position from the caller's slot to the worker's new slot — each copy still points at the same worker. Copies that land on unreliable workers fall outside pass one and become a shortfall, as the schedule contract already allows.

Under ignore_reliability the reorder brought no benefit, so it's dropped: the fleet keeps the caller's order and positions stay valid with no remap (which also keeps the ring cache warm across status flips).
Extracted from a larger branch so it can be reviewed and merged on its own.