### PR TITLE
Mark workers with stale RPC as unreliable NET-912

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "network-scheduler"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tools/compare_fb", "tools/clear_block_hash", "tools/reshuffle_sim"]
 
 [package]
 name = "network-scheduler"
-version = "3.12.0"
+version = "3.13.0"
 edition = "2024"
 
 [features]

--- a/examples/scheduler_config.yaml
+++ b/examples/scheduler_config.yaml
@@ -8,6 +8,8 @@ network_state_url: "https://fake-metadata.sqd-datasets.io"
 scheduler_state_bucket: network-scheduler-state
 min_supported_worker_version: "2.6.0-rc1"
 min_recommended_worker_version: "2.6.0"
+# Epochs of lag before a worker is marked stale_rpc; `null` disables the check. Default: 2
+max_worker_epoch_lag: 2
 cloudflare_storage_secret: ""
 strict_continuity_check: true
 datasets:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,12 @@ pub struct Config {
     #[serde(default = "default_min_worker_version")]
     pub min_recommended_worker_version: Version,
 
+    /// Epochs a worker's reported on-chain epoch may lag the network's before its contract reads
+    /// count as broken. The fleet doesn't roll over simultaneously, so one epoch of lag is routine.
+    /// `null` disables the check.
+    #[serde(default = "default_max_worker_epoch_lag")]
+    pub max_worker_epoch_lag: Option<u32>,
+
     #[serde_as(as = "DurationSeconds")]
     #[serde(rename = "assignment_delay_sec", default = "default_assignment_delay")]
     pub assignment_delay: Duration,
@@ -249,6 +255,10 @@ fn default_true() -> bool {
 
 fn default_min_worker_version() -> Version {
     "2.0.0".parse().unwrap()
+}
+
+fn default_max_worker_epoch_lag() -> Option<u32> {
+    Some(2)
 }
 
 fn default_assignment_ttl() -> Duration {

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -22,6 +22,46 @@ struct PingRow {
     version: String,
     stored_bytes: u64,
     timestamp: u64,
+    /// `None` for workers predating the field or ones that never completed a contract read.
+    current_epoch: Option<u32>,
+}
+
+/// Config thresholds plus the epoch baseline derived from the run's own rows.
+struct StatusThresholds<'a> {
+    /// Pings older than this (ms) mean the worker stopped reporting.
+    inactive_threshold: u64,
+    /// Below this many stored bytes the worker isn't carrying its share.
+    stale_threshold: u64,
+    min_version: &'a Version,
+    /// Highest epoch anyone reported this run; `None` if nobody did.
+    max_epoch: Option<u32>,
+    /// Epochs a worker may lag [`Self::max_epoch`]; `None` disables the check.
+    max_epoch_lag: Option<u32>,
+}
+
+/// Derive a worker's status from its latest ping. Each condition overrides the ones before it, so
+/// the order below is the precedence order, weakest first.
+fn worker_status(row: &PingRow, version: Option<&Version>, t: &StatusThresholds) -> WorkerStatus {
+    let mut status = WorkerStatus::Online;
+    // No epoch at all fails the same way as a frozen one: the worker never read the contract.
+    // Without a baseline there is nothing to compare against, so the check stays silent.
+    if let (Some(max_epoch), Some(max_lag)) = (t.max_epoch, t.max_epoch_lag)
+        && row
+            .current_epoch
+            .is_none_or(|epoch| epoch < max_epoch.saturating_sub(max_lag))
+    {
+        status = WorkerStatus::StaleRpc;
+    }
+    if row.stored_bytes < t.stale_threshold {
+        status = WorkerStatus::Stale;
+    }
+    if version.is_none_or(|ver| ver < t.min_version) {
+        status = WorkerStatus::UnsupportedVersion;
+    }
+    if row.timestamp < t.inactive_threshold {
+        status = WorkerStatus::Offline;
+    }
+    status
 }
 
 pub struct ClickhouseClient {
@@ -62,6 +102,7 @@ impl ClickhouseClient {
         inactive_timeout: Duration,
         stale_threshold: u64,
         min_version: &Version,
+        max_epoch_lag: Option<u32>,
     ) -> Result<Vec<Worker>> {
         let _timer = crate::metrics::Timer::new("get_active_workers");
 
@@ -73,7 +114,7 @@ impl ClickhouseClient {
 
         let query = format!(
             r"
-            SELECT DISTINCT ON (worker_id) worker_id, version, stored_bytes, timestamp
+            SELECT DISTINCT ON (worker_id) worker_id, version, stored_bytes, timestamp, current_epoch
             FROM {PINGS_TABLE}
             WHERE timestamp >= (SELECT MAX(timestamp) FROM {PINGS_TABLE}) - INTERVAL 1 DAY
             ORDER BY worker_id, timestamp DESC
@@ -82,7 +123,8 @@ impl ClickhouseClient {
 
         let mut cursor = self.client.query(&query).fetch::<PingRow>()?;
 
-        let mut results = Vec::new();
+        // Buffered, not classified inline: the epoch baseline needs every row first.
+        let mut rows = Vec::new();
         while let Some(row) = cursor.next().await? {
             let peer_id = match row.worker_id.parse() {
                 Ok(peer_id) => peer_id,
@@ -92,22 +134,40 @@ impl ClickhouseClient {
                     continue;
                 }
             };
-            let parsed_version = Version::from_str(&row.version).ok();
-            let mut status = WorkerStatus::Online;
-            if row.stored_bytes < stale_threshold {
-                status = WorkerStatus::Stale;
-            }
-            if parsed_version.as_ref().is_none_or(|ver| ver < min_version) {
-                status = WorkerStatus::UnsupportedVersion;
-            }
-            if row.timestamp < inactive_threshold {
-                status = WorkerStatus::Offline;
-            }
-            results.push(Worker {
-                id: peer_id,
-                status,
-                version: parsed_version,
-            });
+            rows.push((peer_id, row));
+        }
+
+        let thresholds = StatusThresholds {
+            inactive_threshold,
+            stale_threshold,
+            min_version,
+            max_epoch: rows.iter().filter_map(|(_, row)| row.current_epoch).max(),
+            max_epoch_lag,
+        };
+
+        let results: Vec<Worker> = rows
+            .into_iter()
+            .map(|(peer_id, row)| {
+                let version = Version::from_str(&row.version).ok();
+                let status = worker_status(&row, version.as_ref(), &thresholds);
+                Worker {
+                    id: peer_id,
+                    status,
+                    version,
+                }
+            })
+            .collect();
+
+        let stale_rpc = results
+            .iter()
+            .filter(|w| w.status == WorkerStatus::StaleRpc)
+            .count();
+        if stale_rpc > 0 {
+            tracing::warn!(
+                "{stale_rpc} workers report no epoch or lag the network epoch ({}) by more than {}",
+                thresholds.max_epoch.unwrap_or_default(),
+                thresholds.max_epoch_lag.unwrap_or_default(),
+            );
         }
 
         crate::metrics::report_workers(&results);
@@ -121,6 +181,7 @@ impl ClickhouseClient {
             config.worker_inactive_timeout,
             config.worker_stale_bytes,
             &config.min_supported_worker_version,
+            config.max_worker_epoch_lag,
         )
         .await
         .context("Can't read active workers from ClickHouse")
@@ -306,6 +367,157 @@ mod test {
         assert!(have[0].summary.is_some());
         let have_tstp = have[0].summary.as_ref().unwrap().last_block_timestamp;
         assert_eq!(have_tstp, tstp.timestamp_millis() as u64);
+    }
+
+    const STALE_BYTES: u64 = 600 << 30;
+    const INACTIVE_BEFORE: u64 = 1_000;
+
+    fn ping(stored_bytes: u64, timestamp: u64, current_epoch: Option<u32>) -> PingRow {
+        PingRow {
+            worker_id: "12D3KooWR1VSmCyVGTc8ewcm3LW82VeT68rjCKjBvGfpkt6ALxPx".to_owned(),
+            version: "2.13.0".to_owned(),
+            stored_bytes,
+            timestamp,
+            current_epoch,
+        }
+    }
+
+    fn status_of(row: &PingRow, max_epoch: Option<u32>) -> WorkerStatus {
+        status_of_with_lag(row, max_epoch, Some(2))
+    }
+
+    fn status_of_with_lag(
+        row: &PingRow,
+        max_epoch: Option<u32>,
+        max_epoch_lag: Option<u32>,
+    ) -> WorkerStatus {
+        let version = Version::from_str(&row.version).ok();
+        let min_version = Version::parse("2.10.1").unwrap();
+        worker_status(
+            row,
+            version.as_ref(),
+            &StatusThresholds {
+                inactive_threshold: INACTIVE_BEFORE,
+                stale_threshold: STALE_BYTES,
+                min_version: &min_version,
+                max_epoch,
+                max_epoch_lag,
+            },
+        )
+    }
+
+    #[test]
+    fn epoch_lag_within_tolerance_stays_online() {
+        let healthy = ping(STALE_BYTES, 2_000, Some(58132));
+        assert_eq!(status_of(&healthy, Some(58132)), WorkerStatus::Online);
+
+        // One epoch behind is routine: the fleet does not roll over simultaneously.
+        let lagging = ping(STALE_BYTES, 2_000, Some(58131));
+        assert_eq!(status_of(&lagging, Some(58132)), WorkerStatus::Online);
+
+        // Exactly at the tolerance is still fine; one past it is not.
+        let at_limit = ping(STALE_BYTES, 2_000, Some(58130));
+        assert_eq!(status_of(&at_limit, Some(58132)), WorkerStatus::Online);
+        let over_limit = ping(STALE_BYTES, 2_000, Some(58129));
+        assert_eq!(status_of(&over_limit, Some(58132)), WorkerStatus::StaleRpc);
+    }
+
+    #[test]
+    fn frozen_epoch_is_stale_rpc() {
+        let frozen = ping(STALE_BYTES, 2_000, Some(56354));
+        assert_eq!(status_of(&frozen, Some(58132)), WorkerStatus::StaleRpc);
+    }
+
+    #[test]
+    fn missing_epoch_is_stale_rpc() {
+        // Never completed a contract read: as broken as a frozen epoch.
+        let unknown = ping(STALE_BYTES, 2_000, None);
+        assert_eq!(status_of(&unknown, Some(58132)), WorkerStatus::StaleRpc);
+    }
+
+    #[test]
+    fn without_a_baseline_the_check_stays_silent() {
+        // Nobody reports an epoch (e.g. before the field rolled out): the check can't fire.
+        let reporting = ping(STALE_BYTES, 2_000, Some(1));
+        assert_eq!(status_of(&reporting, None), WorkerStatus::Online);
+
+        let unknown = ping(STALE_BYTES, 2_000, None);
+        assert_eq!(status_of(&unknown, None), WorkerStatus::Online);
+    }
+
+    #[test]
+    fn null_config_disables_the_check() {
+        let frozen = ping(STALE_BYTES, 2_000, Some(56354));
+        assert_eq!(
+            status_of_with_lag(&frozen, Some(58132), None),
+            WorkerStatus::Online
+        );
+
+        let unknown = ping(STALE_BYTES, 2_000, None);
+        assert_eq!(
+            status_of_with_lag(&unknown, Some(58132), None),
+            WorkerStatus::Online
+        );
+    }
+
+    #[test]
+    fn configured_tolerance_is_honored() {
+        let lagging = ping(STALE_BYTES, 2_000, Some(58122));
+        assert_eq!(
+            status_of_with_lag(&lagging, Some(58132), Some(10)),
+            WorkerStatus::Online
+        );
+        assert_eq!(
+            status_of_with_lag(&lagging, Some(58132), Some(9)),
+            WorkerStatus::StaleRpc
+        );
+        // Zero tolerance: anything but the newest epoch is stale.
+        assert_eq!(
+            status_of_with_lag(&ping(STALE_BYTES, 2_000, Some(58131)), Some(58132), Some(0)),
+            WorkerStatus::StaleRpc
+        );
+    }
+
+    #[test]
+    fn stale_rpc_yields_to_the_more_serious_statuses() {
+        // Those mean the worker can't serve data; a frozen epoch only matters for one that can.
+        let low_storage = ping(STALE_BYTES - 1, 2_000, Some(56354));
+        assert_eq!(status_of(&low_storage, Some(58132)), WorkerStatus::Stale);
+
+        let offline = ping(STALE_BYTES, INACTIVE_BEFORE - 1, Some(56354));
+        assert_eq!(status_of(&offline, Some(58132)), WorkerStatus::Offline);
+
+        let mut old = ping(STALE_BYTES, 2_000, Some(56354));
+        old.version = "2.9.0".to_owned();
+        assert_eq!(
+            status_of(&old, Some(58132)),
+            WorkerStatus::UnsupportedVersion
+        );
+
+        // Versions predating the field report no epoch, but only min_supported_worker_version
+        // keeps them out of stale_rpc.
+        let mut old_without_epoch = ping(STALE_BYTES, 2_000, None);
+        old_without_epoch.version = "2.9.0".to_owned();
+        assert_eq!(
+            status_of(&old_without_epoch, Some(58132)),
+            WorkerStatus::UnsupportedVersion
+        );
+    }
+
+    #[test]
+    fn stale_rpc_is_unreliable_and_serializes_as_stale_rpc() {
+        let worker = Worker {
+            id: "12D3KooWR1VSmCyVGTc8ewcm3LW82VeT68rjCKjBvGfpkt6ALxPx"
+                .parse()
+                .unwrap(),
+            status: WorkerStatus::StaleRpc,
+            version: Version::parse("2.13.0").ok(),
+        };
+        assert!(!worker.reliable());
+        assert_eq!(worker.status.to_string(), "stale_rpc");
+
+        let json = serde_json::to_value(&worker).unwrap();
+        assert_eq!(json["status"], "stale_rpc");
     }
 
     #[test]

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -161,7 +161,9 @@ impl Assignment {
                 WorkerStatus::UnsupportedVersion => {
                     sqd_assignments::WorkerStatus::UnsupportedVersion
                 }
-                WorkerStatus::Stale => sqd_assignments::WorkerStatus::Unreliable,
+                WorkerStatus::Stale | WorkerStatus::StaleRpc => {
+                    sqd_assignments::WorkerStatus::Unreliable
+                }
             };
             tracing::trace!("Serializing worker {}", worker.id);
             let indexes = match version {
@@ -227,6 +229,7 @@ mod tests {
             cloudflare_storage_secret: "secret".to_owned().into(),
             min_supported_worker_version: "2.0.0".parse().unwrap(),
             min_recommended_worker_version: "3.0.0".parse().unwrap(),
+            max_worker_epoch_lag: Some(2),
             assignment_delay: Duration::from_secs(60),
             assignment_ttl: Duration::from_secs(86400),
             concurrent_dataset_downloads: 1,

--- a/src/types/worker.rs
+++ b/src/types/worker.rs
@@ -6,6 +6,9 @@ use semver::Version;
 pub enum WorkerStatus {
     Online,
     Stale,
+    /// Otherwise healthy, but its contract reads have been failing, so its compute-unit
+    /// allocations are stale. See [`crate::cli::Config::max_worker_epoch_lag`].
+    StaleRpc,
     UnsupportedVersion,
     Offline,
 }
@@ -15,6 +18,7 @@ impl std::fmt::Display for WorkerStatus {
         match self {
             WorkerStatus::Online => write!(f, "online"),
             WorkerStatus::Stale => write!(f, "stale"),
+            WorkerStatus::StaleRpc => write!(f, "stale_rpc"),
             WorkerStatus::UnsupportedVersion => write!(f, "unsupported_version"),
             WorkerStatus::Offline => write!(f, "offline"),
         }


### PR DESCRIPTION
### Goal
It has happened many times that a group of workers gets stuck with stale RPC data. It results in rejecting queries from recently registered portals. Right now there are 34 such workers, all belonging to the same operator.

Highlighting these workers as "Jailed" (in UI terms) with status "`stale_rpc`" so that their owners know about the issue and fix it sooner.

### How it works
- Pings collector saves information about the current on-chain epoch reported by the worker. Usually all the latest pings either have the same epoch reported or differ by 1.
- If some worker's reported epoch is older than the newest reported epoch by 2 or more, the scheduler flags it.
- It makes the worker "unreliable" in terms of scheduling, and its "status" is written as `stale_rpc` in https://metadata.sqd-datasets.io/scheduler/mainnet/status.json