### PR TITLE
feat(schema-bundle): Add missing read schemas in the bundle, generated every round disregarding the shortage.

### DIFF
--- a/crates/scheduler-metadata/migrations/0001_sched_tables.sql
+++ b/crates/scheduler-metadata/migrations/0001_sched_tables.sql
@@ -133,12 +133,10 @@ CREATE TABLE IF NOT EXISTS sched_chunk_metadata (
     dropped_from_worker_assignment_at BIGINT
 );
 
--- Write-schema ids covered by the bundle of the last SUCCESSFUL scheduling cycle, written in the
--- same transaction that commits the assignment (a shortage rolls back before the write, freezing
--- the set with the assignment it describes). Read by generate_schema_bundle so a bundle built
--- during a shortage still covers everything the frozen published assignment names. A few hundred
--- rows, replaced wholesale each success — never derived from the placement tables. The FK also
--- blocks a future hard-delete of a schema row the published assignment still references.
+-- Write-schema ids of the last successful cycle's bundle, replaced wholesale in the transaction
+-- that commits the assignment — a shortage never reaches the write, freezing the set with the
+-- assignment it describes. Keeps a shortage-round bundle covering the frozen published assignment;
+-- the FK also blocks hard-deleting a schema row that assignment still references.
 CREATE TABLE IF NOT EXISTS sched_worker_assignment_schemas (
     schema_id INTEGER PRIMARY KEY REFERENCES schemas(id)
 );

--- a/crates/scheduler-metadata/migrations/0001_sched_tables.sql
+++ b/crates/scheduler-metadata/migrations/0001_sched_tables.sql
@@ -133,6 +133,16 @@ CREATE TABLE IF NOT EXISTS sched_chunk_metadata (
     dropped_from_worker_assignment_at BIGINT
 );
 
+-- Write-schema ids covered by the bundle of the last SUCCESSFUL scheduling cycle, written in the
+-- same transaction that commits the assignment (a shortage rolls back before the write, freezing
+-- the set with the assignment it describes). Read by generate_schema_bundle so a bundle built
+-- during a shortage still covers everything the frozen published assignment names. A few hundred
+-- rows, replaced wholesale each success — never derived from the placement tables. The FK also
+-- blocks a future hard-delete of a schema row the published assignment still references.
+CREATE TABLE IF NOT EXISTS sched_worker_assignment_schemas (
+    schema_id INTEGER PRIMARY KEY REFERENCES schemas(id)
+);
+
 -- What the scheduler currently wants; published worker assignment = this ∪ sched_stale_mappings.
 -- No chunks FK, same as the twin below: the cycle re-stages the whole ideal via COPY, and an FK
 -- would cost a per-row check on every staged row. Integrity comes from sched_worker_assignment_diffs

--- a/crates/scheduler-metadata/migrations/0001_sched_tables.sql
+++ b/crates/scheduler-metadata/migrations/0001_sched_tables.sql
@@ -77,8 +77,8 @@ CREATE INDEX IF NOT EXISTS chunks_dataset_range_gist ON chunks USING gist (
     int8range(first_block, first_block + last_block_delta, '[]')
 );
 
--- Drives active_schema_bundle's per-schema "does any live chunk still use this schema?" probe.
--- chunk_pk is included so the nested-loop scan stays index-only.
+-- Drives the per-schema "does any live chunk still use this schema?" probe (LIVE_CHUNK_EXISTS,
+-- the `active` flag of list_write_schemas). chunk_pk is included so the scan stays index-only.
 CREATE INDEX IF NOT EXISTS chunks_schema_id ON chunks (schema_id, chunk_pk);
 
 -- Drives head()'s resume-point probe. Within a dataset, admitted chunks are non-overlapping with

--- a/docs/adr/0002-schema-bundle-covers-visible-chunks.md
+++ b/docs/adr/0002-schema-bundle-covers-visible-chunks.md
@@ -52,9 +52,11 @@ chunk that any narrower snapshot misses:
   placement. A chunk that a *later* assignment dropped can still be promoted off that earlier entry
   and keep serving its draining copies for M ticks — so the portal names it while the current
   assignment no longer lists it.
-- **The snapshot goes stale under shortage.** The bundle is frozen during scheduling, one step
-  before promotion; a sustained shortage keeps it frozen, so a per-cycle snapshot would never catch
-  up. A lifetime window holds no matter how long the freeze lasts or how far the watermark stalls.
+- **The snapshot goes stale under shortage.** (Since superseded in part: the bundle now regenerates
+  every round from committed rows, with the last successful assignment's schema set persisted in
+  `sched_worker_assignment_schemas` — so a shortage freezes the assignment but not the bundle. The
+  lifetime window remains the write section's base for the reason above.) A lifetime window holds no
+  matter how long a shortage lasts or how far the watermark stalls.
 
 The effect: **resolvability follows the routable lifetime, not the current holders.** How many
 copies exist (availability) and whether the file set can be derived (resolvability) are decoupled —

--- a/docs/mvcc-schema.md
+++ b/docs/mvcc-schema.md
@@ -275,6 +275,21 @@ CREATE TABLE sched_worker_confirmations (
 );
 ```
 
+### sched_worker_assignment_schemas
+
+Write-schema ids of the last successful cycle's bundle, replaced wholesale in the transaction that
+commits the assignment — a shortage never reaches the write, freezing the set with the assignment
+it describes. `generate_schema_bundle` builds the bundle's write section from it (and derives the
+read section's dataset scope through `schemas.dataset_id`), so a shortage-round bundle keeps
+covering the frozen published assignment. A few hundred rows, computed in Rust from the cycle's own
+scan, never derived from the placement tables.
+
+```sql
+CREATE TABLE sched_worker_assignment_schemas (
+    schema_id INTEGER PRIMARY KEY REFERENCES schemas(id)
+);
+```
+
 ### sched_ideal_chunk_workers / sched_confirmed_chunk_workers
 
 The two routing tables behind the two-gate model. `sched_ideal_chunk_workers` is what the

--- a/docs/schema-bundle-lifecycle.md
+++ b/docs/schema-bundle-lifecycle.md
@@ -37,12 +37,12 @@ portal can name it, and it outlives every portal that might still name it.
 The bundle maps each schema to its definition, and carries a **content fingerprint** so a client can
 detect when the set of schemas changes.
 
-Its defining property: it is generated from **committed chunk rows alone** — the routable window
-(ADR 0002) plus the persisted write-schema set of the last successful assignment
-(`sched_worker_assignment_schemas`, committed in the same transaction as the assignment it
-describes). It is therefore independent of whether the round's placement succeeded, and identical
-after a process restart: the same generator serves success, shortage, and visibility-driven
-refreshes.
+Its defining property: it is generated from **committed rows alone** — the persisted write-schema
+set of the last successful cycle (`sched_worker_assignment_schemas`, committed in the same
+transaction as the assignment it describes, and by construction the routable window of ADR 0002 at
+that commit) plus the current read schemas. It is therefore independent of whether the round's
+placement succeeded, and identical after a process restart: the same generator serves success,
+shortage, and visibility-driven refreshes.
 
 ## Lifecycle
 

--- a/docs/schema-bundle-lifecycle.md
+++ b/docs/schema-bundle-lifecycle.md
@@ -37,10 +37,12 @@ portal can name it, and it outlives every portal that might still name it.
 The bundle maps each schema to its definition, and carries a **content fingerprint** so a client can
 detect when the set of schemas changes.
 
-Its defining property: it is built from the worker assignment's **own chunks** — it holds exactly
-the schemas those chunks reference, and nothing else. So it matches the assignment by construction
-and can never drift from it (there is no separate storage scan that could disagree). The assignment
-and its bundle are frozen together as one pair.
+Its defining property: it is generated from **committed chunk rows alone** — the routable window
+(ADR 0002) plus the persisted write-schema set of the last successful assignment
+(`sched_worker_assignment_schemas`, committed in the same transaction as the assignment it
+describes). It is therefore independent of whether the round's placement succeeded, and identical
+after a process restart: the same generator serves success, shortage, and visibility-driven
+refreshes.
 
 ## Lifecycle
 
@@ -59,15 +61,16 @@ chunk is retired from the worker assignment. A portal that is a little behind st
 not-yet-retired chunks, so it still resolves. Crucially this grace window is the **same clock** as
 the chunk's own retirement — there is no separate schema clock that could fall out of sync.
 
-**A capacity shortage freezes the assignment and its bundle together.** When the scheduler cannot
-place a full assignment, the last good assignment and its bundle stay frozen as a pair; neither
-advances. The frozen bundle still covers every chunk the current portal assignment can name —
-anything a portal still routes to was confirmed under that assignment, so its schema is in that
-bundle. Chunk retirement keeps running during a shortage, but it only retires chunks whose grace
-window has fully elapsed, never one a portal still routes to.
+**A capacity shortage freezes the assignment but not the bundle.** When the scheduler cannot place
+a full assignment, the last good assignment stays frozen — but the bundle keeps regenerating every
+round. Its write section cannot shrink below what the frozen assignment names (the persisted set is
+only replaced by the next successful cycle, atomically with the assignment that supersedes it), and
+its read section always carries the current read schemas — so a read schema promoted mid-shortage
+reaches portals immediately instead of waiting out the streak.
 
 In simulation, a consistency check confirms that every chunk the current worker and portal
-assignments name resolves under the frozen bundle.
+assignments name resolves under the round's bundle, and a strict oracle confirms every read schema
+a portal is told to use resolves in the bundle published with it.
 
 ## Limits
 

--- a/src/multistep_controller.rs
+++ b/src/multistep_controller.rs
@@ -69,7 +69,7 @@ pub async fn run(
         min_replication: config.min_replication,
         ignore_reliability: config.ignore_reliability,
     };
-    let (assignment, _) = {
+    let assignment = {
         let _timer = metrics::Timer::new("multistep:schedule");
         storage
             .run_scheduling_cycle(
@@ -80,12 +80,21 @@ pub async fn run(
             )
             .context("run multistep scheduling cycle")?
     };
+    // Exercises the production bundle path even though nothing publishes it yet; the BundleId is
+    // the value a caching consumer would key on.
+    let bundle = storage
+        .generate_schema_bundle()
+        .context("generate schema bundle")?;
 
     tracing::info!(
-        "Multistep scheduling cycle done: assignment {}, {} chunks placed, replication_by_weight={:?}",
+        "Multistep scheduling cycle done: assignment {}, {} chunks placed, replication_by_weight={:?}, \
+         bundle {} ({} write / {} read schemas)",
         assignment.id,
         assignment.chunk_workers.len(),
         assignment.replication_by_weight,
+        bundle.id(),
+        bundle.schemas().len(),
+        bundle.read_schemas().len(),
     );
 
     Ok(())

--- a/src/multistep_controller.rs
+++ b/src/multistep_controller.rs
@@ -80,8 +80,7 @@ pub async fn run(
             )
             .context("run multistep scheduling cycle")?
     };
-    // Exercises the production bundle path even though nothing publishes it yet; the BundleId is
-    // the value a caching consumer would key on.
+    // Nothing publishes the bundle yet; generating it exercises the production path.
     let bundle = storage
         .generate_schema_bundle()
         .context("generate schema bundle")?;

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -1424,9 +1424,8 @@ fn churn_knife_edge_false_shortage_is_excused() {
     );
 }
 
-/// A promote during a shortage streak is published by the visibility cycle while the bundle stays
-/// frozen, so the portal names an id its own bundle cannot resolve. Nothing records which read ids a
-/// published bundle carried, so the visibility cycle cannot know what the frozen bundle holds.
+/// Shared fixture for the pair below: the same actions under a floor that shortages (`3`) and one
+/// that does not (`2`).
 ///
 /// **Hand-built, not captured** — the walk did not find this and realistically cannot: it needs a
 /// `PromoteReadSchema` (weight 1 against ~20 competing choices), a sustained shortage, and a portal
@@ -1484,21 +1483,24 @@ fn portal_read_schema_case(floor: u16) -> (SimConfig, Vec<Action>) {
     (config, actions)
 }
 
-/// The pinned gap: `replay` passes because the walk stands down on a frozen bundle, and the
-/// unexcused verdict reports the incoherence. Letting the bundle advance under shortage flips this to
-/// an empty fault list and removes the stand-down with it.
+/// A read schema promoted during a shortage must still be resolvable by the portal that is told to
+/// use it. **This is a reproduction of an open bug, so it fails**: the visibility cycle publishes the
+/// fresh pointer while the bundle stays frozen, and the portal ends up naming an id its own bundle
+/// cannot resolve.
+///
+/// `#[ignore]` keeps `cargo test` green while the fix is outstanding — run it with
+/// `cargo test --features mvcc-chunks -- --ignored` to see the failure. Fixing it means letting the
+/// bundle advance under shortage; once it passes, drop the stand-down arm in
+/// `assert_portal_read_schema_resolution`, which exists only to excuse this fault in the walk.
 #[test]
-fn portal_read_schema_outruns_the_frozen_bundle() {
+#[ignore = "reproduces the frozen-bundle gap; passes once the bundle advances under shortage"]
+fn portal_read_schema_resolves_under_shortage() {
     let (config, actions) = portal_read_schema_case(3);
     let sut = replay(&config, actions);
-    let faults = sut.portal_read_schema_faults().expect("portal has fetched");
-    assert!(
-        matches!(
-            faults.as_slice(),
-            [ReadSchemaFault::Unresolvable { dataset, .. }] if dataset == "s3://sim-1"
-        ),
-        "expected exactly one Unresolvable fault for s3://sim-1 — a widening of the gap must fail \
-         this test rather than be absorbed by it. got {faults:?}",
+    assert_eq!(
+        sut.portal_read_schema_faults().expect("portal has fetched"),
+        vec![],
+        "the portal names a read schema its own bundle cannot resolve",
     );
 }
 

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -1423,10 +1423,9 @@ fn churn_knife_edge_false_shortage_is_excused() {
 }
 
 /// A read schema promoted while the fleet is over-subscribed must still resolve for the portal told
-/// to use it. Captured from `in_memory::churn_simulation` (proptest-shrunk to seven transitions)
-/// when the bundle still froze with the assignment under a shortage. The bundle now regenerates
-/// every round, and the strict read-schema oracle enforces that during `replay` — the replay is the
-/// assertion. The shortage is real capacity pressure (4 workers, floor 4, saturation 0.8).
+/// to use it. Captured from `in_memory::churn_simulation` (proptest-shrunk) when the bundle still
+/// froze with the assignment under a shortage; the strict oracle now enforces the fix during
+/// `replay`. The shortage is real capacity pressure, not a floor above the worker count.
 fn portal_read_schema_frozen_bundle_case() -> (SimConfig, Vec<Action>) {
     let config = SimConfig {
         worker_count: 4,

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -2,6 +2,7 @@
 //! carry their own key/size/weight/dataset, so each sequence replays deterministically with no
 //! seed. The replay *is* the assertion: it panics iff the property is violated.
 
+use super::sut::placement_oracles::ReadSchemaFault;
 use super::sut::{Action, ConvergenceCheck, NewChunk, SimConfig, SimUnderTest};
 use super::utils::{
     CHUNK_SIZE, NEVER_GC_TICKS, SCHEMA_POOL, WORKER_CAPACITY, blocks_for_key, mint_key, new_chunk,
@@ -1415,5 +1416,104 @@ fn churn_knife_edge_false_shortage_is_excused() {
             ]),
             Action::CheckConverged(ConvergenceCheck::FloorLocallyFeasible),
         ],
+    );
+}
+
+/// A read schema promoted during a shortage streak is named by the portal assignment while the
+/// bundle stays frozen from the last successful scheduling cycle — so the portal names an id its own
+/// bundle cannot resolve. `run_scheduling_cycle` returns `Shortage` before the bundle is built,
+/// while `run_visibility_cycle` keeps publishing a freshly resolved pointer, and nothing persists
+/// which read ids a published bundle carried, so the visibility cycle cannot know what the frozen
+/// bundle holds. The walk oracle stands this case down; these two tests pin it in place.
+///
+/// `floor` is the whole polarity switch. 3 over 2 workers is unsatisfiable — `min_replication` is
+/// not clamped to the worker count, and `Placement::ensure_minimum`'s tag loop refuses a worker that
+/// already holds the chunk — so every later cycle shortages and the bundle freezes. Floor 2 is a
+/// no-op retune whose cycle succeeds, so the bundle advances past the promote. Same actions
+/// otherwise, which is what proves the failure comes from the freeze and not from a broken resolver.
+fn portal_read_schema_case(floor: u16) -> (SimConfig, Vec<Action>) {
+    let config = SimConfig {
+        worker_count: 2,
+        min_replication: 2,
+        ..base_config()
+    };
+    // Key 11: not a multiple of 20, so it gets its own block window rather than the shared
+    // collision window that registration rejects.
+    let chunk = new_chunk((mint_key(11), CHUNK_SIZE, 1, "s3://sim-1".to_string()));
+    let actions = vec![
+        // Generation 1: the chunk is placed on both workers.
+        Action::AddChunks(vec![chunk]),
+        // 100% quorum: both workers must poll before the watermark advances, and nothing becomes
+        // portal-visible without it — otherwise the assignment names no dataset and the oracle is
+        // vacuous.
+        Action::WorkerFetchAssignment {
+            worker: 0,
+            succeeds: true,
+        },
+        Action::WorkerFetchAssignment {
+            worker: 1,
+            succeeds: true,
+        },
+        // Promoted at generation 1, running no cycle — a promote lands on the ingester's clock.
+        // SCHEMA_POOL[1] rather than [0]: [0] is `DatasetSchema::default()`, byte-identical to the
+        // write schema every dataset is seeded with, so promoting it would read as a no-op.
+        Action::PromoteReadSchema {
+            dataset: "s3://sim-1".into(),
+            schema: SCHEMA_POOL[1].clone(),
+        },
+        // Generation 2: schedules fine, so this bundle is built after the promote and carries the
+        // new read id; the visibility pass promotes the chunk, so the portal now names sim-1.
+        Action::AdvanceClock(1),
+        // In-fixture positive control: this pair is coherent AND enforced (generation 2 > promoted
+        // at 1), so a refactor that neuters the oracle fails here first.
+        Action::PortalFetchAssignment { succeeds: true },
+        // `do_set_min_replication` runs the cycle itself.
+        Action::SetMinReplication(floor),
+        // SCHEMA_POOL[0] has never been in this dataset's READ registry (the seed touched only the
+        // write registry), so the id genuinely moves — re-promoting the same content would be
+        // id-stable on both backends and the test would pass vacuously.
+        Action::PromoteReadSchema {
+            dataset: "s3://sim-1".into(),
+            schema: SCHEMA_POOL[0].clone(),
+        },
+        // Under floor 3 this shortages again, but the visibility pass still publishes — with the
+        // FRESH pointer. Under floor 2 the cycle succeeds and the bundle picks the promote up.
+        Action::AdvanceClock(1),
+        Action::PortalFetchAssignment { succeeds: true },
+    ];
+    (config, actions)
+}
+
+/// The pinned gap: `replay` passes because the walk oracle stands down on a frozen bundle, and the
+/// unexcused verdict then reports the incoherence this case exists to hold in place. When the bundle
+/// is allowed to advance under shortage, this assertion flips to an empty fault list and the
+/// stand-down arm in `assert_portal_read_schema_resolution` goes with it.
+#[test]
+fn portal_read_schema_outruns_the_frozen_bundle() {
+    let (config, actions) = portal_read_schema_case(3);
+    let sut = replay(&config, actions);
+    let faults = sut.portal_read_schema_faults().expect("portal has fetched");
+    assert!(
+        matches!(
+            faults.as_slice(),
+            [ReadSchemaFault::Unresolvable { dataset, .. }] if dataset == "s3://sim-1"
+        ),
+        "expected exactly one Unresolvable fault for s3://sim-1 — a widening of the gap must fail \
+         this test rather than be absorbed by it. got {faults:?}",
+    );
+}
+
+/// Positive control on the same actions with a satisfiable floor: the cycle after the promote
+/// succeeds, its bundle carries the new read id, and the reference resolves. Without it the pinned
+/// gap above would also pass if resolution were broken outright. `replay` is itself an assertion
+/// here — at generation 3 > promoted-at 2 the walk oracle is enforcing, so a broken reference panics
+/// inside `check_invariants` before the explicit check runs.
+#[test]
+fn portal_read_schema_resolves_after_a_successful_cycle() {
+    let (config, actions) = portal_read_schema_case(2);
+    let sut = replay(&config, actions);
+    assert_eq!(
+        sut.portal_read_schema_faults().expect("portal has fetched"),
+        vec![],
     );
 }

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -1,6 +1,11 @@
-//! Captured regressions — shrunk action sequences, each pinning one scheduler property. Chunks
-//! carry their own key/size/weight/dataset, so each sequence replays deterministically with no
-//! seed. The replay *is* the assertion: it panics iff the property is violated.
+//! Deterministic action sequences, each pinning one scheduler property. Chunks carry their own
+//! key/size/weight/dataset, so a sequence replays with no seed.
+//!
+//! Most cases are **captured**: shrunk (or delta-debugged) from a walk that actually failed, and the
+//! replay *is* the assertion — it panics iff the property is violated. A few are **hand-built**,
+//! for states the walk cannot realistically reach; those say so, and may assert by probing the SUT
+//! after the replay rather than by the replay panicking. Check which kind a case is before treating
+//! it as evidence that proptest found something.
 
 use super::sut::placement_oracles::ReadSchemaFault;
 use super::sut::{Action, ConvergenceCheck, NewChunk, SimConfig, SimUnderTest};
@@ -1421,8 +1426,14 @@ fn churn_knife_edge_false_shortage_is_excused() {
 
 /// A promote during a shortage streak is published by the visibility cycle while the bundle stays
 /// frozen, so the portal names an id its own bundle cannot resolve. Nothing records which read ids a
-/// published bundle carried, so the visibility cycle cannot know what the frozen bundle holds. The
-/// walk oracle stands this down; these tests pin it.
+/// published bundle carried, so the visibility cycle cannot know what the frozen bundle holds.
+///
+/// **Hand-built, not captured** — the walk did not find this and realistically cannot: it needs a
+/// `PromoteReadSchema` (weight 1 against ~20 competing choices), a sustained shortage, and a portal
+/// fetch to coincide. It also pins a gap that is deliberately still open rather than guarding a
+/// fixed bug, so `replay` PASSES here — the walk oracle stands the case down — and the assertion is
+/// a probe of the unexcused verdict afterwards. Both differences are why it does not follow this
+/// file's usual "the replay is the assertion" shape.
 ///
 /// `floor` is the polarity switch: 3 over 2 workers is unsatisfiable (`min_replication` is not
 /// clamped to the worker count, and `ensure_minimum` refuses a worker already holding the chunk), so

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -1419,33 +1419,27 @@ fn churn_knife_edge_false_shortage_is_excused() {
     );
 }
 
-/// A read schema promoted during a shortage streak is named by the portal assignment while the
-/// bundle stays frozen from the last successful scheduling cycle — so the portal names an id its own
-/// bundle cannot resolve. `run_scheduling_cycle` returns `Shortage` before the bundle is built,
-/// while `run_visibility_cycle` keeps publishing a freshly resolved pointer, and nothing persists
-/// which read ids a published bundle carried, so the visibility cycle cannot know what the frozen
-/// bundle holds. The walk oracle stands this case down; these two tests pin it in place.
+/// A promote during a shortage streak is published by the visibility cycle while the bundle stays
+/// frozen, so the portal names an id its own bundle cannot resolve. Nothing records which read ids a
+/// published bundle carried, so the visibility cycle cannot know what the frozen bundle holds. The
+/// walk oracle stands this down; these tests pin it.
 ///
-/// `floor` is the whole polarity switch. 3 over 2 workers is unsatisfiable — `min_replication` is
-/// not clamped to the worker count, and `Placement::ensure_minimum`'s tag loop refuses a worker that
-/// already holds the chunk — so every later cycle shortages and the bundle freezes. Floor 2 is a
-/// no-op retune whose cycle succeeds, so the bundle advances past the promote. Same actions
-/// otherwise, which is what proves the failure comes from the freeze and not from a broken resolver.
+/// `floor` is the polarity switch: 3 over 2 workers is unsatisfiable (`min_replication` is not
+/// clamped to the worker count, and `ensure_minimum` refuses a worker already holding the chunk), so
+/// every later cycle shortages. Floor 2 is a no-op retune whose cycle succeeds. Same actions
+/// otherwise, which is what shows the failure comes from the freeze, not a broken resolver.
 fn portal_read_schema_case(floor: u16) -> (SimConfig, Vec<Action>) {
     let config = SimConfig {
         worker_count: 2,
         min_replication: 2,
         ..base_config()
     };
-    // Key 11: not a multiple of 20, so it gets its own block window rather than the shared
-    // collision window that registration rejects.
+    // Not a multiple of 20, so it gets its own block window rather than the rejected shared one.
     let chunk = new_chunk((mint_key(11), CHUNK_SIZE, 1, "s3://sim-1".to_string()));
     let actions = vec![
         // Generation 1: the chunk is placed on both workers.
         Action::AddChunks(vec![chunk]),
-        // 100% quorum: both workers must poll before the watermark advances, and nothing becomes
-        // portal-visible without it — otherwise the assignment names no dataset and the oracle is
-        // vacuous.
+        // 100% quorum: without both polls nothing is portal-visible and the oracle is vacuous.
         Action::WorkerFetchAssignment {
             worker: 0,
             succeeds: true,
@@ -1454,40 +1448,34 @@ fn portal_read_schema_case(floor: u16) -> (SimConfig, Vec<Action>) {
             worker: 1,
             succeeds: true,
         },
-        // Promoted at generation 1, running no cycle — a promote lands on the ingester's clock.
-        // SCHEMA_POOL[1] rather than [0]: [0] is `DatasetSchema::default()`, byte-identical to the
-        // write schema every dataset is seeded with, so promoting it would read as a no-op.
+        // No cycle: a promote lands on the ingester's clock. Not SCHEMA_POOL[0] — that is
+        // `DatasetSchema::default()`, identical to the seeded write schema, so it would be a no-op.
         Action::PromoteReadSchema {
             dataset: "s3://sim-1".into(),
             schema: SCHEMA_POOL[1].clone(),
         },
-        // Generation 2: schedules fine, so this bundle is built after the promote and carries the
-        // new read id; the visibility pass promotes the chunk, so the portal now names sim-1.
+        // Generation 2: succeeds, so this bundle carries the new read id and the portal names sim-1.
         Action::AdvanceClock(1),
-        // In-fixture positive control: this pair is coherent AND enforced (generation 2 > promoted
-        // at 1), so a refactor that neuters the oracle fails here first.
+        // Positive control: coherent and enforced (generation 2 > promoted-at 1), so a refactor that
+        // neuters the oracle fails here first.
         Action::PortalFetchAssignment { succeeds: true },
-        // `do_set_min_replication` runs the cycle itself.
         Action::SetMinReplication(floor),
-        // SCHEMA_POOL[0] has never been in this dataset's READ registry (the seed touched only the
-        // write registry), so the id genuinely moves — re-promoting the same content would be
-        // id-stable on both backends and the test would pass vacuously.
+        // SCHEMA_POOL[0] was never in this dataset's read registry, so the id genuinely moves;
+        // re-promoting the same content is id-stable and would pass vacuously.
         Action::PromoteReadSchema {
             dataset: "s3://sim-1".into(),
             schema: SCHEMA_POOL[0].clone(),
         },
-        // Under floor 3 this shortages again, but the visibility pass still publishes — with the
-        // FRESH pointer. Under floor 2 the cycle succeeds and the bundle picks the promote up.
+        // Floor 3 shortages again, yet the visibility pass still publishes the fresh pointer.
         Action::AdvanceClock(1),
         Action::PortalFetchAssignment { succeeds: true },
     ];
     (config, actions)
 }
 
-/// The pinned gap: `replay` passes because the walk oracle stands down on a frozen bundle, and the
-/// unexcused verdict then reports the incoherence this case exists to hold in place. When the bundle
-/// is allowed to advance under shortage, this assertion flips to an empty fault list and the
-/// stand-down arm in `assert_portal_read_schema_resolution` goes with it.
+/// The pinned gap: `replay` passes because the walk stands down on a frozen bundle, and the
+/// unexcused verdict reports the incoherence. Letting the bundle advance under shortage flips this to
+/// an empty fault list and removes the stand-down with it.
 #[test]
 fn portal_read_schema_outruns_the_frozen_bundle() {
     let (config, actions) = portal_read_schema_case(3);
@@ -1503,11 +1491,9 @@ fn portal_read_schema_outruns_the_frozen_bundle() {
     );
 }
 
-/// Positive control on the same actions with a satisfiable floor: the cycle after the promote
-/// succeeds, its bundle carries the new read id, and the reference resolves. Without it the pinned
-/// gap above would also pass if resolution were broken outright. `replay` is itself an assertion
-/// here — at generation 3 > promoted-at 2 the walk oracle is enforcing, so a broken reference panics
-/// inside `check_invariants` before the explicit check runs.
+/// Same actions, satisfiable floor: the cycle after the promote succeeds and the reference resolves.
+/// Without this the pinned gap would also pass if resolution were broken outright. `replay` is itself
+/// an assertion — at generation 3 the walk is enforcing, so a broken reference panics first.
 #[test]
 fn portal_read_schema_resolves_after_a_successful_cycle() {
     let (config, actions) = portal_read_schema_case(2);

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -1422,13 +1422,11 @@ fn churn_knife_edge_false_shortage_is_excused() {
     );
 }
 
-/// A read schema promoted while the fleet is over-subscribed must still be resolvable by the portal
-/// that is told to use it. Captured from `in_memory::churn_simulation` (shrunk by proptest to these
-/// seven transitions) back when the bundle froze with the assignment under a shortage — the portal
-/// then named an id its own bundle could not resolve. Now the bundle is generated every round from
-/// committed rows, so the promote reaches it even though placement keeps failing, and the strict
-/// read-schema oracle enforces exactly that during `replay` — the replay is the assertion. The
-/// shortage is real capacity pressure (4 workers, floor 4, saturation 0.8).
+/// A read schema promoted while the fleet is over-subscribed must still resolve for the portal told
+/// to use it. Captured from `in_memory::churn_simulation` (proptest-shrunk to seven transitions)
+/// when the bundle still froze with the assignment under a shortage. The bundle now regenerates
+/// every round, and the strict read-schema oracle enforces that during `replay` — the replay is the
+/// assertion. The shortage is real capacity pressure (4 workers, floor 4, saturation 0.8).
 fn portal_read_schema_frozen_bundle_case() -> (SimConfig, Vec<Action>) {
     let config = SimConfig {
         worker_count: 4,

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -1,10 +1,8 @@
 //! Deterministic action sequences, each pinning one scheduler property. Chunks carry their own
 //! key/size/weight/dataset, so a sequence replays with no seed.
 //!
-//! Most cases are **captured**: shrunk (or delta-debugged) from a walk that actually failed, and the
-//! replay *is* the assertion — it panics iff the property is violated. A few are **hand-built**;
-//! those say so, and say why, and may assert by probing the SUT after the replay instead. Check
-//! which kind a case is before treating it as evidence that proptest found something.
+//! Every case is captured: shrunk (or delta-debugged) from a walk that actually failed, and the
+//! replay *is* the assertion — it panics iff the property is violated.
 
 use super::sut::{Action, ConvergenceCheck, NewChunk, SimConfig, SimUnderTest};
 use super::utils::{
@@ -1426,7 +1424,7 @@ fn churn_knife_edge_false_shortage_is_excused() {
 /// to use it. Captured from `in_memory::churn_simulation` (proptest-shrunk) when the bundle still
 /// froze with the assignment under a shortage; the strict oracle now enforces the fix during
 /// `replay`. The shortage is real capacity pressure, not a floor above the worker count.
-fn portal_read_schema_frozen_bundle_case() -> (SimConfig, Vec<Action>) {
+fn portal_read_schema_under_shortage_case() -> (SimConfig, Vec<Action>) {
     let config = SimConfig {
         worker_count: 4,
         min_replication: 4,
@@ -1453,13 +1451,13 @@ fn portal_read_schema_frozen_bundle_case() -> (SimConfig, Vec<Action>) {
 
 #[test]
 fn portal_read_schema_resolves_under_shortage() {
-    let (config, actions) = portal_read_schema_frozen_bundle_case();
+    let (config, actions) = portal_read_schema_under_shortage_case();
     replay(&config, actions);
 }
 
 /// Postgres twin: the same case on the real backend, keeping the shortage-round bundle at parity.
 #[test]
 fn portal_read_schema_resolves_under_shortage_pg() {
-    let (config, actions) = portal_read_schema_frozen_bundle_case();
+    let (config, actions) = portal_read_schema_under_shortage_case();
     replay_pg(&config, actions);
 }

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -2,10 +2,9 @@
 //! key/size/weight/dataset, so a sequence replays with no seed.
 //!
 //! Most cases are **captured**: shrunk (or delta-debugged) from a walk that actually failed, and the
-//! replay *is* the assertion — it panics iff the property is violated. A few are **hand-built**,
-//! for states the walk cannot realistically reach; those say so, and may assert by probing the SUT
-//! after the replay rather than by the replay panicking. Check which kind a case is before treating
-//! it as evidence that proptest found something.
+//! replay *is* the assertion — it panics iff the property is violated. A few are **hand-built**;
+//! those say so, and say why, and may assert by probing the SUT after the replay instead. Check
+//! which kind a case is before treating it as evidence that proptest found something.
 
 use super::sut::placement_oracles::ReadSchemaFault;
 use super::sut::{Action, ConvergenceCheck, NewChunk, SimConfig, SimUnderTest};
@@ -1427,12 +1426,12 @@ fn churn_knife_edge_false_shortage_is_excused() {
 /// Shared fixture for the pair below: the same actions under a floor that shortages (`3`) and one
 /// that does not (`2`).
 ///
-/// **Hand-built, not captured** — the walk did not find this and realistically cannot: it needs a
-/// `PromoteReadSchema` (weight 1 against ~20 competing choices), a sustained shortage, and a portal
-/// fetch to coincide. It also pins a gap that is deliberately still open rather than guarding a
-/// fixed bug, so `replay` PASSES here — the walk oracle stands the case down — and the assertion is
-/// a probe of the unexcused verdict afterwards. Both differences are why it does not follow this
-/// file's usual "the replay is the assertion" shape.
+/// **Hand-built, not captured** — but not because the walk cannot reach this state. Measured on a
+/// 64-case churn sweep: shortages in 39.6% of transitions, promotes in 3.3%, and the walk oracle's
+/// excused-fault counter firing with mean 0.11 (max 3) over 7043 samples. The walk hits this
+/// constantly; the only reason it stays green is the stand-down in
+/// `assert_portal_read_schema_resolution`, which exists to keep the sweeps usable while the gap is
+/// open. Remove that and the sweeps catch it without this fixture.
 ///
 /// `floor` is the polarity switch: 3 over 2 workers is unsatisfiable (`min_replication` is not
 /// clamped to the worker count, and `ensure_minimum` refuses a worker already holding the chunk), so

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -1423,21 +1423,12 @@ fn churn_knife_edge_false_shortage_is_excused() {
 }
 
 /// A read schema promoted while the fleet is over-subscribed must still be resolvable by the portal
-/// that is told to use it. **Reproduces an open bug, so it fails**: `run_scheduling_cycle` returns
-/// `Shortage` before it builds a bundle, while `run_visibility_cycle` keeps publishing the fresh
-/// pointer — so the portal names read schema 1 for `s3://sim-0` against a bundle frozen before that
-/// promote existed.
-///
-/// Captured from `in_memory::churn_simulation` with the walk oracle's frozen-bundle stand-down
-/// disabled, then shrunk by proptest to these seven transitions. The shortage here comes from real
-/// capacity pressure (4 workers, floor 4, saturation 0.8), not from a floor set above the worker
-/// count.
-///
-/// `#[ignore]` keeps `cargo test` green while the fix is outstanding; run it with
-/// `cargo test --features mvcc-chunks -- --ignored`. The fix is to let the bundle advance under
-/// shortage; when this passes, delete the stand-down arm in
-/// `assert_portal_read_schema_resolution`, which exists only to keep the sweeps green meanwhile —
-/// with it gone the sweeps catch this class on their own.
+/// that is told to use it. Captured from `in_memory::churn_simulation` (shrunk by proptest to these
+/// seven transitions) back when the bundle froze with the assignment under a shortage — the portal
+/// then named an id its own bundle could not resolve. Now the bundle is generated every round from
+/// committed rows, so the promote reaches it even though placement keeps failing, and the strict
+/// read-schema oracle enforces exactly that during `replay` — the replay is the assertion. The
+/// shortage is real capacity pressure (4 workers, floor 4, saturation 0.8).
 fn portal_read_schema_frozen_bundle_case() -> (SimConfig, Vec<Action>) {
     let config = SimConfig {
         worker_count: 4,
@@ -1464,13 +1455,14 @@ fn portal_read_schema_frozen_bundle_case() -> (SimConfig, Vec<Action>) {
 }
 
 #[test]
-#[ignore = "reproduces the frozen-bundle gap; passes once the bundle advances under shortage"]
 fn portal_read_schema_resolves_under_shortage() {
     let (config, actions) = portal_read_schema_frozen_bundle_case();
-    let sut = replay(&config, actions);
-    assert_eq!(
-        sut.portal_read_schema_faults().expect("portal has fetched"),
-        vec![],
-        "the portal names a read schema its own bundle cannot resolve",
-    );
+    replay(&config, actions);
+}
+
+/// Postgres twin: the same case on the real backend, keeping the shortage-round bundle at parity.
+#[test]
+fn portal_read_schema_resolves_under_shortage_pg() {
+    let (config, actions) = portal_read_schema_frozen_bundle_case();
+    replay_pg(&config, actions);
 }

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -6,7 +6,6 @@
 //! those say so, and say why, and may assert by probing the SUT after the replay instead. Check
 //! which kind a case is before treating it as evidence that proptest found something.
 
-use super::sut::placement_oracles::ReadSchemaFault;
 use super::sut::{Action, ConvergenceCheck, NewChunk, SimConfig, SimUnderTest};
 use super::utils::{
     CHUNK_SIZE, NEVER_GC_TICKS, SCHEMA_POOL, WORKER_CAPACITY, blocks_for_key, mint_key, new_chunk,
@@ -1423,95 +1422,55 @@ fn churn_knife_edge_false_shortage_is_excused() {
     );
 }
 
-/// Shared fixture for the pair below: the same actions under a floor that shortages (`3`) and one
-/// that does not (`2`).
+/// A read schema promoted while the fleet is over-subscribed must still be resolvable by the portal
+/// that is told to use it. **Reproduces an open bug, so it fails**: `run_scheduling_cycle` returns
+/// `Shortage` before it builds a bundle, while `run_visibility_cycle` keeps publishing the fresh
+/// pointer — so the portal names read schema 1 for `s3://sim-0` against a bundle frozen before that
+/// promote existed.
 ///
-/// **Hand-built, not captured** — but not because the walk cannot reach this state. Measured on a
-/// 64-case churn sweep: shortages in 39.6% of transitions, promotes in 3.3%, and the walk oracle's
-/// excused-fault counter firing with mean 0.11 (max 3) over 7043 samples. The walk hits this
-/// constantly; the only reason it stays green is the stand-down in
-/// `assert_portal_read_schema_resolution`, which exists to keep the sweeps usable while the gap is
-/// open. Remove that and the sweeps catch it without this fixture.
+/// Captured from `in_memory::churn_simulation` with the walk oracle's frozen-bundle stand-down
+/// disabled, then shrunk by proptest to these seven transitions. The shortage here comes from real
+/// capacity pressure (4 workers, floor 4, saturation 0.8), not from a floor set above the worker
+/// count.
 ///
-/// `floor` is the polarity switch: 3 over 2 workers is unsatisfiable (`min_replication` is not
-/// clamped to the worker count, and `ensure_minimum` refuses a worker already holding the chunk), so
-/// every later cycle shortages. Floor 2 is a no-op retune whose cycle succeeds. Same actions
-/// otherwise, which is what shows the failure comes from the freeze, not a broken resolver.
-fn portal_read_schema_case(floor: u16) -> (SimConfig, Vec<Action>) {
+/// `#[ignore]` keeps `cargo test` green while the fix is outstanding; run it with
+/// `cargo test --features mvcc-chunks -- --ignored`. The fix is to let the bundle advance under
+/// shortage; when this passes, delete the stand-down arm in
+/// `assert_portal_read_schema_resolution`, which exists only to keep the sweeps green meanwhile —
+/// with it gone the sweeps catch this class on their own.
+fn portal_read_schema_frozen_bundle_case() -> (SimConfig, Vec<Action>) {
     let config = SimConfig {
-        worker_count: 2,
-        min_replication: 2,
+        worker_count: 4,
+        min_replication: 4,
+        saturation: 0.8,
+        confirm_threshold_pct: 89,
+        gc_ticks: 15,
         ..base_config()
     };
-    // Not a multiple of 20, so it gets its own block window rather than the rejected shared one.
-    let chunk = new_chunk((mint_key(11), CHUNK_SIZE, 1, "s3://sim-1".to_string()));
+    let nc = |key: u64, weight: u16, dataset: &str| {
+        new_chunk((mint_key(key), CHUNK_SIZE, weight, format!("s3://{dataset}")))
+    };
+    #[rustfmt::skip]
     let actions = vec![
-        // Generation 1: the chunk is placed on both workers.
-        Action::AddChunks(vec![chunk]),
-        // 100% quorum: without both polls nothing is portal-visible and the oracle is vacuous.
-        Action::WorkerFetchAssignment {
-            worker: 0,
-            succeeds: true,
-        },
-        Action::WorkerFetchAssignment {
-            worker: 1,
-            succeeds: true,
-        },
-        // No cycle: a promote lands on the ingester's clock. Not SCHEMA_POOL[0] — that is
-        // `DatasetSchema::default()`, identical to the seeded write schema, so it would be a no-op.
-        Action::PromoteReadSchema {
-            dataset: "s3://sim-1".into(),
-            schema: SCHEMA_POOL[1].clone(),
-        },
-        // Generation 2: succeeds, so this bundle carries the new read id and the portal names sim-1.
-        Action::AdvanceClock(1),
-        // Positive control: coherent and enforced (generation 2 > promoted-at 1), so a refactor that
-        // neuters the oracle fails here first.
+        Action::AddChunks(vec![nc(54268, 1, "sim-0")]),
+        Action::CheckConverged(ConvergenceCheck::FloorLocallyFeasible),
+        Action::AddChunks(vec![nc(53944, 1, "sim-0"), nc(52853, 12, "sim-1"), nc(45551, 12, "sim-2"), nc(61969, 4, "sim-0")]),
+        Action::PromoteReadSchema { dataset: "s3://sim-0".into(), schema: SCHEMA_POOL[0].clone() },
+        Action::AddChunks(vec![nc(17181, 12, "sim-2"), nc(1608, 12, "sim-2"), nc(27218, 4, "sim-0"), nc(37183, 1, "sim-1")]),
         Action::PortalFetchAssignment { succeeds: true },
-        Action::SetMinReplication(floor),
-        // SCHEMA_POOL[0] was never in this dataset's read registry, so the id genuinely moves;
-        // re-promoting the same content is id-stable and would pass vacuously.
-        Action::PromoteReadSchema {
-            dataset: "s3://sim-1".into(),
-            schema: SCHEMA_POOL[0].clone(),
-        },
-        // Floor 3 shortages again, yet the visibility pass still publishes the fresh pointer.
-        Action::AdvanceClock(1),
-        Action::PortalFetchAssignment { succeeds: true },
+        Action::SetDatasetSchema { dataset: "s3://sim-0".into(), schema: SCHEMA_POOL[0].clone() },
     ];
     (config, actions)
 }
 
-/// A read schema promoted during a shortage must still be resolvable by the portal that is told to
-/// use it. **This is a reproduction of an open bug, so it fails**: the visibility cycle publishes the
-/// fresh pointer while the bundle stays frozen, and the portal ends up naming an id its own bundle
-/// cannot resolve.
-///
-/// `#[ignore]` keeps `cargo test` green while the fix is outstanding — run it with
-/// `cargo test --features mvcc-chunks -- --ignored` to see the failure. Fixing it means letting the
-/// bundle advance under shortage; once it passes, drop the stand-down arm in
-/// `assert_portal_read_schema_resolution`, which exists only to excuse this fault in the walk.
 #[test]
 #[ignore = "reproduces the frozen-bundle gap; passes once the bundle advances under shortage"]
 fn portal_read_schema_resolves_under_shortage() {
-    let (config, actions) = portal_read_schema_case(3);
+    let (config, actions) = portal_read_schema_frozen_bundle_case();
     let sut = replay(&config, actions);
     assert_eq!(
         sut.portal_read_schema_faults().expect("portal has fetched"),
         vec![],
         "the portal names a read schema its own bundle cannot resolve",
-    );
-}
-
-/// Same actions, satisfiable floor: the cycle after the promote succeeds and the reference resolves.
-/// Without this the pinned gap would also pass if resolution were broken outright. `replay` is itself
-/// an assertion — at generation 3 the walk is enforcing, so a broken reference panics first.
-#[test]
-fn portal_read_schema_resolves_after_a_successful_cycle() {
-    let (config, actions) = portal_read_schema_case(2);
-    let sut = replay(&config, actions);
-    assert_eq!(
-        sut.portal_read_schema_faults().expect("portal has fetched"),
-        vec![],
     );
 }

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -57,7 +57,7 @@ mod churn;
 mod flood;
 mod guided;
 mod observers;
-mod placement_oracles;
+pub(super) mod placement_oracles;
 mod preconditions;
 mod trace;
 mod zero_quorum;
@@ -359,6 +359,9 @@ pub(super) struct SimUnderTest<D: SimStorage> {
     /// Confirmation watermark at the latest portal assignment's publication — the consistency
     /// oracle's accountability bound.
     latest_portal_watermark: AssignmentId,
+    /// The publication accompanying `latest_portal_assignment`, captured in the sole setter so the
+    /// bundle, generation and promote log can never drift from the assignment they shipped with.
+    latest_portal_publication: Option<observers::PortalPublication>,
     /// Per departed worker, the newest assignment that still placed it — until the routing
     /// watermark passes it, the oracles hold the worker to nothing (see
     /// [`routing_has_caught_up_with_departure`](Self::routing_has_caught_up_with_departure)).
@@ -521,14 +524,29 @@ impl<D: SimStorage> SimUnderTest<D> {
         ));
     }
 
+    /// Refresh the portal observer from the current publication — the single path both the explicit
+    /// fetch action and the convergence fixed point take. `check_converged` bypasses
+    /// `do_portal_fetch`, and shortage regressions land there, so a second refresh site would leave
+    /// the captured pair stale in exactly the states the read-schema oracle targets.
+    fn refresh_portal_observer(&mut self) {
+        let Some(assignment) = self.latest_portal_assignment.clone() else {
+            return;
+        };
+        let Some(publication) = self.latest_portal_publication.clone() else {
+            return;
+        };
+        self.portal_state.observer_assignment(
+            &assignment,
+            self.latest_portal_watermark,
+            publication,
+            self.now,
+        );
+    }
+
     /// The portal polls the latest portal assignment: success refreshes its snapshot to age zero.
     fn do_portal_fetch(&mut self, succeeds: bool) {
-        if succeeds && let Some(assignment) = self.latest_portal_assignment.clone() {
-            self.portal_state.observer_assignment(
-                &assignment,
-                self.latest_portal_watermark,
-                self.now,
-            );
+        if succeeds {
+            self.refresh_portal_observer();
         }
         self.trace_step(&format!(
             "PortalFetch({})",
@@ -973,13 +991,7 @@ impl<D: SimStorage> SimUnderTest<D> {
         }
         // Refresh the portal at the fixed point. Below a 100% quorum the designated laggards are
         // still behind, so even this fetch carries straggler-scoping obligations.
-        if let Some(portal_assignment) = self.latest_portal_assignment.clone() {
-            self.portal_state.observer_assignment(
-                &portal_assignment,
-                self.latest_portal_watermark,
-                self.now,
-            );
-        }
+        self.refresh_portal_observer();
         // Fixed-point routing liveness: the per-cycle strand check tolerates preempted-but-still-
         // routed pairs as bounded routing-lag. At a drained, shortage-free fixed point all lag has
         // resolved, so routing must match the assignment pair-by-pair — a mismatch here is a stuck
@@ -1175,6 +1187,16 @@ impl<D: SimStorage> SimUnderTest<D> {
         self.assert_schema_bundle_consistency();
         self.latest_portal_watermark =
             self.storage.get_worker_assignment_confirmation() as AssignmentId;
+        // Captured HERE, not at fetch time: the promote log and the bundle must be the ones in
+        // force when this assignment was published. Rebuilding the triple when a portal fetches
+        // would let a promote issued afterwards retroactively indict an assignment that predates
+        // it — the assignment would be blamed for referencing nothing, when nothing was there to
+        // reference.
+        self.latest_portal_publication = Some(observers::PortalPublication {
+            bundle: self.latest_worker_bundle.clone(),
+            generation: self.bundle_generation,
+            promoted: self.model_read_schemas.clone(),
+        });
         self.latest_portal_assignment = Some(assignment);
     }
 
@@ -1363,6 +1385,7 @@ impl<D: SimStorage> SimUnderTest<D> {
         ) {
             panic!("{message}");
         }
+        self.assert_portal_read_schema_resolution();
         if let Err(message) = placement_oracles::bundle_covers_promoted_read_schemas(
             bundle,
             self.latest_worker_assignment.as_ref(),
@@ -1371,6 +1394,67 @@ impl<D: SimStorage> SimUnderTest<D> {
         ) {
             panic!("{message}");
         }
+    }
+
+    /// Every read schema the portal names must resolve in the bundle it was handed with — checked
+    /// against what the portal actually holds, not against the latest published pair.
+    ///
+    /// **Known gap, deliberately excused:** an `Unresolvable` whose promote landed at or after the
+    /// bundle's generation is the frozen-bundle window. `run_scheduling_cycle` returns `Shortage`
+    /// before the bundle is built, while `run_visibility_cycle` keeps publishing a freshly resolved
+    /// pointer, and nothing persists which read ids a published bundle carried — so the visibility
+    /// cycle cannot know what the frozen bundle holds. Pinned by
+    /// `portal_read_schema_outruns_the_frozen_bundle`; when the bundle is allowed to advance under
+    /// shortage this arm and that test go together.
+    ///
+    /// Everything else is fatal, and the excused count is measured rather than silently dropped —
+    /// an excuse that starts firing broadly shows up as a statistic instead of hiding a regression.
+    fn assert_portal_read_schema_resolution(&self) {
+        let Some(publication) = self.portal_state.publication.as_ref() else {
+            return;
+        };
+        let (Some(portal), Some(bundle)) = (
+            self.portal_state.snapshot.as_ref(),
+            publication.bundle.as_ref(),
+        ) else {
+            return;
+        };
+        let faults =
+            placement_oracles::portal_read_schemas_resolve(portal, bundle, &publication.promoted);
+        let (excused, fatal): (Vec<_>, Vec<_>) = faults.into_iter().partition(|fault| {
+            matches!(
+                fault,
+                placement_oracles::ReadSchemaFault::Unresolvable { promoted_at, .. }
+                    if publication.generation <= *promoted_at
+            )
+        });
+        statistics::measure(
+            "schema: read refs excused by frozen bundle",
+            excused.len() as f64,
+        );
+        statistics::classify(
+            !fatal.is_empty(),
+            "schema: portal read reference unresolvable (fatal)",
+        );
+        if let Some(fault) = fatal.first() {
+            panic!("{fault}");
+        }
+    }
+
+    /// The unexcused verdict, for regressions that need to assert on the gap itself rather than on
+    /// the walk's stand-down. `None` before a portal has fetched anything.
+    #[cfg(test)]
+    pub(super) fn portal_read_schema_faults(
+        &self,
+    ) -> Option<Vec<placement_oracles::ReadSchemaFault>> {
+        let publication = self.portal_state.publication.as_ref()?;
+        let portal = self.portal_state.snapshot.as_ref()?;
+        let bundle = publication.bundle.as_ref()?;
+        Some(placement_oracles::portal_read_schemas_resolve(
+            portal,
+            bundle,
+            &publication.promoted,
+        ))
     }
 
     // ---- Observation layer (fleet + portal) -------------------------------------------------
@@ -1833,6 +1917,7 @@ impl<D: SimStorage> SimUnderTest<D> {
             bundle_generation: 0,
             latest_portal_assignment: None,
             latest_portal_watermark: 0,
+            latest_portal_publication: None,
             placed_until_departure: BTreeMap::new(),
             confirm_threshold_pct: config.confirm_threshold_pct,
             converge_checked: false,

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -1110,11 +1110,8 @@ impl<D: SimStorage> SimUnderTest<D> {
     // ---- Storage cycle (shared machinery) ---------------------------------------------------
 
     /// Run one scheduling pass against the live clock, recording the shortage flag. Returns the new
-    /// assignment's id on success, or `None` on a recorded shortage.
-    ///
-    /// The bundle is generated on EVERY outcome: it is a function of committed rows (routable
-    /// window ∪ the persisted set of the last successful assignment), so a shortage advances it —
-    /// promotes keep flowing to portals while the assignment stays frozen. That is the fix the
+    /// assignment's id on success, or `None` on a recorded shortage. The bundle is generated on
+    /// EVERY outcome, so a shortage advances it while the assignment stays frozen — the fix the
     /// strict read-schema oracle enforces.
     fn run_scheduler(&mut self) -> Option<AssignmentId> {
         let id =
@@ -1394,10 +1391,9 @@ impl<D: SimStorage> SimUnderTest<D> {
         }
     }
 
-    /// Checked against what the portal holds, not the latest published pair. Strict: every fault is
-    /// fatal. The bundle advances on every round including shortages (it is generated from
-    /// committed rows, independent of placement), so there is no frozen-bundle state left to
-    /// excuse — a portal must always be able to resolve every read schema it is told to use.
+    /// Checked against what the portal holds, not the latest published pair. Strict — every fault
+    /// is fatal: the bundle advances on every round including shortages, so there is no frozen
+    /// state left to excuse.
     fn assert_portal_read_schema_resolution(&self) {
         let Some(publication) = self.portal_state.publication.as_ref() else {
             return;

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -207,10 +207,9 @@ pub(super) enum Action {
         dataset: String,
         schema: DatasetSchema,
     },
-    /// Promote `dataset`'s current READ schema — the metadata service's admin path, which in
-    /// production runs on the ingester's clock with no scheduler coordination. Unlike
-    /// [`Action::SetDatasetSchema`] (the write registry) this affects no chunk: it changes what
-    /// the bundle must carry for readers.
+    /// Promote `dataset`'s current READ schema — the ingester's admin path, on its own clock with no
+    /// scheduler coordination. Unlike [`Action::SetDatasetSchema`] (the write registry) it touches
+    /// no chunk.
     PromoteReadSchema {
         dataset: String,
         schema: DatasetSchema,
@@ -343,24 +342,19 @@ pub(super) struct SimUnderTest<D: SimStorage> {
     /// Bundle frozen with `latest_worker_assignment`; both stay frozen together across a shortage
     /// streak, so the oracle checks the assignment against the bundle it shipped with.
     latest_worker_bundle: Option<SchemaBundle>,
-    /// Read schemas as the SIM issued them: dataset → (content handed to `promote_read_schema`,
-    /// [`bundle_generation`](Self::bundle_generation) at the moment of the promote). Written only
-    /// from the sim's own action, never read back from a backend — it is the read-schema oracle's
-    /// independent reference, so subject (the published bundle) and reference (this map) cannot
-    /// agree by construction the way a storage-derived expectation would.
+    /// dataset → (content the sim promoted, [`bundle_generation`](Self::bundle_generation) then).
+    /// Written only by the sim's action, never read back from a backend — that independence is what
+    /// makes the read-schema oracle able to fail.
     model_read_schemas: BTreeMap<String, (DatasetSchema, u64)>,
-    /// Bumped every time a bundle is frozen. A promote reaches the bundle on the next successful
-    /// scheduling cycle, never instantly, so the oracle waits for a generation strictly newer than
-    /// the promote's before demanding coverage. Under a sustained shortage this never advances —
-    /// which is exactly today's contract: a frozen bundle carries no new read schema.
+    /// Bumped whenever a bundle is frozen. The oracle waits for a generation newer than a promote's
+    /// before demanding coverage; under shortage this never advances, which is the contract today.
     bundle_generation: u64,
     /// Latest published portal assignment (what a `PortalFetch` samples).
     latest_portal_assignment: Option<PortalAssignment>,
     /// Confirmation watermark at the latest portal assignment's publication — the consistency
     /// oracle's accountability bound.
     latest_portal_watermark: AssignmentId,
-    /// The publication accompanying `latest_portal_assignment`, captured in the sole setter so the
-    /// bundle, generation and promote log can never drift from the assignment they shipped with.
+    /// Captured in the sole setter, so it can't drift from the assignment it shipped with.
     latest_portal_publication: Option<observers::PortalPublication>,
     /// Per departed worker, the newest assignment that still placed it — until the routing
     /// watermark passes it, the oracles hold the worker to nothing (see
@@ -524,10 +518,9 @@ impl<D: SimStorage> SimUnderTest<D> {
         ));
     }
 
-    /// Refresh the portal observer from the current publication — the single path both the explicit
-    /// fetch action and the convergence fixed point take. `check_converged` bypasses
-    /// `do_portal_fetch`, and shortage regressions land there, so a second refresh site would leave
-    /// the captured pair stale in exactly the states the read-schema oracle targets.
+    /// The single refresh path for both the fetch action and the convergence fixed point.
+    /// `check_converged` bypasses `do_portal_fetch` and shortage regressions land there, so a second
+    /// site would leave the captured pair stale in exactly the states the oracle targets.
     fn refresh_portal_observer(&mut self) {
         let Some(assignment) = self.latest_portal_assignment.clone() else {
             return;
@@ -582,10 +575,8 @@ impl<D: SimStorage> SimUnderTest<D> {
         self.trace_step(&format!("SetDatasetSchema({dataset})"));
     }
 
-    /// Promote `dataset`'s current read schema, recording the content in `model_read_schemas` as
-    /// the oracle's reference. Deliberately does NOT run a cycle: a promote lands on the
-    /// ingester's clock, so the interleaving worth testing is one that falls between cycles — and,
-    /// during a shortage streak, one whose bundle never advances at all.
+    /// Records the content as the oracle's reference. Runs no cycle on purpose: a promote lands on
+    /// the ingester's clock, so the interleaving worth testing is one falling between cycles.
     pub(super) fn do_promote_read_schema(&mut self, dataset: &str, schema: DatasetSchema) {
         self.storage
             .promote_read_schema(dataset, schema.clone())
@@ -1187,11 +1178,8 @@ impl<D: SimStorage> SimUnderTest<D> {
         self.assert_schema_bundle_consistency();
         self.latest_portal_watermark =
             self.storage.get_worker_assignment_confirmation() as AssignmentId;
-        // Captured HERE, not at fetch time: the promote log and the bundle must be the ones in
-        // force when this assignment was published. Rebuilding the triple when a portal fetches
-        // would let a promote issued afterwards retroactively indict an assignment that predates
-        // it — the assignment would be blamed for referencing nothing, when nothing was there to
-        // reference.
+        // Captured here, not at fetch time: rebuilding it on fetch would let a later promote indict
+        // an assignment that predates it.
         self.latest_portal_publication = Some(observers::PortalPublication {
             bundle: self.latest_worker_bundle.clone(),
             generation: self.bundle_generation,
@@ -1396,19 +1384,16 @@ impl<D: SimStorage> SimUnderTest<D> {
         }
     }
 
-    /// Every read schema the portal names must resolve in the bundle it was handed with — checked
-    /// against what the portal actually holds, not against the latest published pair.
+    /// Checked against what the portal holds, not the latest published pair.
     ///
-    /// **Known gap, deliberately excused:** an `Unresolvable` whose promote landed at or after the
-    /// bundle's generation is the frozen-bundle window. `run_scheduling_cycle` returns `Shortage`
-    /// before the bundle is built, while `run_visibility_cycle` keeps publishing a freshly resolved
-    /// pointer, and nothing persists which read ids a published bundle carried — so the visibility
-    /// cycle cannot know what the frozen bundle holds. Pinned by
-    /// `portal_read_schema_outruns_the_frozen_bundle`; when the bundle is allowed to advance under
-    /// shortage this arm and that test go together.
+    /// **Known gap, excused:** an `Unresolvable` promoted at or after the bundle's generation is the
+    /// frozen-bundle window — `run_scheduling_cycle` returns `Shortage` before building a bundle
+    /// while the visibility cycle keeps publishing a fresh pointer, and nothing records which read
+    /// ids a published bundle carried. Pinned by `portal_read_schema_outruns_the_frozen_bundle`;
+    /// letting the bundle advance under shortage removes both.
     ///
-    /// Everything else is fatal, and the excused count is measured rather than silently dropped —
-    /// an excuse that starts firing broadly shows up as a statistic instead of hiding a regression.
+    /// Everything else is fatal. The excused count is measured, so an excuse that starts firing
+    /// broadly shows up as a statistic instead of hiding a regression.
     fn assert_portal_read_schema_resolution(&self) {
         let Some(publication) = self.portal_state.publication.as_ref() else {
             return;
@@ -1441,8 +1426,7 @@ impl<D: SimStorage> SimUnderTest<D> {
         }
     }
 
-    /// The unexcused verdict, for regressions that need to assert on the gap itself rather than on
-    /// the walk's stand-down. `None` before a portal has fetched anything.
+    /// The unexcused verdict, for regressions asserting on the gap itself. `None` before a fetch.
     #[cfg(test)]
     pub(super) fn portal_read_schema_faults(
         &self,

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -1389,7 +1389,7 @@ impl<D: SimStorage> SimUnderTest<D> {
     /// **Known gap, excused:** an `Unresolvable` promoted at or after the bundle's generation is the
     /// frozen-bundle window — `run_scheduling_cycle` returns `Shortage` before building a bundle
     /// while the visibility cycle keeps publishing a fresh pointer, and nothing records which read
-    /// ids a published bundle carried. Pinned by `portal_read_schema_outruns_the_frozen_bundle`;
+    /// ids a published bundle carried. Reproduced by `portal_read_schema_resolves_under_shortage`;
     /// letting the bundle advance under shortage removes both.
     ///
     /// Everything else is fatal. The excused count is measured, so an excuse that starts firing

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -207,6 +207,14 @@ pub(super) enum Action {
         dataset: String,
         schema: DatasetSchema,
     },
+    /// Promote `dataset`'s current READ schema — the metadata service's admin path, which in
+    /// production runs on the ingester's clock with no scheduler coordination. Unlike
+    /// [`Action::SetDatasetSchema`] (the write registry) this affects no chunk: it changes what
+    /// the bundle must carry for readers.
+    PromoteReadSchema {
+        dataset: String,
+        schema: DatasetSchema,
+    },
     /// Do nothing — the idle tail after the run completes.
     NoOp,
 }
@@ -225,6 +233,7 @@ fn action_kind(action: &Action) -> &'static str {
         Action::RegisterCorrection { .. } => "action: register-correction",
         Action::SetMinReplication(_) => "action: set-min-replication",
         Action::SetDatasetSchema { .. } => "action: set-dataset-schema",
+        Action::PromoteReadSchema { .. } => "action: promote-read-schema",
         Action::NoOp => "action: no-op (idle tail)",
     }
 }
@@ -334,6 +343,17 @@ pub(super) struct SimUnderTest<D: SimStorage> {
     /// Bundle frozen with `latest_worker_assignment`; both stay frozen together across a shortage
     /// streak, so the oracle checks the assignment against the bundle it shipped with.
     latest_worker_bundle: Option<SchemaBundle>,
+    /// Read schemas as the SIM issued them: dataset → (content handed to `promote_read_schema`,
+    /// [`bundle_generation`](Self::bundle_generation) at the moment of the promote). Written only
+    /// from the sim's own action, never read back from a backend — it is the read-schema oracle's
+    /// independent reference, so subject (the published bundle) and reference (this map) cannot
+    /// agree by construction the way a storage-derived expectation would.
+    model_read_schemas: BTreeMap<String, (DatasetSchema, u64)>,
+    /// Bumped every time a bundle is frozen. A promote reaches the bundle on the next successful
+    /// scheduling cycle, never instantly, so the oracle waits for a generation strictly newer than
+    /// the promote's before demanding coverage. Under a sustained shortage this never advances —
+    /// which is exactly today's contract: a frozen bundle carries no new read schema.
+    bundle_generation: u64,
     /// Latest published portal assignment (what a `PortalFetch` samples).
     latest_portal_assignment: Option<PortalAssignment>,
     /// Confirmation watermark at the latest portal assignment's publication — the consistency
@@ -542,6 +562,20 @@ impl<D: SimStorage> SimUnderTest<D> {
         self.run_cycle();
         statistics::label("schema: dataset schema changed");
         self.trace_step(&format!("SetDatasetSchema({dataset})"));
+    }
+
+    /// Promote `dataset`'s current read schema, recording the content in `model_read_schemas` as
+    /// the oracle's reference. Deliberately does NOT run a cycle: a promote lands on the
+    /// ingester's clock, so the interleaving worth testing is one that falls between cycles — and,
+    /// during a shortage streak, one whose bundle never advances at all.
+    pub(super) fn do_promote_read_schema(&mut self, dataset: &str, schema: DatasetSchema) {
+        self.storage
+            .promote_read_schema(dataset, schema.clone())
+            .expect("dataset is pre-registered by the sim config");
+        self.model_read_schemas
+            .insert(dataset.to_owned(), (schema, self.bundle_generation));
+        statistics::label("schema: read schema promoted");
+        self.trace_step(&format!("PromoteReadSchema({dataset})"));
     }
 
     /// Standard addition flow (record weights → insert → register), shared by adds and test
@@ -1088,6 +1122,7 @@ impl<D: SimStorage> SimUnderTest<D> {
                 self.latest_worker_assignment = Some(assignment);
                 // Freeze with the assignment; on a shortage (below) neither is reassigned.
                 self.latest_worker_bundle = Some(bundle);
+                self.bundle_generation += 1;
                 Some(id)
             }
             Err(StorageError::Shortage) => {
@@ -1325,6 +1360,14 @@ impl<D: SimStorage> SimUnderTest<D> {
             bundle,
             self.latest_worker_assignment.as_ref(),
             self.latest_portal_assignment.as_ref(),
+        ) {
+            panic!("{message}");
+        }
+        if let Err(message) = placement_oracles::bundle_covers_promoted_read_schemas(
+            bundle,
+            self.latest_worker_assignment.as_ref(),
+            &self.model_read_schemas,
+            self.bundle_generation,
         ) {
             panic!("{message}");
         }
@@ -1640,6 +1683,9 @@ impl<D: SimStorage> SimUnderTest<D> {
             Action::SetDatasetSchema { dataset, schema } => {
                 self.do_set_dataset_schema(&dataset, schema);
             }
+            Action::PromoteReadSchema { dataset, schema } => {
+                self.do_promote_read_schema(&dataset, schema);
+            }
             Action::NoOp => {}
         }
         self.assert_physical_retention();
@@ -1783,6 +1829,8 @@ impl<D: SimStorage> SimUnderTest<D> {
             portal_state: Portal::default(),
             latest_worker_assignment: None,
             latest_worker_bundle: None,
+            model_read_schemas: BTreeMap::new(),
+            bundle_generation: 0,
             latest_portal_assignment: None,
             latest_portal_watermark: 0,
             placed_until_departure: BTreeMap::new(),

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -339,16 +339,14 @@ pub(super) struct SimUnderTest<D: SimStorage> {
     /// Latest published worker assignment (what a `WorkerFetch` samples); `None` until the first
     /// scheduling cycle.
     latest_worker_assignment: Option<WorkerAssignment>,
-    /// The bundle of the latest round — regenerated on every outcome, so it advances across a
-    /// shortage streak while `latest_worker_assignment` stays frozen; the oracles check both
-    /// against it.
+    /// Regenerated every round, so it advances across a shortage streak while
+    /// `latest_worker_assignment` stays frozen.
     latest_worker_bundle: Option<SchemaBundle>,
-    /// dataset → (content the sim promoted, [`bundle_generation`](Self::bundle_generation) then).
-    /// Written only by the sim's action, never read back from a backend — that independence is what
-    /// makes the read-schema oracle able to fail.
+    /// dataset → (promoted content, [`bundle_generation`](Self::bundle_generation) at the promote).
+    /// Never read back from a backend — that independence is what lets the oracle fail.
     model_read_schemas: BTreeMap<String, (DatasetSchema, u64)>,
-    /// Bumped once per round (every outcome). The worker-side oracle waits for a generation newer
-    /// than a promote's before demanding coverage — the legitimate one-round propagation lag.
+    /// Bumped once per round. The worker-side oracle enforces a promote only once the generation
+    /// passes it — the legitimate one-round propagation lag.
     bundle_generation: u64,
     /// Latest published portal assignment (what a `PortalFetch` samples).
     latest_portal_assignment: Option<PortalAssignment>,
@@ -519,9 +517,8 @@ impl<D: SimStorage> SimUnderTest<D> {
         ));
     }
 
-    /// The single refresh path for both the fetch action and the convergence fixed point.
-    /// `check_converged` bypasses `do_portal_fetch` and shortage regressions land there, so a second
-    /// site would leave the captured pair stale in exactly the states the oracle targets.
+    /// The single refresh path for the fetch action AND the convergence fixed point — a second site
+    /// would leave the captured pair stale in exactly the states the oracle targets.
     fn refresh_portal_observer(&mut self) {
         let Some(assignment) = self.latest_portal_assignment.clone() else {
             return;
@@ -576,8 +573,8 @@ impl<D: SimStorage> SimUnderTest<D> {
         self.trace_step(&format!("SetDatasetSchema({dataset})"));
     }
 
-    /// Records the content as the oracle's reference. Runs no cycle on purpose: a promote lands on
-    /// the ingester's clock, so the interleaving worth testing is one falling between cycles.
+    /// Records the content as the oracle's reference. Runs no cycle: a promote lands on the
+    /// ingester's clock, between rounds.
     pub(super) fn do_promote_read_schema(&mut self, dataset: &str, schema: DatasetSchema) {
         self.storage
             .promote_read_schema(dataset, schema.clone())
@@ -1109,10 +1106,9 @@ impl<D: SimStorage> SimUnderTest<D> {
 
     // ---- Storage cycle (shared machinery) ---------------------------------------------------
 
-    /// Run one scheduling pass against the live clock, recording the shortage flag. Returns the new
-    /// assignment's id on success, or `None` on a recorded shortage. The bundle is generated on
-    /// EVERY outcome, so a shortage advances it while the assignment stays frozen — the fix the
-    /// strict read-schema oracle enforces.
+    /// One scheduling pass; returns the new assignment's id, or `None` on a recorded shortage. The
+    /// bundle regenerates on EVERY outcome — a shortage advances it while the assignment stays
+    /// frozen, which is the fix the strict read-schema oracle enforces.
     fn run_scheduler(&mut self) -> Option<AssignmentId> {
         let id =
             match self
@@ -1186,8 +1182,8 @@ impl<D: SimStorage> SimUnderTest<D> {
         self.assert_schema_bundle_consistency();
         self.latest_portal_watermark =
             self.storage.get_worker_assignment_confirmation() as AssignmentId;
-        // Captured here, not at fetch time: rebuilding it on fetch would let a later promote indict
-        // an assignment that predates it.
+        // Captured at publish: rebuilding on fetch would let a later promote indict an older
+        // assignment.
         self.latest_portal_publication = Some(observers::PortalPublication {
             bundle: self.latest_worker_bundle.clone(),
             promoted: self.model_read_schemas.clone(),
@@ -1391,9 +1387,8 @@ impl<D: SimStorage> SimUnderTest<D> {
         }
     }
 
-    /// Checked against what the portal holds, not the latest published pair. Strict — every fault
-    /// is fatal: the bundle advances on every round including shortages, so there is no frozen
-    /// state left to excuse.
+    /// Strict: every fault is fatal — the bundle advances every round, so there is no frozen state
+    /// to excuse. Checked against what the portal holds, not the latest published pair.
     fn assert_portal_read_schema_resolution(&self) {
         let Some(publication) = self.portal_state.publication.as_ref() else {
             return;

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -339,15 +339,16 @@ pub(super) struct SimUnderTest<D: SimStorage> {
     /// Latest published worker assignment (what a `WorkerFetch` samples); `None` until the first
     /// scheduling cycle.
     latest_worker_assignment: Option<WorkerAssignment>,
-    /// Bundle frozen with `latest_worker_assignment`; both stay frozen together across a shortage
-    /// streak, so the oracle checks the assignment against the bundle it shipped with.
+    /// The bundle of the latest round — regenerated on every outcome, so it advances across a
+    /// shortage streak while `latest_worker_assignment` stays frozen; the oracles check both
+    /// against it.
     latest_worker_bundle: Option<SchemaBundle>,
     /// dataset → (content the sim promoted, [`bundle_generation`](Self::bundle_generation) then).
     /// Written only by the sim's action, never read back from a backend — that independence is what
     /// makes the read-schema oracle able to fail.
     model_read_schemas: BTreeMap<String, (DatasetSchema, u64)>,
-    /// Bumped whenever a bundle is frozen. The oracle waits for a generation newer than a promote's
-    /// before demanding coverage; under shortage this never advances, which is the contract today.
+    /// Bumped once per round (every outcome). The worker-side oracle waits for a generation newer
+    /// than a promote's before demanding coverage — the legitimate one-round propagation lag.
     bundle_generation: u64,
     /// Latest published portal assignment (what a `PortalFetch` samples).
     latest_portal_assignment: Option<PortalAssignment>,
@@ -1110,31 +1111,41 @@ impl<D: SimStorage> SimUnderTest<D> {
 
     /// Run one scheduling pass against the live clock, recording the shortage flag. Returns the new
     /// assignment's id on success, or `None` on a recorded shortage.
+    ///
+    /// The bundle is generated on EVERY outcome: it is a function of committed rows (routable
+    /// window ∪ the persisted set of the last successful assignment), so a shortage advances it —
+    /// promotes keep flowing to portals while the assignment stays frozen. That is the fix the
+    /// strict read-schema oracle enforces.
     fn run_scheduler(&mut self) -> Option<AssignmentId> {
-        match self
-            .storage
-            .run_scheduling_cycle(&self.algo, &self.config, self.now, M_TICKS)
-        {
-            Ok((assignment, bundle)) => {
-                self.schedule_status = ScheduleStatus::SchedulerPlaced;
-                self.is_infeasible = false;
-                // A successful schedule ends a saturation episode — re-arm the latch so the walk
-                // can saturate, probe, and recover again.
-                self.converge_checked = false;
-                let id = assignment.id;
-                self.latest_worker_assignment = Some(assignment);
-                // Freeze with the assignment; on a shortage (below) neither is reassigned.
-                self.latest_worker_bundle = Some(bundle);
-                self.bundle_generation += 1;
-                Some(id)
-            }
-            Err(StorageError::Shortage) => {
-                self.schedule_status = ScheduleStatus::NotEnoughCapacity;
-                self.is_infeasible = true;
-                None
-            }
-            Err(err) => panic!("scheduling cycle failed (not a shortage): {err}"),
-        }
+        let id =
+            match self
+                .storage
+                .run_scheduling_cycle(&self.algo, &self.config, self.now, M_TICKS)
+            {
+                Ok(assignment) => {
+                    self.schedule_status = ScheduleStatus::SchedulerPlaced;
+                    self.is_infeasible = false;
+                    // A successful schedule ends a saturation episode — re-arm the latch so the walk
+                    // can saturate, probe, and recover again.
+                    self.converge_checked = false;
+                    let id = assignment.id;
+                    self.latest_worker_assignment = Some(assignment);
+                    Some(id)
+                }
+                Err(StorageError::Shortage) => {
+                    self.schedule_status = ScheduleStatus::NotEnoughCapacity;
+                    self.is_infeasible = true;
+                    None
+                }
+                Err(err) => panic!("scheduling cycle failed (not a shortage): {err}"),
+            };
+        self.latest_worker_bundle = Some(
+            self.storage
+                .generate_schema_bundle()
+                .expect("bundle generation is outcome-independent"),
+        );
+        self.bundle_generation += 1;
+        id
     }
 
     /// One storage cycle: schedule, advance the clock, run visibility, assert per-step safety.
@@ -1182,7 +1193,6 @@ impl<D: SimStorage> SimUnderTest<D> {
         // an assignment that predates it.
         self.latest_portal_publication = Some(observers::PortalPublication {
             bundle: self.latest_worker_bundle.clone(),
-            generation: self.bundle_generation,
             promoted: self.model_read_schemas.clone(),
         });
         self.latest_portal_assignment = Some(assignment);
@@ -1384,16 +1394,10 @@ impl<D: SimStorage> SimUnderTest<D> {
         }
     }
 
-    /// Checked against what the portal holds, not the latest published pair.
-    ///
-    /// **Known gap, excused:** an `Unresolvable` promoted at or after the bundle's generation is the
-    /// frozen-bundle window — `run_scheduling_cycle` returns `Shortage` before building a bundle
-    /// while the visibility cycle keeps publishing a fresh pointer, and nothing records which read
-    /// ids a published bundle carried. Reproduced by `portal_read_schema_resolves_under_shortage`;
-    /// letting the bundle advance under shortage removes both.
-    ///
-    /// Everything else is fatal. The excused count is measured, so an excuse that starts firing
-    /// broadly shows up as a statistic instead of hiding a regression.
+    /// Checked against what the portal holds, not the latest published pair. Strict: every fault is
+    /// fatal. The bundle advances on every round including shortages (it is generated from
+    /// committed rows, independent of placement), so there is no frozen-bundle state left to
+    /// excuse — a portal must always be able to resolve every read schema it is told to use.
     fn assert_portal_read_schema_resolution(&self) {
         let Some(publication) = self.portal_state.publication.as_ref() else {
             return;
@@ -1406,39 +1410,9 @@ impl<D: SimStorage> SimUnderTest<D> {
         };
         let faults =
             placement_oracles::portal_read_schemas_resolve(portal, bundle, &publication.promoted);
-        let (excused, fatal): (Vec<_>, Vec<_>) = faults.into_iter().partition(|fault| {
-            matches!(
-                fault,
-                placement_oracles::ReadSchemaFault::Unresolvable { promoted_at, .. }
-                    if publication.generation <= *promoted_at
-            )
-        });
-        statistics::measure(
-            "schema: read refs excused by frozen bundle",
-            excused.len() as f64,
-        );
-        statistics::classify(
-            !fatal.is_empty(),
-            "schema: portal read reference unresolvable (fatal)",
-        );
-        if let Some(fault) = fatal.first() {
+        if let Some(fault) = faults.first() {
             panic!("{fault}");
         }
-    }
-
-    /// The unexcused verdict, for regressions asserting on the gap itself. `None` before a fetch.
-    #[cfg(test)]
-    pub(super) fn portal_read_schema_faults(
-        &self,
-    ) -> Option<Vec<placement_oracles::ReadSchemaFault>> {
-        let publication = self.portal_state.publication.as_ref()?;
-        let portal = self.portal_state.snapshot.as_ref()?;
-        let bundle = publication.bundle.as_ref()?;
-        Some(placement_oracles::portal_read_schemas_resolve(
-            portal,
-            bundle,
-            &publication.promoted,
-        ))
     }
 
     // ---- Observation layer (fleet + portal) -------------------------------------------------

--- a/src/multistep_scheduler/sim/sut/churn.rs
+++ b/src/multistep_scheduler/sim/sut/churn.rs
@@ -9,8 +9,8 @@ use proptest::prelude::*;
 use proptest::strategy::Union;
 
 use super::super::utils::{
-    SimProfile, add_random_chunks, advance_clock, default_sim_config, register_correction,
-    set_dataset_schema,
+    SimProfile, add_random_chunks, advance_clock, default_sim_config, promote_read_schema,
+    register_correction, set_dataset_schema,
 };
 use super::{
     Action, ConvergenceCheck, SimConfig, SimStorage, SimUnderTest, standard_preconditions,
@@ -116,6 +116,8 @@ impl<D: SimStorage + SimProfile> IterativeModelStateMachine for ChurnModel<D> {
         }
 
         choices.push((1, set_dataset_schema(&config.datasets)));
+
+        choices.push((1, promote_read_schema(&config.datasets)));
         choices.extend(super::super::utils::fetch_choices(sut));
         Union::new_weighted(choices).boxed()
     }

--- a/src/multistep_scheduler/sim/sut/guided.rs
+++ b/src/multistep_scheduler/sim/sut/guided.rs
@@ -7,8 +7,8 @@ use proptest::prelude::*;
 use proptest::strategy::Union;
 
 use super::super::utils::{
-    SimProfile, add_random_chunks, advance_clock, default_sim_config, register_correction,
-    set_dataset_schema,
+    SimProfile, add_random_chunks, advance_clock, default_sim_config, promote_read_schema,
+    register_correction, set_dataset_schema,
 };
 use super::{
     Action, ConvergenceCheck, SimConfig, SimStorage, SimUnderTest, standard_preconditions,
@@ -86,6 +86,7 @@ impl<D: SimStorage + SimProfile> IterativeModelStateMachine for SimModel<D> {
             choices.push((weight, Just(Action::SetMinReplication(floor + 1)).boxed()));
         }
         choices.push((1, set_dataset_schema(&config.datasets)));
+        choices.push((1, promote_read_schema(&config.datasets)));
         choices.extend(super::super::utils::fetch_choices(sut));
         Union::new_weighted(choices).boxed()
     }

--- a/src/multistep_scheduler/sim/sut/observers.rs
+++ b/src/multistep_scheduler/sim/sut/observers.rs
@@ -122,24 +122,20 @@ pub(super) struct Portal {
     pub(super) snapshot: Option<PortalAssignment>,
     pub(super) fetched_at: Tick,
     pub(super) watermark: AssignmentId,
-    /// The publication `snapshot` was taken from — the bundle, generation and promote log as of
-    /// the same instant. Captured rather than read live, so a promote issued after this fetch can
-    /// never retroactively indict a pair that was coherent when handed over.
+    /// The publication `snapshot` came from. Captured, not read live, so a later promote can't
+    /// indict a pair that was coherent when handed over.
     pub(super) publication: Option<PortalPublication>,
 }
 
-/// Everything published alongside a portal assignment, captured at the instant of publication so a
-/// consumer-side oracle can never pair a held assignment with a bundle the portal never saw.
+/// Captured at publication, so an oracle can't pair a held assignment with a bundle never sent.
 #[derive(Debug, Clone)]
 pub(super) struct PortalPublication {
-    /// The bundle in force at publication — the one a portal holding this assignment would have to
-    /// resolve against. `None` before the first successful scheduling cycle. Under a shortage
-    /// streak this is the FROZEN bundle, which is the point rather than an artefact.
+    /// What a portal holding this assignment must resolve against; `None` before the first
+    /// successful cycle. Under shortage this is the frozen bundle — the point, not an artefact.
     pub(super) bundle: Option<SchemaBundle>,
     /// `bundle_generation` at publication.
     pub(super) generation: u64,
-    /// The sim's own promote log as of publication — written only by the sim's action, never read
-    /// back from a backend.
+    /// The sim's promote log at publication; never read back from a backend.
     pub(super) promoted: BTreeMap<String, (DatasetSchema, u64)>,
 }
 

--- a/src/multistep_scheduler/sim/sut/observers.rs
+++ b/src/multistep_scheduler/sim/sut/observers.rs
@@ -122,19 +122,16 @@ pub(super) struct Portal {
     pub(super) snapshot: Option<PortalAssignment>,
     pub(super) fetched_at: Tick,
     pub(super) watermark: AssignmentId,
-    /// The publication `snapshot` came from. Captured, not read live, so a later promote can't
-    /// indict a pair that was coherent when handed over.
+    /// The publication `snapshot` came from, captured at publish time.
     pub(super) publication: Option<PortalPublication>,
 }
 
-/// Captured at publication, so an oracle can't pair a held assignment with a bundle never sent.
+/// What was published alongside a portal assignment, captured at that instant.
 #[derive(Debug, Clone)]
 pub(super) struct PortalPublication {
-    /// What a portal holding this assignment must resolve against; `None` only before the first
-    /// scheduling round. Regenerated every round — success or shortage — so it always carries the
-    /// current read schemas.
+    /// What a portal holding this assignment resolves against; `None` before the first round.
     pub(super) bundle: Option<SchemaBundle>,
-    /// The sim's promote log at publication; never read back from a backend.
+    /// The sim's promote log at publication.
     pub(super) promoted: BTreeMap<String, (DatasetSchema, u64)>,
 }
 

--- a/src/multistep_scheduler/sim/sut/observers.rs
+++ b/src/multistep_scheduler/sim/sut/observers.rs
@@ -130,11 +130,10 @@ pub(super) struct Portal {
 /// Captured at publication, so an oracle can't pair a held assignment with a bundle never sent.
 #[derive(Debug, Clone)]
 pub(super) struct PortalPublication {
-    /// What a portal holding this assignment must resolve against; `None` before the first
-    /// successful cycle. Under shortage this is the frozen bundle — the point, not an artefact.
+    /// What a portal holding this assignment must resolve against; `None` only before the first
+    /// scheduling round. Regenerated every round — success or shortage — so it always carries the
+    /// current read schemas.
     pub(super) bundle: Option<SchemaBundle>,
-    /// `bundle_generation` at publication.
-    pub(super) generation: u64,
     /// The sim's promote log at publication; never read back from a backend.
     pub(super) promoted: BTreeMap<String, (DatasetSchema, u64)>,
 }
@@ -280,7 +279,6 @@ mod tests {
             2,
             PortalPublication {
                 bundle: None,
-                generation: 0,
                 promoted: BTreeMap::new(),
             },
             12,

--- a/src/multistep_scheduler/sim/sut/observers.rs
+++ b/src/multistep_scheduler/sim/sut/observers.rs
@@ -6,8 +6,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::scheduler_storage::{
-    AssignmentId, ChunkPk, PortalAssignment, Tick, WorkerAssignment, WorkerPk,
+    AssignmentId, ChunkPk, PortalAssignment, SchemaBundle, Tick, WorkerAssignment, WorkerPk,
 };
+use crate::types::DatasetSchema;
 
 /// One worker's observed local state.
 #[derive(Debug, Default)]
@@ -121,6 +122,25 @@ pub(super) struct Portal {
     pub(super) snapshot: Option<PortalAssignment>,
     pub(super) fetched_at: Tick,
     pub(super) watermark: AssignmentId,
+    /// The publication `snapshot` was taken from — the bundle, generation and promote log as of
+    /// the same instant. Captured rather than read live, so a promote issued after this fetch can
+    /// never retroactively indict a pair that was coherent when handed over.
+    pub(super) publication: Option<PortalPublication>,
+}
+
+/// Everything published alongside a portal assignment, captured at the instant of publication so a
+/// consumer-side oracle can never pair a held assignment with a bundle the portal never saw.
+#[derive(Debug, Clone)]
+pub(super) struct PortalPublication {
+    /// The bundle in force at publication — the one a portal holding this assignment would have to
+    /// resolve against. `None` before the first successful scheduling cycle. Under a shortage
+    /// streak this is the FROZEN bundle, which is the point rather than an artefact.
+    pub(super) bundle: Option<SchemaBundle>,
+    /// `bundle_generation` at publication.
+    pub(super) generation: u64,
+    /// The sim's own promote log as of publication — written only by the sim's action, never read
+    /// back from a backend.
+    pub(super) promoted: BTreeMap<String, (DatasetSchema, u64)>,
 }
 
 impl Portal {
@@ -130,11 +150,13 @@ impl Portal {
         &mut self,
         assignment: &PortalAssignment,
         watermark: AssignmentId,
+        publication: PortalPublication,
         now: Tick,
     ) {
         self.snapshot = Some(assignment.clone());
         self.fetched_at = now;
         self.watermark = watermark;
+        self.publication = Some(publication);
     }
 }
 
@@ -255,8 +277,18 @@ mod tests {
             chunk_workers: BTreeMap::new(),
             chunks: BTreeMap::new(),
             workers: BTreeMap::new(),
+            read_schemas: BTreeMap::new(),
         };
-        portal.observer_assignment(&pa, 2, 12);
+        portal.observer_assignment(
+            &pa,
+            2,
+            PortalPublication {
+                bundle: None,
+                generation: 0,
+                promoted: BTreeMap::new(),
+            },
+            12,
+        );
         assert_eq!(portal.fetched_at, 12);
         assert_eq!(portal.watermark, 2);
         assert_eq!(portal.snapshot_age(20), 8);

--- a/src/multistep_scheduler/sim/sut/placement_oracles.rs
+++ b/src/multistep_scheduler/sim/sut/placement_oracles.rs
@@ -609,6 +609,7 @@ fn can_host_after_dropping_bonuses(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::scheduler_storage::{SchemaId, WorkerAssignmentChunk};
 
     fn wk(ids: &[i32]) -> Vec<WorkerPk> {
         ids.iter().map(|&w| WorkerPk(w)).collect()
@@ -650,6 +651,151 @@ mod tests {
             workers: BTreeMap::new(),
             read_schemas: BTreeMap::new(),
         }
+    }
+
+    // ---- read-schema resolution -------------------------------------------------------------
+
+    fn read_schema(table: &str) -> DatasetSchema {
+        DatasetSchema::new(BTreeMap::from([(
+            table.to_owned(),
+            crate::types::TableSchema::default(),
+        )]))
+    }
+
+    /// A portal assignment naming one chunk in `dataset`, with `reference` as that dataset's entry.
+    fn portal_naming(dataset: &str, reference: Option<Option<i32>>) -> PortalAssignment {
+        let name: crate::types::DatasetId = std::sync::Arc::new(dataset.to_owned());
+        let chunk = WorkerAssignmentChunk {
+            dataset: name.clone(),
+            id: std::sync::Arc::new("c0".to_owned()),
+            size: 1,
+            blocks: 0..=1,
+            schema_id: SchemaId(1),
+            tables_present: None,
+        };
+        PortalAssignment {
+            id: 1,
+            chunk_workers: BTreeMap::new(),
+            chunks: BTreeMap::from([(ChunkPk(0), chunk)]),
+            workers: BTreeMap::new(),
+            read_schemas: match reference {
+                None => BTreeMap::new(),
+                Some(id) => BTreeMap::from([(name, id.map(ReadSchemaId))]),
+            },
+        }
+    }
+
+    fn bundle_with_read(entries: &[(i32, DatasetSchema)]) -> SchemaBundle {
+        SchemaBundle::from_sections(
+            BTreeMap::new(),
+            entries
+                .iter()
+                .map(|(id, schema)| (ReadSchemaId(*id), schema.clone()))
+                .collect(),
+        )
+    }
+
+    fn promoted_log(
+        dataset: &str,
+        schema: DatasetSchema,
+        at: u64,
+    ) -> BTreeMap<String, (DatasetSchema, u64)> {
+        BTreeMap::from([(dataset.to_owned(), (schema, at))])
+    }
+
+    /// Every fault variant fires on its own minimal violating state, and the coherent case is clean.
+    /// Without this only `Unresolvable` was ever constructed, so the other five arms were untested
+    /// and could have been unreachable or mis-ordered without any test noticing.
+    #[test]
+    fn portal_read_schemas_resolve_detects_each_fault() {
+        let blocks = read_schema("blocks");
+        let logs = read_schema("logs");
+        let ds = "s3://a";
+
+        // Coherent: reference resolves to the promoted content.
+        assert_eq!(
+            portal_read_schemas_resolve(
+                &portal_naming(ds, Some(Some(7))),
+                &bundle_with_read(&[(7, blocks.clone())]),
+                &promoted_log(ds, blocks.clone(), 1),
+            ),
+            vec![],
+        );
+
+        // Named dataset with no entry at all.
+        assert_eq!(
+            portal_read_schemas_resolve(
+                &portal_naming(ds, None),
+                &bundle_with_read(&[]),
+                &BTreeMap::new(),
+            ),
+            vec![ReadSchemaFault::Unscoped { dataset: ds.into() }],
+        );
+
+        // Entry for a dataset no chunk names.
+        let mut orphaned = portal_naming(ds, Some(None));
+        orphaned
+            .read_schemas
+            .insert(std::sync::Arc::new("s3://gone".to_owned()), None);
+        assert_eq!(
+            portal_read_schemas_resolve(&orphaned, &bundle_with_read(&[]), &BTreeMap::new()),
+            vec![ReadSchemaFault::Orphaned {
+                dataset: "s3://gone".into()
+            }],
+        );
+
+        // Promoted, but the assignment references nothing.
+        assert_eq!(
+            portal_read_schemas_resolve(
+                &portal_naming(ds, Some(None)),
+                &bundle_with_read(&[]),
+                &promoted_log(ds, blocks.clone(), 2),
+            ),
+            vec![ReadSchemaFault::MissingReference {
+                dataset: ds.into(),
+                promoted_at: 2
+            }],
+        );
+
+        // References an id for a dataset never promoted for.
+        assert_eq!(
+            portal_read_schemas_resolve(
+                &portal_naming(ds, Some(Some(7))),
+                &bundle_with_read(&[(7, blocks.clone())]),
+                &BTreeMap::new(),
+            ),
+            vec![ReadSchemaFault::Fabricated {
+                dataset: ds.into(),
+                id: ReadSchemaId(7)
+            }],
+        );
+
+        // Referenced id is not in the bundle — the frozen-bundle shape.
+        assert_eq!(
+            portal_read_schemas_resolve(
+                &portal_naming(ds, Some(Some(7))),
+                &bundle_with_read(&[]),
+                &promoted_log(ds, blocks.clone(), 3),
+            ),
+            vec![ReadSchemaFault::Unresolvable {
+                dataset: ds.into(),
+                id: ReadSchemaId(7),
+                promoted_at: 3
+            }],
+        );
+
+        // Resolves, but to content never promoted for this dataset.
+        assert_eq!(
+            portal_read_schemas_resolve(
+                &portal_naming(ds, Some(Some(7))),
+                &bundle_with_read(&[(7, logs)]),
+                &promoted_log(ds, blocks, 4),
+            ),
+            vec![ReadSchemaFault::ContentMismatch {
+                dataset: ds.into(),
+                id: ReadSchemaId(7)
+            }],
+        );
     }
 
     fn worker_assignment(routing: &[(i64, &[i32])]) -> WorkerAssignment {

--- a/src/multistep_scheduler/sim/sut/placement_oracles.rs
+++ b/src/multistep_scheduler/sim/sut/placement_oracles.rs
@@ -29,6 +29,7 @@ use crate::scheduler_storage::test_harness::inspect::Snapshot;
 use crate::scheduler_storage::{
     ChunkPk, PortalAssignment, SchemaBundle, Tick, WorkerAssignment, WorkerPk,
 };
+use crate::types::DatasetSchema;
 
 /// Routing coverage by physical possession: within the M window, a routed chunk must be physically
 /// held (`holds` — not the published listing, which is [`published_coverage`]'s job) by one of its
@@ -223,6 +224,60 @@ pub(super) fn schema_bundle_consistency(
                     chunk.schema_id,
                 ));
             }
+        }
+    }
+    Ok(())
+}
+
+/// Every dataset the worker assignment names must have its promoted READ schema carried in the
+/// bundle frozen with that assignment — otherwise a portal validating a query against that dataset
+/// has nothing to resolve.
+///
+/// The reference is `promoted`, the sim's own log of what it handed to `promote_read_schema`, and
+/// the subject is the published bundle. Neither is derived from the other through storage, so this
+/// cannot pass by both sides reading the same query — the failure mode of a containment check
+/// written against a storage-derived expectation.
+///
+/// Scoped to datasets the assignment actually names: a promote for a dataset with no placed chunk
+/// is correctly absent (nothing routes to it, so nothing needs to describe it).
+///
+/// A promote propagates on the next successful scheduling cycle, never instantly, so each entry
+/// carries the bundle generation current when it was issued and is only enforced once
+/// `bundle_generation` has moved past it. That is not a loophole for the frozen-shortage case — it
+/// encodes it: while placement is in shortage no bundle is frozen, the generation never advances,
+/// and a promote genuinely cannot reach a portal. If bundle generation is ever decoupled from
+/// placement, this check tightens on its own with no edit.
+pub(super) fn bundle_covers_promoted_read_schemas(
+    bundle: &SchemaBundle,
+    worker_assignment: Option<&WorkerAssignment>,
+    promoted: &BTreeMap<String, (DatasetSchema, u64)>,
+    bundle_generation: u64,
+) -> Result<(), String> {
+    let Some(assignment) = worker_assignment else {
+        return Ok(());
+    };
+    // Compared by content, not by id: `DatasetSchema` is not `Ord`, and content is also the only
+    // thing the sim knows independently of storage — an id would have to be read back from the
+    // backend that assigned it. The read section holds one schema per in-play dataset, so the
+    // linear scan is trivial.
+    for chunk in assignment.chunks.values() {
+        let Some((expected, promoted_at)) = promoted.get(chunk.dataset.as_str()) else {
+            continue;
+        };
+        // Not yet due: no bundle has been frozen since this promote.
+        if bundle_generation <= *promoted_at {
+            continue;
+        }
+        if !bundle.read_schemas().values().any(|s| s == expected) {
+            return Err(format!(
+                "dataset {} is named by the worker assignment and had a read schema promoted at \
+                 bundle generation {promoted_at} ({} bundles frozen since), but that schema is \
+                 absent from the bundle frozen with the assignment — a portal could not resolve \
+                 it. bundle read section holds {} schema(s)",
+                chunk.dataset,
+                bundle_generation - promoted_at,
+                bundle.read_schemas().len(),
+            ));
         }
     }
     Ok(())

--- a/src/multistep_scheduler/sim/sut/placement_oracles.rs
+++ b/src/multistep_scheduler/sim/sut/placement_oracles.rs
@@ -27,7 +27,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::scheduler_storage::test_harness::inspect::Snapshot;
 use crate::scheduler_storage::{
-    ChunkPk, PortalAssignment, SchemaBundle, Tick, WorkerAssignment, WorkerPk,
+    ChunkPk, PortalAssignment, ReadSchemaId, SchemaBundle, Tick, WorkerAssignment, WorkerPk,
 };
 use crate::types::DatasetSchema;
 
@@ -283,6 +283,151 @@ pub(super) fn bundle_covers_promoted_read_schemas(
     Ok(())
 }
 
+/// Why a portal's read-schema reference is incoherent with the bundle it was published with. A
+/// typed verdict rather than a string, so a regression can pin the exact fault without asserting on
+/// message text or on a backend-assigned id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReadSchemaFault {
+    /// A dataset the chunk set names has no reference entry at all — a resolution omission. Ids are
+    /// never reused, so a reference that could not be produced must be visible, never answered by
+    /// silence.
+    Unscoped { dataset: String },
+    /// An entry for a dataset no chunk names — the reference failed to retire.
+    Orphaned { dataset: String },
+    /// The sim promoted for this dataset before publication, yet the reference is `None`.
+    MissingReference { dataset: String, promoted_at: u64 },
+    /// The reference names an id for a dataset the sim never promoted for.
+    Fabricated { dataset: String, id: ReadSchemaId },
+    /// The reference names an id the paired bundle cannot resolve. **This is the frozen-bundle
+    /// gap**: the visibility cycle published a fresh pointer against a bundle that never advanced.
+    Unresolvable {
+        dataset: String,
+        id: ReadSchemaId,
+        promoted_at: u64,
+    },
+    /// The id resolves, but to content the sim never promoted for this dataset — a wrong-dataset or
+    /// wrong-section attribution that presence alone cannot see.
+    ContentMismatch { dataset: String, id: ReadSchemaId },
+}
+
+impl std::fmt::Display for ReadSchemaFault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unscoped { dataset } => write!(
+                f,
+                "dataset {dataset} has portal-visible chunks but no read-schema reference — the \
+                    backend omitted it instead of publishing an explicit `None`"
+            ),
+            Self::Orphaned { dataset } => write!(
+                f,
+                "dataset {dataset} has a read-schema reference but no chunk in the assignment — \
+                    the reference failed to retire with its last visible chunk"
+            ),
+            Self::MissingReference {
+                dataset,
+                promoted_at,
+            } => write!(
+                f,
+                "dataset {dataset} had a read schema promoted (at bundle generation \
+                    {promoted_at}) but the portal assignment references none"
+            ),
+            Self::Fabricated { dataset, id } => write!(
+                f,
+                "portal references read schema {id} for dataset {dataset}, which never had one \
+                    promoted"
+            ),
+            Self::Unresolvable {
+                dataset,
+                id,
+                promoted_at,
+            } => write!(
+                f,
+                "portal references read schema {id} for dataset {dataset} (promoted at bundle \
+                    generation {promoted_at}) but the bundle published with that assignment cannot \
+                    resolve it — the portal names a schema it cannot read"
+            ),
+            Self::ContentMismatch { dataset, id } => write!(
+                f,
+                "read schema {id} resolves in the bundle, but to content never promoted for \
+                    dataset {dataset}"
+            ),
+        }
+    }
+}
+
+/// CONSUMER-SIDE read-schema resolvability: every read schema the PORTAL names must resolve in the
+/// bundle the portal was handed alongside it.
+///
+/// Subject is the assignment a portal actually holds; the reference is the bundle captured at that
+/// same publication plus the sim's own promote log. The bundle comes from `run_scheduling_cycle`,
+/// the reference map from `run_visibility_cycle`, and the promote log is never read back from a
+/// backend — so unlike [`schema_bundle_consistency`], which draws subject and invariant from the
+/// same chunk pins, this cannot pass by one query agreeing with itself.
+///
+/// Returns **every** fault, never just the first: the caller partitions them into fatal and
+/// gap-excused, and a single early return would let one excused fault mask a real one behind it.
+///
+/// Resolution is checked BY ID, not by content: read ids are allocated per `(dataset, content)`, so
+/// with a small canned schema pool a content-only check would be satisfied by any dataset's entry.
+/// Content is then checked separately, to catch a right-shaped id resolving to the wrong schema.
+///
+/// No age stand-down. Resolvability is not availability (ADR 0002 — a chunk may sit at zero copies
+/// yet stay fully resolvable), and a captured pair is self-consistent at any age; copying
+/// `portal_consistency`'s `age >= M_TICKS` gate would silence the target case outright, since a
+/// shortage streak advances the clock by `M_TICKS` per drain.
+pub(super) fn portal_read_schemas_resolve(
+    portal: &PortalAssignment,
+    bundle: &SchemaBundle,
+    promoted: &BTreeMap<String, (DatasetSchema, u64)>,
+) -> Vec<ReadSchemaFault> {
+    let mut faults = Vec::new();
+    let named = portal.named_datasets();
+    for dataset in &named {
+        if !portal.read_schemas.contains_key(dataset) {
+            faults.push(ReadSchemaFault::Unscoped {
+                dataset: dataset.to_string(),
+            });
+        }
+    }
+    for dataset in portal.read_schemas.keys() {
+        if !named.contains(dataset) {
+            faults.push(ReadSchemaFault::Orphaned {
+                dataset: dataset.to_string(),
+            });
+        }
+    }
+    for (dataset, reference) in &portal.read_schemas {
+        let logged = promoted.get(dataset.as_str());
+        match (reference, logged) {
+            // Never promoted, nothing referenced — the seeded state of every dataset.
+            (None, None) => {}
+            (None, Some((_, promoted_at))) => faults.push(ReadSchemaFault::MissingReference {
+                dataset: dataset.to_string(),
+                promoted_at: *promoted_at,
+            }),
+            (Some(id), None) => faults.push(ReadSchemaFault::Fabricated {
+                dataset: dataset.to_string(),
+                id: *id,
+            }),
+            (Some(id), Some((content, promoted_at))) => match bundle.get_read(*id) {
+                None => faults.push(ReadSchemaFault::Unresolvable {
+                    dataset: dataset.to_string(),
+                    id: *id,
+                    promoted_at: *promoted_at,
+                }),
+                Some(resolved) if resolved != content => {
+                    faults.push(ReadSchemaFault::ContentMismatch {
+                        dataset: dataset.to_string(),
+                        id: *id,
+                    })
+                }
+                Some(_) => {}
+            },
+        }
+    }
+    faults
+}
+
 /// A converged-floor violation: the under-replicated chunk (for the failure dump) and the message.
 pub(super) struct FloorViolation {
     pub(super) chunk: usize,
@@ -524,6 +669,7 @@ mod tests {
                 .collect(),
             chunks: BTreeMap::new(),
             workers: BTreeMap::new(),
+            read_schemas: BTreeMap::new(),
         }
     }
 

--- a/src/multistep_scheduler/sim/sut/placement_oracles.rs
+++ b/src/multistep_scheduler/sim/sut/placement_oracles.rs
@@ -201,9 +201,9 @@ pub(super) fn routing_matches_assignment_at_fixed_point(
     Ok(())
 }
 
-/// Every chunk a published assignment names must resolve under the [`SchemaBundle`] frozen with
-/// that worker assignment: the chunk's pinned `schema_id` must be in the bundle, or a worker/portal
-/// couldn't derive its file set. Either assignment may be absent (nothing published yet).
+/// Every chunk a published assignment names must resolve under the [`SchemaBundle`] published with
+/// it: the chunk's pinned `schema_id` must be in the bundle, or a worker/portal couldn't derive its
+/// file set. Either assignment may be absent (nothing published yet).
 pub(super) fn schema_bundle_consistency(
     bundle: &SchemaBundle,
     worker_assignment: Option<&WorkerAssignment>,
@@ -218,9 +218,8 @@ pub(super) fn schema_bundle_consistency(
         for (chunk_pk, chunk) in chunks {
             if !bundle.contains(chunk.schema_id) {
                 return Err(format!(
-                    "{label} names chunk {chunk_pk:?} with schema {}, absent from the schema \
-                     bundle frozen with the worker assignment — a worker or portal couldn't \
-                     resolve this chunk's file set",
+                    "{label} names chunk {chunk_pk:?} with schema {}, absent from the published \
+                     schema bundle — a worker or portal couldn't resolve this chunk's file set",
                     chunk.schema_id,
                 ));
             }

--- a/src/multistep_scheduler/sim/sut/placement_oracles.rs
+++ b/src/multistep_scheduler/sim/sut/placement_oracles.rs
@@ -229,14 +229,10 @@ pub(super) fn schema_bundle_consistency(
     Ok(())
 }
 
-/// Every dataset the worker assignment names must have its promoted read schema in the bundle
-/// frozen with it. Subject is the bundle; reference is `promoted`, the sim's own promote log —
-/// neither derived from the other, so this can't pass by one storage query agreeing with itself.
-///
-/// A promote reaches the bundle on the next successful cycle, not instantly, so an entry is only
-/// enforced once `bundle_generation` passes the generation it was issued at. That encodes the
-/// shortage case rather than excusing it: a frozen bundle never advances the generation, and a
-/// promote genuinely cannot reach a portal. Decoupling the two tightens this with no edit.
+/// Every dataset the worker assignment names must have its promoted read schema in the bundle.
+/// Reference is `promoted`, the sim's own log — independent of storage, so this can actually fail.
+/// An entry is enforced only once `bundle_generation` passes its promote (one round of lag is
+/// legitimate).
 pub(super) fn bundle_covers_promoted_read_schemas(
     bundle: &SchemaBundle,
     worker_assignment: Option<&WorkerAssignment>,
@@ -246,7 +242,6 @@ pub(super) fn bundle_covers_promoted_read_schemas(
     let Some(assignment) = worker_assignment else {
         return Ok(());
     };
-    // By content, not id: content is the only thing the sim knows without reading storage back.
     for chunk in assignment.chunks.values() {
         let Some((expected, promoted_at)) = promoted.get(chunk.dataset.as_str()) else {
             continue;
@@ -269,10 +264,10 @@ pub(super) fn bundle_covers_promoted_read_schemas(
     Ok(())
 }
 
-/// Typed so a regression can pin the exact fault without matching message text or a backend id.
+/// Typed so a regression can pin the exact fault without matching message text.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ReadSchemaFault {
-    /// A named dataset has no entry at all — an omission, which must be visible rather than silent.
+    /// A named dataset has no entry at all.
     Unscoped { dataset: String },
     /// An entry for a dataset no chunk names — the reference failed to retire.
     Orphaned { dataset: String },
@@ -280,8 +275,7 @@ pub(crate) enum ReadSchemaFault {
     MissingReference { dataset: String, promoted_at: u64 },
     /// The reference names an id for a dataset the sim never promoted for.
     Fabricated { dataset: String, id: ReadSchemaId },
-    /// The reference names an id the paired bundle cannot resolve. **This is the frozen-bundle
-    /// gap**: the visibility cycle published a fresh pointer against a bundle that never advanced.
+    /// The reference names an id the paired bundle cannot resolve.
     Unresolvable {
         dataset: String,
         id: ReadSchemaId,
@@ -337,23 +331,12 @@ impl std::fmt::Display for ReadSchemaFault {
     }
 }
 
-/// Every read schema the portal names must resolve in the bundle it was handed with.
-///
-/// Subject is the assignment a portal holds; reference is the bundle captured at that publication
-/// plus the sim's promote log. The two come from different cycles and the log never touches storage,
-/// so unlike [`schema_bundle_consistency`] — which draws both sides from the chunk pins — this can
-/// actually fail.
-///
-/// Returns every fault, not the first: the caller partitions fatal from gap-excused, and an early
-/// return would let an excused fault mask a real one.
-///
-/// Resolution is by id. Read ids are per `(dataset, content)`, so against a small canned pool a
-/// content check alone would be satisfied by any dataset's entry; content is checked separately, to
-/// catch an id resolving to the wrong schema.
-///
-/// No age stand-down: a captured pair is self-consistent at any age, and copying
-/// `portal_consistency`'s `age >= M_TICKS` gate would silence the target case, since a shortage
-/// streak advances the clock by `M_TICKS` per drain.
+/// Every read schema the portal names must resolve in the bundle it was handed with. Subject is
+/// what the portal holds; references (the captured bundle, the sim's promote log) come from other
+/// sources, so unlike [`schema_bundle_consistency`] this can actually fail. Resolution is by id —
+/// against the small canned pool a content match would be satisfied by any dataset's entry — then
+/// content, to catch an id resolving to the wrong schema. Returns every fault, so one cannot mask
+/// another. No age stand-down: a captured pair is self-consistent at any age.
 pub(super) fn portal_read_schemas_resolve(
     portal: &PortalAssignment,
     bundle: &SchemaBundle,
@@ -378,7 +361,6 @@ pub(super) fn portal_read_schemas_resolve(
     for (dataset, reference) in &portal.read_schemas {
         let logged = promoted.get(dataset.as_str());
         match (reference, logged) {
-            // Never promoted — the seeded state of every dataset.
             (None, None) => {}
             (None, Some((_, promoted_at))) => faults.push(ReadSchemaFault::MissingReference {
                 dataset: dataset.to_string(),

--- a/src/multistep_scheduler/sim/sut/placement_oracles.rs
+++ b/src/multistep_scheduler/sim/sut/placement_oracles.rs
@@ -229,24 +229,14 @@ pub(super) fn schema_bundle_consistency(
     Ok(())
 }
 
-/// Every dataset the worker assignment names must have its promoted READ schema carried in the
-/// bundle frozen with that assignment — otherwise a portal validating a query against that dataset
-/// has nothing to resolve.
+/// Every dataset the worker assignment names must have its promoted read schema in the bundle
+/// frozen with it. Subject is the bundle; reference is `promoted`, the sim's own promote log —
+/// neither derived from the other, so this can't pass by one storage query agreeing with itself.
 ///
-/// The reference is `promoted`, the sim's own log of what it handed to `promote_read_schema`, and
-/// the subject is the published bundle. Neither is derived from the other through storage, so this
-/// cannot pass by both sides reading the same query — the failure mode of a containment check
-/// written against a storage-derived expectation.
-///
-/// Scoped to datasets the assignment actually names: a promote for a dataset with no placed chunk
-/// is correctly absent (nothing routes to it, so nothing needs to describe it).
-///
-/// A promote propagates on the next successful scheduling cycle, never instantly, so each entry
-/// carries the bundle generation current when it was issued and is only enforced once
-/// `bundle_generation` has moved past it. That is not a loophole for the frozen-shortage case — it
-/// encodes it: while placement is in shortage no bundle is frozen, the generation never advances,
-/// and a promote genuinely cannot reach a portal. If bundle generation is ever decoupled from
-/// placement, this check tightens on its own with no edit.
+/// A promote reaches the bundle on the next successful cycle, not instantly, so an entry is only
+/// enforced once `bundle_generation` passes the generation it was issued at. That encodes the
+/// shortage case rather than excusing it: a frozen bundle never advances the generation, and a
+/// promote genuinely cannot reach a portal. Decoupling the two tightens this with no edit.
 pub(super) fn bundle_covers_promoted_read_schemas(
     bundle: &SchemaBundle,
     worker_assignment: Option<&WorkerAssignment>,
@@ -256,15 +246,11 @@ pub(super) fn bundle_covers_promoted_read_schemas(
     let Some(assignment) = worker_assignment else {
         return Ok(());
     };
-    // Compared by content, not by id: `DatasetSchema` is not `Ord`, and content is also the only
-    // thing the sim knows independently of storage — an id would have to be read back from the
-    // backend that assigned it. The read section holds one schema per in-play dataset, so the
-    // linear scan is trivial.
+    // By content, not id: content is the only thing the sim knows without reading storage back.
     for chunk in assignment.chunks.values() {
         let Some((expected, promoted_at)) = promoted.get(chunk.dataset.as_str()) else {
             continue;
         };
-        // Not yet due: no bundle has been frozen since this promote.
         if bundle_generation <= *promoted_at {
             continue;
         }
@@ -283,14 +269,10 @@ pub(super) fn bundle_covers_promoted_read_schemas(
     Ok(())
 }
 
-/// Why a portal's read-schema reference is incoherent with the bundle it was published with. A
-/// typed verdict rather than a string, so a regression can pin the exact fault without asserting on
-/// message text or on a backend-assigned id.
+/// Typed so a regression can pin the exact fault without matching message text or a backend id.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ReadSchemaFault {
-    /// A dataset the chunk set names has no reference entry at all — a resolution omission. Ids are
-    /// never reused, so a reference that could not be produced must be visible, never answered by
-    /// silence.
+    /// A named dataset has no entry at all — an omission, which must be visible rather than silent.
     Unscoped { dataset: String },
     /// An entry for a dataset no chunk names — the reference failed to retire.
     Orphaned { dataset: String },
@@ -355,26 +337,23 @@ impl std::fmt::Display for ReadSchemaFault {
     }
 }
 
-/// CONSUMER-SIDE read-schema resolvability: every read schema the PORTAL names must resolve in the
-/// bundle the portal was handed alongside it.
+/// Every read schema the portal names must resolve in the bundle it was handed with.
 ///
-/// Subject is the assignment a portal actually holds; the reference is the bundle captured at that
-/// same publication plus the sim's own promote log. The bundle comes from `run_scheduling_cycle`,
-/// the reference map from `run_visibility_cycle`, and the promote log is never read back from a
-/// backend — so unlike [`schema_bundle_consistency`], which draws subject and invariant from the
-/// same chunk pins, this cannot pass by one query agreeing with itself.
+/// Subject is the assignment a portal holds; reference is the bundle captured at that publication
+/// plus the sim's promote log. The two come from different cycles and the log never touches storage,
+/// so unlike [`schema_bundle_consistency`] — which draws both sides from the chunk pins — this can
+/// actually fail.
 ///
-/// Returns **every** fault, never just the first: the caller partitions them into fatal and
-/// gap-excused, and a single early return would let one excused fault mask a real one behind it.
+/// Returns every fault, not the first: the caller partitions fatal from gap-excused, and an early
+/// return would let an excused fault mask a real one.
 ///
-/// Resolution is checked BY ID, not by content: read ids are allocated per `(dataset, content)`, so
-/// with a small canned schema pool a content-only check would be satisfied by any dataset's entry.
-/// Content is then checked separately, to catch a right-shaped id resolving to the wrong schema.
+/// Resolution is by id. Read ids are per `(dataset, content)`, so against a small canned pool a
+/// content check alone would be satisfied by any dataset's entry; content is checked separately, to
+/// catch an id resolving to the wrong schema.
 ///
-/// No age stand-down. Resolvability is not availability (ADR 0002 — a chunk may sit at zero copies
-/// yet stay fully resolvable), and a captured pair is self-consistent at any age; copying
-/// `portal_consistency`'s `age >= M_TICKS` gate would silence the target case outright, since a
-/// shortage streak advances the clock by `M_TICKS` per drain.
+/// No age stand-down: a captured pair is self-consistent at any age, and copying
+/// `portal_consistency`'s `age >= M_TICKS` gate would silence the target case, since a shortage
+/// streak advances the clock by `M_TICKS` per drain.
 pub(super) fn portal_read_schemas_resolve(
     portal: &PortalAssignment,
     bundle: &SchemaBundle,
@@ -399,7 +378,7 @@ pub(super) fn portal_read_schemas_resolve(
     for (dataset, reference) in &portal.read_schemas {
         let logged = promoted.get(dataset.as_str());
         match (reference, logged) {
-            // Never promoted, nothing referenced — the seeded state of every dataset.
+            // Never promoted — the seeded state of every dataset.
             (None, None) => {}
             (None, Some((_, promoted_at))) => faults.push(ReadSchemaFault::MissingReference {
                 dataset: dataset.to_string(),

--- a/src/multistep_scheduler/sim/sut/preconditions.rs
+++ b/src/multistep_scheduler/sim/sut/preconditions.rs
@@ -12,7 +12,8 @@ pub(super) fn standard_preconditions<D: super::SimStorage>(
         Action::AddChunks(_)
         | Action::NoOp
         | Action::WorkerJoined(_)
-        | Action::SetDatasetSchema { .. } => true,
+        | Action::SetDatasetSchema { .. }
+        | Action::PromoteReadSchema { .. } => true,
         Action::AdvanceClock(_) => {
             sut.has_stale_mappings() || sut.has_published_portal_assignment()
         }

--- a/src/multistep_scheduler/sim/sut/trace.rs
+++ b/src/multistep_scheduler/sim/sut/trace.rs
@@ -289,6 +289,7 @@ pub(super) fn action_label(action: &Action) -> String {
                 if *succeeds { "ok" } else { "missed" }
             )
         }
+        Action::PromoteReadSchema { dataset, .. } => format!("PromoteReadSchema({dataset})"),
         Action::PortalFetchAssignment { succeeds } => {
             format!("PortalFetch({})", if *succeeds { "ok" } else { "missed" })
         }

--- a/src/multistep_scheduler/sim/utils.rs
+++ b/src/multistep_scheduler/sim/utils.rs
@@ -507,6 +507,18 @@ pub(super) fn set_dataset_schema(datasets: &[String]) -> BoxedStrategy<Action> {
         .boxed()
 }
 
+/// A `PromoteReadSchema` for a random dataset, drawing from the same canned [`SCHEMA_POOL`].
+/// Like `set_dataset_schema` it needs no precondition — the ingester promotes at arbitrary times,
+/// which is exactly the interleaving under test.
+pub(super) fn promote_read_schema(datasets: &[String]) -> BoxedStrategy<Action> {
+    (
+        prop::sample::select(datasets.to_vec()),
+        prop::sample::select(SCHEMA_POOL.to_vec()),
+    )
+        .prop_map(|(dataset, schema)| Action::PromoteReadSchema { dataset, schema })
+        .boxed()
+}
+
 // ===========================================================================
 // Model chunk ⇄ storage chunk, and the sim's weight strategy.
 //

--- a/src/multistep_scheduler/sim/utils.rs
+++ b/src/multistep_scheduler/sim/utils.rs
@@ -507,9 +507,8 @@ pub(super) fn set_dataset_schema(datasets: &[String]) -> BoxedStrategy<Action> {
         .boxed()
 }
 
-/// A `PromoteReadSchema` for a random dataset, drawing from the same canned [`SCHEMA_POOL`].
-/// Like `set_dataset_schema` it needs no precondition — the ingester promotes at arbitrary times,
-/// which is exactly the interleaving under test.
+/// A `PromoteReadSchema` for a random dataset, from the same canned [`SCHEMA_POOL`]. No
+/// precondition: the ingester promotes at arbitrary times, which is the interleaving under test.
 pub(super) fn promote_read_schema(datasets: &[String]) -> BoxedStrategy<Action> {
     (
         prop::sample::select(datasets.to_vec()),

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -1231,7 +1231,7 @@ impl SchedulerStorage for InMemoryStorage {
         let workers = self.assignment_workers();
 
         // The post-eviction chunk set's datasets, each with its current read pointer. Same rule as
-        // Postgres' `portal_read_schema_refs`.
+        // Postgres' `read_schema_ids_by_dataset`.
         let read_schemas: BTreeMap<crate::types::DatasetId, Option<ReadSchemaId>> = portal_chunks
             .values()
             .map(|chunk| chunk.dataset.clone())

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -235,10 +235,9 @@ pub(crate) struct InMemoryStorage {
     /// `(dataset, canonical json)` → id: re-registering seen content reuses its id (mirrors
     /// `UNIQUE (dataset_id, hash)`)
     schema_ids: HashMap<(Dataset, String), SchemaId>,
-    /// Mirrors `schemas.dataset_id` — the generator derives its read-section scope through it.
+    /// Mirrors `schemas.dataset_id`.
     schema_datasets: HashMap<SchemaId, Dataset>,
-    /// Mirrors `sched_worker_assignment_schemas`: the write ids of the last successful round's
-    /// bundle, replaced atomically with the assignment; a shortage leaves it frozen.
+    /// Mirrors `sched_worker_assignment_schemas`; a shortage leaves it frozen.
     worker_assignment_schemas: BTreeSet<SchemaId>,
     /// Each dataset's latest-registered write schema id, so the sim can stamp inserts with the id a
     /// fresh write would pin. Earlier ids stay in `schemas` (write schemas are immutable).
@@ -816,7 +815,7 @@ impl SchedulerStorage for InMemoryStorage {
     }
 
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError> {
-        // Write section: routable window ∪ persisted set (postgres `generate_bundle` verbatim).
+        // Postgres `generate_bundle` semantics, verbatim.
         let mut ids: BTreeSet<SchemaId> = self.worker_assignment_schemas.clone();
         let mut datasets: BTreeSet<Dataset> = BTreeSet::new();
         for chunk in self.routable_window_chunks() {
@@ -1128,8 +1127,7 @@ impl SchedulerStorage for InMemoryStorage {
             }
         }
 
-        // Persist the round's bundle write ids (window ∪ this assignment), atomically with the
-        // assignment; a shortage returned earlier, leaving the previous set frozen.
+        // Persist the round's bundle write ids; a shortage returned earlier, freezing the set.
         let mut schema_ids: BTreeSet<SchemaId> =
             assignment.chunks.values().map(|c| c.schema_id).collect();
         schema_ids.extend(self.routable_window_chunks().map(|c| c.schema_id));

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -235,6 +235,11 @@ pub(crate) struct InMemoryStorage {
     /// `(dataset, canonical json)` → id: re-registering seen content reuses its id (mirrors
     /// `UNIQUE (dataset_id, hash)`)
     schema_ids: HashMap<(Dataset, String), SchemaId>,
+    /// Mirrors `schemas.dataset_id` — the generator derives its read-section scope through it.
+    schema_datasets: HashMap<SchemaId, Dataset>,
+    /// Mirrors `sched_worker_assignment_schemas`: the write ids of the last successful round's
+    /// bundle, replaced atomically with the assignment; a shortage leaves it frozen.
+    worker_assignment_schemas: BTreeSet<SchemaId>,
     /// Each dataset's latest-registered write schema id, so the sim can stamp inserts with the id a
     /// fresh write would pin. Earlier ids stay in `schemas` (write schemas are immutable).
     current_schema: HashMap<Dataset, SchemaId>,
@@ -695,6 +700,7 @@ impl InMemoryStorage {
             Entry::Vacant(vac) => {
                 let id = SchemaId(self.counters.schema_id.next() as i32);
                 self.schemas.insert(id, schema);
+                self.schema_datasets.insert(id, dataset.to_owned());
                 *vac.insert(id)
             }
         };
@@ -812,11 +818,11 @@ impl SchedulerStorage for InMemoryStorage {
         })
     }
 
-    fn active_schema_bundle(&self) -> Result<BTreeMap<SchemaId, DatasetSchema>, StorageError> {
-        // Every worker-servable chunk's schema: entered a worker assignment, not yet tombstoned —
-        // the postgres predicate verbatim. Deriving from `current_placement` instead would drop a
-        // chunk reshuffled out of the ideal but still served through its drain window.
-        let mut ids: BTreeSet<SchemaId> = BTreeSet::new();
+    fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError> {
+        // Write section: routable window ∪ the persisted set of the last successful assignment —
+        // the postgres `generate_bundle` semantics verbatim. A persisted id missing from `schemas`
+        // is an error, never a silent shrink.
+        let mut ids: BTreeSet<SchemaId> = self.worker_assignment_schemas.clone();
         for (pk, meta) in &self.sched_chunk_metadata {
             if meta.entered_worker_assignment()
                 && !meta.tombstoned()
@@ -825,19 +831,26 @@ impl SchedulerStorage for InMemoryStorage {
                 ids.insert(chunk.schema_id);
             }
         }
-        Ok(ids
-            .into_iter()
-            .filter_map(|id| self.schemas.get(&id).map(|s| (id, s.clone())))
-            .collect())
-    }
-
-    fn active_read_schemas(&self) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>, StorageError> {
-        Ok(self
-            .datasets_in_routable_window()
+        let mut schemas: BTreeMap<SchemaId, DatasetSchema> = BTreeMap::new();
+        let mut datasets: BTreeSet<Dataset> = self.datasets_in_routable_window();
+        for id in ids {
+            let schema = self.schemas.get(&id).ok_or_else(|| {
+                StorageError::Database(anyhow::anyhow!(
+                    "generate_schema_bundle: schemas map is missing referenced id {id}"
+                ))
+            })?;
+            schemas.insert(id, schema.clone());
+            if let Some(dataset) = self.schema_datasets.get(&id) {
+                datasets.insert(dataset.clone());
+            }
+        }
+        // Read section: the CURRENT pointer of every referenced dataset — promotes always land.
+        let read_schemas: BTreeMap<ReadSchemaId, DatasetSchema> = datasets
             .into_iter()
             .filter_map(|dataset| self.current_read_schema.get(&dataset).copied())
             .filter_map(|id| self.read_schemas.get(&id).map(|s| (id, s.clone())))
-            .collect())
+            .collect();
+        Ok(SchemaBundle::from_sections(schemas, read_schemas))
     }
 
     fn promote_read_schema(
@@ -997,7 +1010,7 @@ impl SchedulerStorage for InMemoryStorage {
         config: &Algo::Config,
         now: Tick,
         m_ticks: u64,
-    ) -> Result<(WorkerAssignment, SchemaBundle), StorageError>
+    ) -> Result<WorkerAssignment, StorageError>
     where
         Algo: SchedulingAlgorithm + Send + Sync,
     {
@@ -1123,23 +1136,20 @@ impl SchedulerStorage for InMemoryStorage {
             }
         }
 
-        // Bundle covers every chunk in its routable window — entered a worker assignment, not yet
-        // tombstoned — not just this cycle's placement (ADR 0002): the portal can still route a
-        // chunk the latest assignment dropped (promoted off an earlier confirmed entry, draining
-        // for M ticks), so keying on current placement would yank a schema still being read.
-        let mut schema_ids: BTreeSet<SchemaId> = assignment.schema_ids();
+        // Persist the round's bundle write ids — routable window ∪ this assignment — atomically
+        // with the assignment (mirrors `sched_worker_assignment_schemas`; a shortage returned
+        // earlier, leaving the previous set frozen).
+        let mut schema_ids: BTreeSet<SchemaId> =
+            assignment.chunks.values().map(|c| c.schema_id).collect();
         schema_ids.extend(
             self.sched_chunk_metadata
                 .iter()
                 .filter(|(_, meta)| meta.entered_worker_assignment() && !meta.tombstoned())
                 .filter_map(|(pk, _)| self.chunks.get(pk).map(|c| c.schema_id)),
         );
-        let schemas: BTreeMap<SchemaId, DatasetSchema> = schema_ids
-            .into_iter()
-            .filter_map(|id| self.schemas.get(&id).map(|schema| (id, schema.clone())))
-            .collect();
-        let bundle = SchemaBundle::from_sections(schemas, self.active_read_schemas()?);
-        Ok((assignment, bundle))
+        self.worker_assignment_schemas = schema_ids;
+
+        Ok(assignment)
     }
 
     /// Record that workers have confirmed up to this assignment: advances the

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -5,7 +5,7 @@
 use crate::scheduler_storage::algorithm::{CurrentPlacement, ScheduleOutput, SchedulingAlgorithm};
 use crate::scheduler_storage::{
     AlgoChunk, AssignmentId, AssignmentWorker, ChunkPk, NewChunk, NewDataset, PortalAssignment,
-    SchedulerStorage, SchemaBundle, SchemaId, StorageError, Tick, WorkerAssignment,
+    ReadSchemaId, SchedulerStorage, SchemaBundle, SchemaId, StorageError, Tick, WorkerAssignment,
     WorkerAssignmentChunk, WorkerPk,
 };
 use crate::types::{BlockNumber, DatasetSchema, Worker, WorkerStatus};
@@ -224,6 +224,7 @@ struct Counters {
     worker_assignment_id: Counter,
     portal_assignment_id: Counter,
     schema_id: Counter,
+    read_schema_id: Counter,
 }
 
 #[derive(Default)]
@@ -237,6 +238,16 @@ pub(crate) struct InMemoryStorage {
     /// Each dataset's latest-registered write schema id, so the sim can stamp inserts with the id a
     /// fresh write would pin. Earlier ids stay in `schemas` (write schemas are immutable).
     current_schema: HashMap<Dataset, SchemaId>,
+    /// Read-schema payloads by id (mirrors `read_schemas`). Never pruned — the pg table has no
+    /// delete path today, and ids are never reused, so a superseded id keeps resolving.
+    read_schemas: HashMap<ReadSchemaId, DatasetSchema>,
+    /// `(dataset, canonical json)` → id, mirroring `UNIQUE (dataset_id, hash)`: re-promoting
+    /// previously superseded content revives that same id, exactly as
+    /// `ON CONFLICT ... DO UPDATE SET superseded_at = NULL` does.
+    read_schema_ids: HashMap<(Dataset, String), ReadSchemaId>,
+    /// The dataset's current read schema — the `superseded_at IS NULL` row. Supersession is just
+    /// this pointer moving, so no per-row stamp is needed.
+    current_read_schema: HashMap<Dataset, ReadSchemaId>,
     chunks: BTreeMap<ChunkPk, WorkerAssignmentChunk>,
     /// Natural identity → surrogate pk; a duplicate `(dataset, id)` insert is rejected
     /// (mirrors Postgres `UNIQUE (dataset_id, chunk_id)`). Never pruned — chunks
@@ -665,6 +676,18 @@ impl InMemoryStorage {
             .collect();
     }
 
+    /// Datasets with a chunk in the routable window (entered a worker assignment, not yet
+    /// tombstoned) — the scoping `active_schema_bundle` applies to write schemas, so the read
+    /// section shrinks on the same clock.
+    fn datasets_in_routable_window(&self) -> BTreeSet<Dataset> {
+        self.sched_chunk_metadata
+            .iter()
+            .filter(|(_, meta)| meta.entered_worker_assignment() && !meta.tombstoned())
+            .filter_map(|(pk, _)| self.chunks.get(pk))
+            .map(|chunk| (*chunk.dataset).clone())
+            .collect()
+    }
+
     /// Register `dataset`'s write schema and return its id, reusing the id of previously seen
     /// identical content — mirrors Postgres' `insert_write_schema`. Records it as the dataset's
     /// latest write schema (the id a fresh write pins).
@@ -810,6 +833,38 @@ impl SchedulerStorage for InMemoryStorage {
             .into_iter()
             .filter_map(|id| self.schemas.get(&id).map(|s| (id, s.clone())))
             .collect())
+    }
+
+    fn active_read_schemas(&self) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>, StorageError> {
+        Ok(self
+            .datasets_in_routable_window()
+            .into_iter()
+            .filter_map(|dataset| self.current_read_schema.get(&dataset).copied())
+            .filter_map(|id| self.read_schemas.get(&id).map(|s| (id, s.clone())))
+            .collect())
+    }
+
+    fn promote_read_schema(
+        &mut self,
+        dataset: &str,
+        schema: DatasetSchema,
+    ) -> Result<ReadSchemaId, StorageError> {
+        if !self.datasets.contains(dataset) {
+            return Err(anyhow::anyhow!("promote_read_schema: dataset {dataset} not found").into());
+        }
+        schema.validate().context("invalid dataset schema")?;
+        use std::collections::hash_map::Entry;
+        let canon = serde_json::to_string(&schema.canonicalized()).expect("schema serializes");
+        let id = match self.read_schema_ids.entry((dataset.to_owned(), canon)) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let id = ReadSchemaId(self.counters.read_schema_id.next() as i32);
+                self.read_schemas.insert(id, schema);
+                *e.insert(id)
+            }
+        };
+        self.current_read_schema.insert(dataset.to_owned(), id);
+        Ok(id)
     }
 
     fn insert_new_chunks(&mut self, chunks: Vec<NewChunk>) -> Result<(), StorageError> {
@@ -1087,7 +1142,7 @@ impl SchedulerStorage for InMemoryStorage {
             .into_iter()
             .filter_map(|id| self.schemas.get(&id).map(|schema| (id, schema.clone())))
             .collect();
-        let bundle = SchemaBundle::from_schemas(schemas);
+        let bundle = SchemaBundle::from_sections(schemas, self.active_read_schemas()?);
         Ok((assignment, bundle))
     }
 

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -815,7 +815,7 @@ impl SchedulerStorage for InMemoryStorage {
     }
 
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError> {
-        // Postgres `generate_bundle` semantics, verbatim: the persisted set covers the window.
+        // Contract on the trait; parity twin of postgres' `generate_bundle`.
         let mut schemas: BTreeMap<SchemaId, DatasetSchema> = BTreeMap::new();
         let mut datasets: BTreeSet<Dataset> = BTreeSet::new();
         for id in self.worker_assignment_schemas.iter().copied() {

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -238,15 +238,12 @@ pub(crate) struct InMemoryStorage {
     /// Each dataset's latest-registered write schema id, so the sim can stamp inserts with the id a
     /// fresh write would pin. Earlier ids stay in `schemas` (write schemas are immutable).
     current_schema: HashMap<Dataset, SchemaId>,
-    /// Read-schema payloads by id (mirrors `read_schemas`). Never pruned — the pg table has no
-    /// delete path today, and ids are never reused, so a superseded id keeps resolving.
+    /// Mirrors `read_schemas`. Never pruned, so a superseded id keeps resolving.
     read_schemas: HashMap<ReadSchemaId, DatasetSchema>,
     /// `(dataset, canonical json)` → id, mirroring `UNIQUE (dataset_id, hash)`: re-promoting
-    /// previously superseded content revives that same id, exactly as
-    /// `ON CONFLICT ... DO UPDATE SET superseded_at = NULL` does.
+    /// superseded content revives its id, as `ON CONFLICT ... SET superseded_at = NULL` does.
     read_schema_ids: HashMap<(Dataset, String), ReadSchemaId>,
-    /// The dataset's current read schema — the `superseded_at IS NULL` row. Supersession is just
-    /// this pointer moving, so no per-row stamp is needed.
+    /// The `superseded_at IS NULL` row. Supersession is this pointer moving, so no per-row stamp.
     current_read_schema: HashMap<Dataset, ReadSchemaId>,
     chunks: BTreeMap<ChunkPk, WorkerAssignmentChunk>,
     /// Natural identity → surrogate pk; a duplicate `(dataset, id)` insert is rejected
@@ -676,9 +673,8 @@ impl InMemoryStorage {
             .collect();
     }
 
-    /// Datasets with a chunk in the routable window (entered a worker assignment, not yet
-    /// tombstoned) — the scoping `active_schema_bundle` applies to write schemas, so the read
-    /// section shrinks on the same clock.
+    /// Datasets with a chunk in the routable window — the scoping `active_schema_bundle` applies to
+    /// write schemas, so the read section shrinks on the same clock.
     fn datasets_in_routable_window(&self) -> BTreeSet<Dataset> {
         self.sched_chunk_metadata
             .iter()
@@ -1234,9 +1230,8 @@ impl SchedulerStorage for InMemoryStorage {
 
         let workers = self.assignment_workers();
 
-        // Exactly the datasets the (post-eviction) chunk set names, each mapped to its current
-        // read pointer — `None` where none was ever promoted, which is the seeded state. Same rule
-        // as the Postgres `portal_read_schema_refs`, derived from the same post-eviction set.
+        // The post-eviction chunk set's datasets, each with its current read pointer. Same rule as
+        // Postgres' `portal_read_schema_refs`.
         let read_schemas: BTreeMap<crate::types::DatasetId, Option<ReadSchemaId>> = portal_chunks
             .values()
             .map(|chunk| chunk.dataset.clone())

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -815,15 +815,10 @@ impl SchedulerStorage for InMemoryStorage {
     }
 
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError> {
-        // Postgres `generate_bundle` semantics, verbatim.
-        let mut ids: BTreeSet<SchemaId> = self.worker_assignment_schemas.clone();
-        let mut datasets: BTreeSet<Dataset> = BTreeSet::new();
-        for chunk in self.routable_window_chunks() {
-            ids.insert(chunk.schema_id);
-            datasets.insert((*chunk.dataset).clone());
-        }
+        // Postgres `generate_bundle` semantics, verbatim: the persisted set covers the window.
         let mut schemas: BTreeMap<SchemaId, DatasetSchema> = BTreeMap::new();
-        for id in ids {
+        let mut datasets: BTreeSet<Dataset> = BTreeSet::new();
+        for id in self.worker_assignment_schemas.iter().copied() {
             // A referenced id missing from `schemas` is an error, never a silent shrink.
             let schema = self.schemas.get(&id).ok_or_else(|| {
                 StorageError::Database(anyhow::anyhow!(

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -678,15 +678,12 @@ impl InMemoryStorage {
             .collect();
     }
 
-    /// Datasets with a chunk in the routable window — the scoping `active_schema_bundle` applies to
-    /// write schemas, so the read section shrinks on the same clock.
-    fn datasets_in_routable_window(&self) -> BTreeSet<Dataset> {
+    /// Chunks in the routable window: entered a worker assignment, not yet tombstoned (ADR 0002).
+    fn routable_window_chunks(&self) -> impl Iterator<Item = &WorkerAssignmentChunk> {
         self.sched_chunk_metadata
             .iter()
             .filter(|(_, meta)| meta.entered_worker_assignment() && !meta.tombstoned())
             .filter_map(|(pk, _)| self.chunks.get(pk))
-            .map(|chunk| (*chunk.dataset).clone())
-            .collect()
     }
 
     /// Register `dataset`'s write schema and return its id, reusing the id of previously seen
@@ -819,21 +816,16 @@ impl SchedulerStorage for InMemoryStorage {
     }
 
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError> {
-        // Write section: routable window ∪ the persisted set of the last successful assignment —
-        // the postgres `generate_bundle` semantics verbatim. A persisted id missing from `schemas`
-        // is an error, never a silent shrink.
+        // Write section: routable window ∪ persisted set (postgres `generate_bundle` verbatim).
         let mut ids: BTreeSet<SchemaId> = self.worker_assignment_schemas.clone();
-        for (pk, meta) in &self.sched_chunk_metadata {
-            if meta.entered_worker_assignment()
-                && !meta.tombstoned()
-                && let Some(chunk) = self.chunks.get(pk)
-            {
-                ids.insert(chunk.schema_id);
-            }
+        let mut datasets: BTreeSet<Dataset> = BTreeSet::new();
+        for chunk in self.routable_window_chunks() {
+            ids.insert(chunk.schema_id);
+            datasets.insert((*chunk.dataset).clone());
         }
         let mut schemas: BTreeMap<SchemaId, DatasetSchema> = BTreeMap::new();
-        let mut datasets: BTreeSet<Dataset> = self.datasets_in_routable_window();
         for id in ids {
+            // A referenced id missing from `schemas` is an error, never a silent shrink.
             let schema = self.schemas.get(&id).ok_or_else(|| {
                 StorageError::Database(anyhow::anyhow!(
                     "generate_schema_bundle: schemas map is missing referenced id {id}"
@@ -844,7 +836,7 @@ impl SchedulerStorage for InMemoryStorage {
                 datasets.insert(dataset.clone());
             }
         }
-        // Read section: the CURRENT pointer of every referenced dataset — promotes always land.
+        // Read section: the CURRENT pointer of every referenced dataset.
         let read_schemas: BTreeMap<ReadSchemaId, DatasetSchema> = datasets
             .into_iter()
             .filter_map(|dataset| self.current_read_schema.get(&dataset).copied())
@@ -1136,17 +1128,11 @@ impl SchedulerStorage for InMemoryStorage {
             }
         }
 
-        // Persist the round's bundle write ids — routable window ∪ this assignment — atomically
-        // with the assignment (mirrors `sched_worker_assignment_schemas`; a shortage returned
-        // earlier, leaving the previous set frozen).
+        // Persist the round's bundle write ids (window ∪ this assignment), atomically with the
+        // assignment; a shortage returned earlier, leaving the previous set frozen.
         let mut schema_ids: BTreeSet<SchemaId> =
             assignment.chunks.values().map(|c| c.schema_id).collect();
-        schema_ids.extend(
-            self.sched_chunk_metadata
-                .iter()
-                .filter(|(_, meta)| meta.entered_worker_assignment() && !meta.tombstoned())
-                .filter_map(|(pk, _)| self.chunks.get(pk).map(|c| c.schema_id)),
-        );
+        schema_ids.extend(self.routable_window_chunks().map(|c| c.schema_id));
         self.worker_assignment_schemas = schema_ids;
 
         Ok(assignment)

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -1234,11 +1234,26 @@ impl SchedulerStorage for InMemoryStorage {
 
         let workers = self.assignment_workers();
 
+        // Exactly the datasets the (post-eviction) chunk set names, each mapped to its current
+        // read pointer — `None` where none was ever promoted, which is the seeded state. Same rule
+        // as the Postgres `portal_read_schema_refs`, derived from the same post-eviction set.
+        let read_schemas: BTreeMap<crate::types::DatasetId, Option<ReadSchemaId>> = portal_chunks
+            .values()
+            .map(|chunk| chunk.dataset.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(|dataset| {
+                let current = self.current_read_schema.get(dataset.as_str()).copied();
+                (dataset, current)
+            })
+            .collect();
+
         Ok(PortalAssignment {
             id: portal_assignment_id as AssignmentId,
             chunk_workers,
             chunks: portal_chunks,
             workers,
+            read_schemas,
         })
     }
 

--- a/src/scheduler_storage/in_memory/tests/correction_tests/machinery.rs
+++ b/src/scheduler_storage/in_memory/tests/correction_tests/machinery.rs
@@ -34,7 +34,6 @@ fn run_cycle_multi(
     storage
         .run_scheduling_cycle(&algorithm, &(), at, GRACE_PERIOD)
         .expect("scheduling succeeds")
-        .0
 }
 
 // ---------------------------------------------------------------------------

--- a/src/scheduler_storage/in_memory/tests/correction_tests/multistep.rs
+++ b/src/scheduler_storage/in_memory/tests/correction_tests/multistep.rs
@@ -97,7 +97,6 @@ fn run_real_cycle<S: SchedulerStorage>(storage: &mut S, at: TimeUnit) -> WorkerA
             GRACE_PERIOD,
         )
         .expect("scheduling succeeds")
-        .0
 }
 
 // ---------------------------------------------------------------------------

--- a/src/scheduler_storage/in_memory/tests/mod.rs
+++ b/src/scheduler_storage/in_memory/tests/mod.rs
@@ -603,7 +603,7 @@ fn run_scheduling_cycle_applies_mapping_from_algorithm() {
     ];
     let algorithm = StaticSchedulingAlgorithm { mapping };
 
-    let (assignment, _) = storage
+    let assignment = storage
         .run_scheduling_cycle(&algorithm, &(), 100, 60)
         .expect("scheduling succeeds");
 
@@ -650,7 +650,7 @@ fn worker_assignment_diffs_recorded_after_cycle_then_cleared_on_confirm() {
     let mapping: IdealMapping = vec![(pk_1, vec![worker_id])];
     let algorithm = StaticSchedulingAlgorithm { mapping };
 
-    let (assignment, _) = storage
+    let assignment = storage
         .run_scheduling_cycle(&algorithm, &(), 100, 60)
         .expect("scheduling succeeds");
 

--- a/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
+++ b/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
@@ -535,7 +535,7 @@ fn schema_bundle_retains_removing_chunk_until_tombstone() {
 }
 
 /// ADR 0002: a portal-visible chunk that loses its last holder (departure) keeps its schema in the
-/// frozen bundle, even though it falls out of ideal ∪ stale — so portals can still resolve it.
+/// bundle, even though it falls out of ideal ∪ stale — so portals can still resolve it.
 #[test]
 fn schema_bundle_covers_holderless_portal_visible_chunk() {
     let Setup {
@@ -571,7 +571,7 @@ fn schema_bundle_covers_holderless_portal_visible_chunk() {
         .unwrap();
 
     // Next cycle places nothing (no active workers) -> chunk is holderless (ideal={}, stale={}),
-    // still portal_visible. The frozen bundle must still carry its schema.
+    // still portal_visible. The bundle must still carry its schema.
     let wa2 = storage
         .run_scheduling_cycle(
             &StaticSchedulingAlgorithm {

--- a/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
+++ b/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
@@ -37,7 +37,7 @@ fn chunk_migration_through_grace_period() {
     let cycle_1 = StaticSchedulingAlgorithm {
         mapping: ideal_mapping([(chunk_pk, vec![w1])]),
     };
-    let (worker_assignment_1, _) = storage
+    let worker_assignment_1 = storage
         .run_scheduling_cycle(&cycle_1, &(), cycle_1_at, GRACE_PERIOD)
         .expect("scheduling succeeds");
 
@@ -62,7 +62,7 @@ fn chunk_migration_through_grace_period() {
     let cycle_2 = StaticSchedulingAlgorithm {
         mapping: ideal_mapping([(chunk_pk, vec![w2])]),
     };
-    let (worker_assignment_2, _) = storage
+    let worker_assignment_2 = storage
         .run_scheduling_cycle(&cycle_2, &(), cycle_2_at, GRACE_PERIOD)
         .expect("scheduling succeeds");
     assert_eq!(
@@ -93,7 +93,7 @@ fn chunk_migration_through_grace_period() {
     let cycle_3 = StaticSchedulingAlgorithm {
         mapping: ideal_mapping([(chunk_pk, vec![w2])]),
     };
-    let (worker_assignment_3, _) = storage
+    let worker_assignment_3 = storage
         .run_scheduling_cycle(&cycle_3, &(), cycle_3_at, GRACE_PERIOD)
         .expect("scheduling succeeds");
     assert_eq!(
@@ -124,7 +124,7 @@ fn chunk_migration_through_grace_period() {
     let cycle_4 = StaticSchedulingAlgorithm {
         mapping: ideal_mapping([(chunk_pk, vec![w2])]),
     };
-    let (worker_assignment_4, _) = storage
+    let worker_assignment_4 = storage
         .run_scheduling_cycle(&cycle_4, &(), cycle_4_at, GRACE_PERIOD)
         .expect("scheduling succeeds");
     assert_eq!(
@@ -333,7 +333,6 @@ fn run_cycle(
     storage
         .run_scheduling_cycle(&algorithm, &(), at, GRACE_PERIOD)
         .expect("scheduling succeeds")
-        .0
 }
 
 fn ideal_mapping<'a>(
@@ -346,7 +345,7 @@ fn ideal_mapping<'a>(
 /// chunk's schema is included, an unplaced chunk's is not, and the id is content-addressed over it.
 #[test]
 fn schema_bundle_holds_only_in_play_schemas() {
-    use crate::scheduler_storage::{BundleId, SchemaBundle};
+    use crate::scheduler_storage::BundleId;
     use crate::types::{DatasetSchema, TableSchema};
 
     let one_table =
@@ -379,7 +378,7 @@ fn schema_bundle_holds_only_in_play_schemas() {
     let wa = run_cycle(&mut storage, &a_pk, vec![w1], CYCLE_INTERVAL);
     let a_schema = wa.chunks.get(&a_pk).unwrap().schema_id;
 
-    let bundle = SchemaBundle::generate(&storage).unwrap();
+    let bundle = storage.generate_schema_bundle().unwrap();
     assert_eq!(bundle.schemas(), &BTreeMap::from([(a_schema, schema_a)]));
     // No read schema promoted, so the read section is empty.
     assert_eq!(bundle.id(), BundleId::from_sections([a_schema], []));
@@ -392,7 +391,7 @@ fn schema_bundle_holds_only_in_play_schemas() {
         .run_visibility_cycle(CYCLE_INTERVAL + DELTA)
         .unwrap();
     assert!(portal.chunk_workers.contains_key(&a_pk));
-    assert_eq!(SchemaBundle::generate(&storage).unwrap().id(), bundle.id());
+    assert_eq!(storage.generate_schema_bundle().unwrap().id(), bundle.id());
 }
 
 /// In-memory twin of Postgres' `schema_bundle_carries_the_current_read_schema`, plus two things it
@@ -413,7 +412,7 @@ fn bundle_read_section_tracks_the_current_read_schema() {
     let w1 = workers(&storage)[0].worker_id;
     run_cycle(&mut storage, &a_pk, vec![w1], CYCLE_INTERVAL);
 
-    let before = SchemaBundle::generate(&storage).unwrap();
+    let before = storage.generate_schema_bundle().unwrap();
     assert!(before.read_schemas().is_empty(), "nothing promoted yet");
 
     // "b" has no placed chunk, so its read schema must not enter the bundle.
@@ -423,7 +422,7 @@ fn bundle_read_section_tracks_the_current_read_schema() {
     let r1 = storage
         .promote_read_schema(&dataset("a"), schema_with_tables(&["blocks"]))
         .unwrap();
-    let one = SchemaBundle::generate(&storage).unwrap();
+    let one = storage.generate_schema_bundle().unwrap();
     assert_eq!(
         one.read_schemas().keys().copied().collect::<Vec<_>>(),
         vec![r1],
@@ -441,7 +440,7 @@ fn bundle_read_section_tracks_the_current_read_schema() {
         .promote_read_schema(&dataset("a"), schema_with_tables(&["blocks", "logs"]))
         .unwrap();
     assert_ne!(r1, r2);
-    let two = SchemaBundle::generate(&storage).unwrap();
+    let two = storage.generate_schema_bundle().unwrap();
     assert_eq!(
         two.read_schemas().keys().copied().collect::<Vec<_>>(),
         vec![r2],
@@ -455,7 +454,7 @@ fn bundle_read_section_tracks_the_current_read_schema() {
         "re-promoting superseded content revives its original id, never mints a new one",
     );
     assert_eq!(
-        SchemaBundle::generate(&storage).unwrap().id(),
+        storage.generate_schema_bundle().unwrap().id(),
         one.id(),
         "so the fingerprint returns to exactly what it was under that schema",
     );
@@ -466,8 +465,6 @@ fn bundle_read_section_tracks_the_current_read_schema() {
 /// leaves when it tombstones. This is what lets `schema_bundle_consistency` drop its exclusion.
 #[test]
 fn schema_bundle_retains_removing_chunk_until_tombstone() {
-    use crate::scheduler_storage::SchemaBundle;
-
     let Setup {
         mut storage,
         worker_ids,
@@ -477,7 +474,7 @@ fn schema_bundle_retains_removing_chunk_until_tombstone() {
     let w1 = worker_ids[0];
 
     // Place, confirm, promote to the portal.
-    let (wa, _) = storage
+    let wa = storage
         .run_scheduling_cycle(
             &StaticSchedulingAlgorithm {
                 mapping: ideal_mapping([(chunk_pk, vec![w1])]),
@@ -495,7 +492,8 @@ fn schema_bundle_retains_removing_chunk_until_tombstone() {
         .run_visibility_cycle(CYCLE_INTERVAL + DELTA)
         .unwrap();
     assert!(
-        SchemaBundle::generate(&storage)
+        storage
+            .generate_schema_bundle()
             .unwrap()
             .contains(schema_id),
         "placed and promoted: schema is in the bundle",
@@ -510,7 +508,8 @@ fn schema_bundle_retains_removing_chunk_until_tombstone() {
         "removing: dropped from the portal",
     );
     assert!(
-        SchemaBundle::generate(&storage)
+        storage
+            .generate_schema_bundle()
             .unwrap()
             .contains(schema_id),
         "removing but pre-tombstone: worker still serves it, so its schema stays in the bundle",
@@ -518,7 +517,7 @@ fn schema_bundle_retains_removing_chunk_until_tombstone() {
 
     // Past M ticks after the portal drop, a scheduling cycle tombstones it — the schema retires,
     // and the bundle returned from that cycle no longer carries it.
-    let (_wa2, bundle) = storage
+    storage
         .run_scheduling_cycle(
             &StaticSchedulingAlgorithm {
                 mapping: ideal_mapping([]),
@@ -528,6 +527,7 @@ fn schema_bundle_retains_removing_chunk_until_tombstone() {
             GRACE_PERIOD,
         )
         .expect("scheduling succeeds");
+    let bundle = storage.generate_schema_bundle().unwrap();
     assert!(
         !bundle.contains(schema_id),
         "tombstoned: schema leaves the bundle",
@@ -547,7 +547,7 @@ fn schema_bundle_covers_holderless_portal_visible_chunk() {
     let w1 = worker_ids[0];
 
     // Place, confirm, promote to the portal -> portal_visible, one holder (w1).
-    let (wa, _) = storage
+    let wa = storage
         .run_scheduling_cycle(
             &StaticSchedulingAlgorithm {
                 mapping: ideal_mapping([(chunk_pk, vec![w1])]),
@@ -572,7 +572,7 @@ fn schema_bundle_covers_holderless_portal_visible_chunk() {
 
     // Next cycle places nothing (no active workers) -> chunk is holderless (ideal={}, stale={}),
     // still portal_visible. The frozen bundle must still carry its schema.
-    let (wa2, bundle) = storage
+    let wa2 = storage
         .run_scheduling_cycle(
             &StaticSchedulingAlgorithm {
                 mapping: ideal_mapping([]),
@@ -582,6 +582,7 @@ fn schema_bundle_covers_holderless_portal_visible_chunk() {
             GRACE_PERIOD,
         )
         .expect("scheduling succeeds");
+    let bundle = storage.generate_schema_bundle().unwrap();
     assert!(
         !wa2.chunks.contains_key(chunk_pk),
         "chunk is holderless: out of ideal ∪ stale",

--- a/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
+++ b/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
@@ -395,10 +395,9 @@ fn schema_bundle_holds_only_in_play_schemas() {
     assert_eq!(SchemaBundle::generate(&storage).unwrap().id(), bundle.id());
 }
 
-/// In-memory twin of the Postgres `schema_bundle_carries_the_current_read_schema`: the read
-/// section tracks the current read schema and moves the fingerprint, a re-promote of previously
-/// superseded content revives its original id (mirroring `ON CONFLICT ... SET superseded_at =
-/// NULL`), and a dataset with no chunk in the routable window contributes nothing.
+/// In-memory twin of Postgres' `schema_bundle_carries_the_current_read_schema`, plus two things it
+/// can't reach: a re-promote of superseded content revives its original id, and a dataset outside
+/// the routable window contributes nothing.
 #[test]
 fn bundle_read_section_tracks_the_current_read_schema() {
     let mut storage = InMemoryStorage::default();

--- a/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
+++ b/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
@@ -2,6 +2,7 @@
 //! span scheduling cycles and visibility cycles together.
 
 use super::*;
+use crate::scheduler_storage::test_harness::utils::schema_with_tables;
 use maplit::{btreemap, hashset};
 use std::collections::{BTreeMap, HashSet};
 
@@ -380,7 +381,8 @@ fn schema_bundle_holds_only_in_play_schemas() {
 
     let bundle = SchemaBundle::generate(&storage).unwrap();
     assert_eq!(bundle.schemas(), &BTreeMap::from([(a_schema, schema_a)]));
-    assert_eq!(bundle.id(), BundleId::from_schema_ids([a_schema]));
+    // No read schema promoted, so the read section is empty.
+    assert_eq!(bundle.id(), BundleId::from_sections([a_schema], []));
 
     // Promote "a" to the portal — still in play, so the bundle is unchanged.
     storage
@@ -391,6 +393,73 @@ fn schema_bundle_holds_only_in_play_schemas() {
         .unwrap();
     assert!(portal.chunk_workers.contains_key(&a_pk));
     assert_eq!(SchemaBundle::generate(&storage).unwrap().id(), bundle.id());
+}
+
+/// In-memory twin of the Postgres `schema_bundle_carries_the_current_read_schema`: the read
+/// section tracks the current read schema and moves the fingerprint, a re-promote of previously
+/// superseded content revives its original id (mirroring `ON CONFLICT ... SET superseded_at =
+/// NULL`), and a dataset with no chunk in the routable window contributes nothing.
+#[test]
+fn bundle_read_section_tracks_the_current_read_schema() {
+    let mut storage = InMemoryStorage::default();
+    storage
+        .insert_new_datasets(vec![dataset("a"), dataset("b")])
+        .unwrap();
+    let a = chunk("a", 1, 100);
+    storage.insert_new_chunks(vec![a.clone()]).unwrap();
+    let a_pk = storage.pk_of(&a);
+    storage
+        .update_worker_set(&[worker(1, None)], 0, 1000)
+        .unwrap();
+    let w1 = workers(&storage)[0].worker_id;
+    run_cycle(&mut storage, &a_pk, vec![w1], CYCLE_INTERVAL);
+
+    let before = SchemaBundle::generate(&storage).unwrap();
+    assert!(before.read_schemas().is_empty(), "nothing promoted yet");
+
+    // "b" has no placed chunk, so its read schema must not enter the bundle.
+    let r_b = storage
+        .promote_read_schema(&dataset("b"), schema_with_tables(&["only_b"]))
+        .unwrap();
+    let r1 = storage
+        .promote_read_schema(&dataset("a"), schema_with_tables(&["blocks"]))
+        .unwrap();
+    let one = SchemaBundle::generate(&storage).unwrap();
+    assert_eq!(
+        one.read_schemas().keys().copied().collect::<Vec<_>>(),
+        vec![r1],
+        "only datasets in the routable window contribute; {r_b} is unplaced",
+    );
+    assert_ne!(one.id(), before.id(), "a promote moves the fingerprint");
+    assert_eq!(
+        one.schemas(),
+        before.schemas(),
+        "and leaves the write section alone",
+    );
+
+    // Supersede it, then re-promote the original content: the first id comes back.
+    let r2 = storage
+        .promote_read_schema(&dataset("a"), schema_with_tables(&["blocks", "logs"]))
+        .unwrap();
+    assert_ne!(r1, r2);
+    let two = SchemaBundle::generate(&storage).unwrap();
+    assert_eq!(
+        two.read_schemas().keys().copied().collect::<Vec<_>>(),
+        vec![r2],
+        "one current read schema per dataset — the superseded one leaves the bundle",
+    );
+    assert_eq!(
+        storage
+            .promote_read_schema(&dataset("a"), schema_with_tables(&["blocks"]))
+            .unwrap(),
+        r1,
+        "re-promoting superseded content revives its original id, never mints a new one",
+    );
+    assert_eq!(
+        SchemaBundle::generate(&storage).unwrap().id(),
+        one.id(),
+        "so the fingerprint returns to exactly what it was under that schema",
+    );
 }
 
 /// Retirement rides the chunk tombstone clock: a chunk dropped from the portal stays

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -180,13 +180,11 @@ pub trait SchedulerStorage {
     where
         Algo: crate::scheduler_storage::algorithm::SchedulingAlgorithm + Send + Sync;
 
-    /// Build the schema bundle from committed rows alone — callable at any time, identical under
-    /// success, shortage, and after a restart (no driver state involved).
-    ///
-    /// Write section: the routable window (ADR 0002) ∪ the persisted schema set of the last
-    /// successful assignment, so nothing the frozen published assignment names ever drops out
-    /// mid-shortage. Read section: the CURRENT read schema of every dataset either side
-    /// references — a promote reaches the very next bundle, which is the point.
+    /// Build the schema bundle from committed rows alone — identical under success, shortage, and
+    /// after a restart. Write section: routable window (ADR 0002) ∪ the persisted set of the last
+    /// successful assignment, so nothing the frozen published assignment names drops out
+    /// mid-shortage. Read section: the CURRENT read schema of every referenced dataset, so a
+    /// promote reaches the very next bundle.
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError>;
 
     /// Advance the confirmation watermark and replay pending routing diffs

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -117,12 +117,6 @@ pub struct WorkerAssignment {
     pub replication_by_weight: BTreeMap<u16, u16>,
 }
 
-impl WorkerAssignment {
-    pub(crate) fn schema_ids(&self) -> BTreeSet<SchemaId> {
-        self.chunks.values().map(|chunk| chunk.schema_id).collect()
-    }
-}
-
 /// The published portal assignment: confirmed routing for portal-visible chunks.
 #[derive(Debug, Clone)]
 pub struct PortalAssignment {
@@ -172,18 +166,28 @@ pub trait SchedulerStorage {
     /// Run one full scheduling cycle: tombstone expired chunks, expire stale
     /// mappings, run `algorithm` in-process, diff + commit results.
     ///
-    /// Returns the published `WorkerAssignment` (ideal ∪ stale) with the [`SchemaBundle`] frozen
-    /// with it — the write schemas its chunks reference, plus the current read schemas of the
-    /// datasets in play — so the two stay paired. On `Shortage` neither advances.
+    /// Returns the published `WorkerAssignment` (ideal ∪ stale). The bundle no longer travels with
+    /// it — call [`Self::generate_schema_bundle`] after every cycle, success or `Shortage`. On
+    /// success the cycle also persists the round's write-schema ids, atomically with the
+    /// assignment, which is what keeps a shortage-round bundle covering the frozen assignment.
     fn run_scheduling_cycle<Algo>(
         &mut self,
         algorithm: &Algo,
         config: &Algo::Config,
         now: Tick,
         m_ticks: u64,
-    ) -> Result<(WorkerAssignment, SchemaBundle), StorageError>
+    ) -> Result<WorkerAssignment, StorageError>
     where
         Algo: crate::scheduler_storage::algorithm::SchedulingAlgorithm + Send + Sync;
+
+    /// Build the schema bundle from committed rows alone — callable at any time, identical under
+    /// success, shortage, and after a restart (no driver state involved).
+    ///
+    /// Write section: the routable window (ADR 0002) ∪ the persisted schema set of the last
+    /// successful assignment, so nothing the frozen published assignment names ever drops out
+    /// mid-shortage. Read section: the CURRENT read schema of every dataset either side
+    /// references — a promote reaches the very next bundle, which is the point.
+    fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError>;
 
     /// Advance the confirmation watermark and replay pending routing diffs
     fn confirm_worker_assignment(
@@ -223,15 +227,6 @@ pub trait SchedulerStorage {
         &self,
         schema_ids: Option<&[SchemaId]>,
     ) -> Result<BTreeMap<SchemaId, DatasetSchema>, StorageError>;
-
-    /// Schemas of every chunk currently in play — held by workers or served by the portal (see
-    /// [`SchemaBundle`]). One round-trip; independent of the published `WorkerAssignment`/
-    /// `PortalAssignment`, which can lag or fail on their own.
-    fn active_schema_bundle(&self) -> Result<BTreeMap<SchemaId, DatasetSchema>, StorageError>;
-
-    /// Every in-play dataset's current read schema, over the same routable window
-    /// `active_schema_bundle` uses, so both sections retire on one clock.
-    fn active_read_schemas(&self) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>, StorageError>;
 
     /// Make `schema` the dataset's current read schema, returning its content-deduped id.
     ///

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -176,8 +176,9 @@ pub trait SchedulerStorage {
         Algo: crate::scheduler_storage::algorithm::SchedulingAlgorithm + Send + Sync;
 
     /// The schema bundle, from committed rows alone — identical under success, shortage, and after
-    /// a restart. Write section: routable window (ADR 0002) ∪ the persisted set. Read section: the
-    /// CURRENT read schema of every referenced dataset, so a promote reaches the very next bundle.
+    /// a restart. Write section: the persisted set of the last successful cycle (≡ the routable
+    /// window at that commit, which only shrinks until the next success). Read section: the CURRENT
+    /// read schema of every referenced dataset, so a promote reaches the very next bundle.
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError>;
 
     /// Advance the confirmation watermark and replay pending routing diffs

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -124,15 +124,10 @@ pub struct PortalAssignment {
     pub chunk_workers: BTreeMap<ChunkPk, Vec<WorkerPk>>,
     pub chunks: BTreeMap<ChunkPk, WorkerAssignmentChunk>,
     pub workers: BTreeMap<WorkerPk, AssignmentWorker>,
-    /// The read-schema id a portal validates each dataset's queries under; resolved against the
-    /// [`SchemaBundle`] published with the assignment.
-    ///
-    /// **Total over the datasets `chunks` names, and no wider** — so it retires with the last
-    /// visible chunk. Keying it off the `datasets` registry would grow forever, since nothing
-    /// deletes a dataset row.
-    ///
-    /// `None` = never promoted, the seeded state of every dataset the scheduler creates. Distinct
-    /// from a missing key, which would be a resolution failure rather than an answer.
+    /// The read-schema id a portal validates each dataset's queries under, resolved against the
+    /// published [`SchemaBundle`]. Total over the datasets `chunks` names and no wider, so it
+    /// retires with the last visible chunk. `None` = never promoted — distinct from a missing key,
+    /// which would be a resolution failure rather than an answer.
     pub read_schemas: BTreeMap<DatasetId, Option<ReadSchemaId>>,
 }
 
@@ -166,10 +161,10 @@ pub trait SchedulerStorage {
     /// Run one full scheduling cycle: tombstone expired chunks, expire stale
     /// mappings, run `algorithm` in-process, diff + commit results.
     ///
-    /// Returns the published `WorkerAssignment` (ideal ∪ stale). The bundle no longer travels with
-    /// it — call [`Self::generate_schema_bundle`] after every cycle, success or `Shortage`. On
-    /// success the cycle also persists the round's write-schema ids, atomically with the
-    /// assignment, which is what keeps a shortage-round bundle covering the frozen assignment.
+    /// Returns the published `WorkerAssignment` (ideal ∪ stale); call
+    /// [`Self::generate_schema_bundle`] after every cycle, success or `Shortage`. Success also
+    /// persists the round's write-schema ids atomically with the assignment — what keeps a
+    /// shortage-round bundle covering the frozen assignment.
     fn run_scheduling_cycle<Algo>(
         &mut self,
         algorithm: &Algo,
@@ -180,11 +175,9 @@ pub trait SchedulerStorage {
     where
         Algo: crate::scheduler_storage::algorithm::SchedulingAlgorithm + Send + Sync;
 
-    /// Build the schema bundle from committed rows alone — identical under success, shortage, and
-    /// after a restart. Write section: routable window (ADR 0002) ∪ the persisted set of the last
-    /// successful assignment, so nothing the frozen published assignment names drops out
-    /// mid-shortage. Read section: the CURRENT read schema of every referenced dataset, so a
-    /// promote reaches the very next bundle.
+    /// The schema bundle, from committed rows alone — identical under success, shortage, and after
+    /// a restart. Write section: routable window (ADR 0002) ∪ the persisted set. Read section: the
+    /// CURRENT read schema of every referenced dataset, so a promote reaches the very next bundle.
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError>;
 
     /// Advance the confirmation watermark and replay pending routing diffs
@@ -226,10 +219,8 @@ pub trait SchedulerStorage {
         schema_ids: Option<&[SchemaId]>,
     ) -> Result<BTreeMap<SchemaId, DatasetSchema>, StorageError>;
 
-    /// Make `schema` the dataset's current read schema, returning its content-deduped id.
-    ///
-    /// For tests and the simulation only. In production the read registry has one writer, the
-    /// metadata service; the read path's concurrency argument rests on there being no second.
+    /// Make `schema` the dataset's current read schema, returning its content-deduped id. Tests and
+    /// the simulation only — in production the metadata service is the registry's ONE writer.
     fn promote_read_schema(
         &mut self,
         dataset: &str,

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -175,10 +175,11 @@ pub trait SchedulerStorage {
     where
         Algo: crate::scheduler_storage::algorithm::SchedulingAlgorithm + Send + Sync;
 
-    /// The schema bundle, from committed rows alone — identical under success, shortage, and after
-    /// a restart. Write section: the persisted set of the last successful cycle (≡ the routable
-    /// window at that commit, which only shrinks until the next success). Read section: the CURRENT
-    /// read schema of every referenced dataset, so a promote reaches the very next bundle.
+    /// The schema bundle — a function of committed rows only, so the last cycle's outcome and
+    /// process restarts don't change it. Write section: the persisted set of the last successful
+    /// cycle, frozen until the next success; the live window only shrinks in between, so the set
+    /// always covers it. Read section: the CURRENT read pointer of each dataset that write section
+    /// references — read live, never persisted, so a promote reaches the very next bundle.
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError>;
 
     /// Advance the confirmation watermark and replay pending routing diffs

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -179,7 +179,8 @@ pub trait SchedulerStorage {
     /// process restarts don't change it. Write section: the persisted set of the last successful
     /// cycle, frozen until the next success; the live window only shrinks in between, so the set
     /// always covers it. Read section: the CURRENT read pointer of each dataset that write section
-    /// references — read live, never persisted, so a promote reaches the very next bundle.
+    /// references — read live, never persisted, so a promote reaches the very next bundle. A
+    /// referenced id whose schema row is missing is an error, never a silent shrink.
     fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError>;
 
     /// Advance the confirmation watermark and replay pending routing diffs

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -130,25 +130,20 @@ pub struct PortalAssignment {
     pub chunk_workers: BTreeMap<ChunkPk, Vec<WorkerPk>>,
     pub chunks: BTreeMap<ChunkPk, WorkerAssignmentChunk>,
     pub workers: BTreeMap<WorkerPk, AssignmentWorker>,
-    /// Per-dataset READ-schema reference: the id a portal validates this dataset's queries under.
-    /// Ids only — the payload travels in the [`SchemaBundle`], and a portal resolves it with
-    /// `bundle.get_read(id)`.
+    /// The read-schema id a portal validates each dataset's queries under; resolved against the
+    /// [`SchemaBundle`] published with the assignment.
     ///
-    /// **Total over the datasets `chunks` names, and no wider.** A dataset enters with its first
-    /// portal-visible chunk and leaves with its last, so this retires on the same clock as the
-    /// chunk set; keying it off the `datasets` registry instead would grow forever, since nothing
+    /// **Total over the datasets `chunks` names, and no wider** — so it retires with the last
+    /// visible chunk. Keying it off the `datasets` registry would grow forever, since nothing
     /// deletes a dataset row.
     ///
-    /// `None` = never promoted. That is the seeded state of every dataset the scheduler creates
-    /// (`insert_new_datasets` writes no read pointer), so it is an honest published state — and
-    /// deliberately distinct from a *missing key*, which would be a resolution failure rather than
-    /// an answer.
+    /// `None` = never promoted, the seeded state of every dataset the scheduler creates. Distinct
+    /// from a missing key, which would be a resolution failure rather than an answer.
     pub read_schemas: BTreeMap<DatasetId, Option<ReadSchemaId>>,
 }
 
 impl PortalAssignment {
-    /// The datasets this assignment names, derived from its chunk set — the exact scope
-    /// `read_schemas` is total over.
+    /// The scope `read_schemas` is total over.
     pub(crate) fn named_datasets(&self) -> BTreeSet<DatasetId> {
         self.chunks
             .values()
@@ -234,17 +229,14 @@ pub trait SchedulerStorage {
     /// `PortalAssignment`, which can lag or fail on their own.
     fn active_schema_bundle(&self) -> Result<BTreeMap<SchemaId, DatasetSchema>, StorageError>;
 
-    /// The current READ schema of every dataset in play, over the same routable window
-    /// `active_schema_bundle` uses — so the read section retires on the same clock as the write
-    /// one, and a decommissioned dataset stops being carried once its chunks are tombstoned.
+    /// Every in-play dataset's current read schema, over the same routable window
+    /// `active_schema_bundle` uses, so both sections retire on one clock.
     fn active_read_schemas(&self) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>, StorageError>;
 
-    /// Make `schema` the dataset's current read schema, returning its (content-deduped) id.
+    /// Make `schema` the dataset's current read schema, returning its content-deduped id.
     ///
-    /// In production the read registry has exactly ONE writer — the metadata service's admin
-    /// endpoint — and the scheduler only ever reads it; this exists so tests and the simulation
-    /// can drive promotion against either backend. Do not call it from the scheduler's own loops:
-    /// a second writer is what the read path's concurrency argument rests on not existing.
+    /// For tests and the simulation only. In production the read registry has one writer, the
+    /// metadata service; the read path's concurrency argument rests on there being no second.
     fn promote_read_schema(
         &mut self,
         dataset: &str,

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -215,15 +215,18 @@ pub trait SchedulerStorage {
         schema: DatasetSchema,
     ) -> Result<(), StorageError>;
 
-    /// Decode schemas for assignment construction: all of them, or those in `schema_ids`.
-    /// Missing ids are omitted.
+    /// Test-only passthrough to the metadata crate's loader; missing ids are omitted (the
+    /// characterization the schema tests pin).
+    #[cfg(test)]
     fn load_schemas(
         &self,
         schema_ids: Option<&[SchemaId]>,
     ) -> Result<BTreeMap<SchemaId, DatasetSchema>, StorageError>;
 
-    /// Make `schema` the dataset's current read schema, returning its content-deduped id. Tests and
-    /// the simulation only — in production the metadata service is the registry's ONE writer.
+    /// Make `schema` the dataset's current read schema, returning its content-deduped id. Test-only
+    /// by construction: in production the metadata service is the read registry's ONE writer, and
+    /// the read path's concurrency argument rests on that.
+    #[cfg(test)]
     fn promote_read_schema(
         &mut self,
         dataset: &str,

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -9,7 +9,7 @@ use crate::weight::SchedulingChunk;
 /// The id newtypes, ingest input types, and the error enum now live in `scheduler-metadata`; the
 /// scheduler keeps its historical `scheduler_storage::{…}` surface via this re-export.
 pub use scheduler_metadata::{
-    ChunkPk, DatasetPk, NewChunk, NewDataset, SchemaId, StorageError, WorkerPk,
+    ChunkPk, DatasetPk, NewChunk, NewDataset, ReadSchemaId, SchemaId, StorageError, WorkerPk,
 };
 
 /// Lower a discovered [`Chunk`](crate::types::Chunk) to a [`NewChunk`] pinned to `schema_id`.
@@ -153,8 +153,8 @@ pub trait SchedulerStorage {
     /// mappings, run `algorithm` in-process, diff + commit results.
     ///
     /// Returns the published `WorkerAssignment` (ideal ∪ stale) with the [`SchemaBundle`] frozen
-    /// with it — the schemas its chunks reference — so the two stay paired. On `Shortage` neither
-    /// advances.
+    /// with it — the write schemas its chunks reference, plus the current read schemas of the
+    /// datasets in play — so the two stay paired. On `Shortage` neither advances.
     fn run_scheduling_cycle<Algo>(
         &mut self,
         algorithm: &Algo,
@@ -181,9 +181,10 @@ pub trait SchedulerStorage {
     fn mark_for_removal(&mut self, chunk_pk: ChunkPk, now: Tick) -> Result<(), StorageError>;
 
     // Seeding/ingestion entry points (production ingestion and the offline tools). Each dataset
-    // carries its identity and storage location plus an initial WRITE schema (the read schema is a
-    // PG/ingest-only concern — see PgIngest); `NewDataset::new` derives the name from the location
-    // (scheme stripped), or `with_name` sets an explicit one.
+    // carries its identity and storage location plus an initial WRITE schema — deliberately no read
+    // pointer, so the read registry keeps exactly one writer (see `promote_read_schema`).
+    // `NewDataset::new` derives the name from the location (scheme stripped), or `with_name` sets
+    // an explicit one.
     fn insert_new_datasets(&mut self, datasets: Vec<NewDataset>) -> Result<(), StorageError>;
     fn insert_new_chunks(&mut self, chunks: Vec<NewChunk>) -> Result<(), StorageError>;
 
@@ -207,6 +208,23 @@ pub trait SchedulerStorage {
     /// [`SchemaBundle`]). One round-trip; independent of the published `WorkerAssignment`/
     /// `PortalAssignment`, which can lag or fail on their own.
     fn active_schema_bundle(&self) -> Result<BTreeMap<SchemaId, DatasetSchema>, StorageError>;
+
+    /// The current READ schema of every dataset in play, over the same routable window
+    /// `active_schema_bundle` uses — so the read section retires on the same clock as the write
+    /// one, and a decommissioned dataset stops being carried once its chunks are tombstoned.
+    fn active_read_schemas(&self) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>, StorageError>;
+
+    /// Make `schema` the dataset's current read schema, returning its (content-deduped) id.
+    ///
+    /// In production the read registry has exactly ONE writer — the metadata service's admin
+    /// endpoint — and the scheduler only ever reads it; this exists so tests and the simulation
+    /// can drive promotion against either backend. Do not call it from the scheduler's own loops:
+    /// a second writer is what the read path's concurrency argument rests on not existing.
+    fn promote_read_schema(
+        &mut self,
+        dataset: &str,
+        schema: DatasetSchema,
+    ) -> Result<ReadSchemaId, StorageError>;
 
     /// Register a new chunk replacement for an old chunk. New chunk must have the same block range
     /// as the old chunk. A production path now — reorgs drive it.

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -130,6 +130,31 @@ pub struct PortalAssignment {
     pub chunk_workers: BTreeMap<ChunkPk, Vec<WorkerPk>>,
     pub chunks: BTreeMap<ChunkPk, WorkerAssignmentChunk>,
     pub workers: BTreeMap<WorkerPk, AssignmentWorker>,
+    /// Per-dataset READ-schema reference: the id a portal validates this dataset's queries under.
+    /// Ids only — the payload travels in the [`SchemaBundle`], and a portal resolves it with
+    /// `bundle.get_read(id)`.
+    ///
+    /// **Total over the datasets `chunks` names, and no wider.** A dataset enters with its first
+    /// portal-visible chunk and leaves with its last, so this retires on the same clock as the
+    /// chunk set; keying it off the `datasets` registry instead would grow forever, since nothing
+    /// deletes a dataset row.
+    ///
+    /// `None` = never promoted. That is the seeded state of every dataset the scheduler creates
+    /// (`insert_new_datasets` writes no read pointer), so it is an honest published state — and
+    /// deliberately distinct from a *missing key*, which would be a resolution failure rather than
+    /// an answer.
+    pub read_schemas: BTreeMap<DatasetId, Option<ReadSchemaId>>,
+}
+
+impl PortalAssignment {
+    /// The datasets this assignment names, derived from its chunk set — the exact scope
+    /// `read_schemas` is total over.
+    pub(crate) fn named_datasets(&self) -> BTreeSet<DatasetId> {
+        self.chunks
+            .values()
+            .map(|chunk| chunk.dataset.clone())
+            .collect()
+    }
 }
 
 /// Storage backend for the MVCC scheduler lifecycle.

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -279,6 +279,43 @@ impl SchedulerStorage for PostgresStorage {
         })
     }
 
+    fn active_read_schemas(
+        &self,
+    ) -> Result<BTreeMap<crate::scheduler_storage::ReadSchemaId, DatasetSchema>, StorageError> {
+        self.with_conn_ref(async move |conn| {
+            schema::active_read_schemas(conn)
+                .await
+                .map_err(StorageError::from)
+        })
+    }
+
+    fn promote_read_schema(
+        &mut self,
+        dataset: &str,
+        schema: DatasetSchema,
+    ) -> Result<crate::scheduler_storage::ReadSchemaId, StorageError> {
+        let dataset = dataset.to_owned();
+        self.with_conn(async move |conn| {
+            let mut tx = conn.begin().await.context("promote_read_schema: begin")?;
+            let dataset_id: crate::scheduler_storage::DatasetPk =
+                sqlx::query_scalar("SELECT id FROM datasets WHERE name = $1")
+                    .bind(&dataset)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("promote_read_schema: resolve dataset")?
+                    .ok_or_else(|| {
+                        StorageError::Database(anyhow::anyhow!(
+                            "promote_read_schema: dataset {dataset} not found"
+                        ))
+                    })?;
+            let id =
+                scheduler_metadata::pg::schema::promote_read_schema(&mut tx, dataset_id, &schema)
+                    .await?;
+            tx.commit().await.context("promote_read_schema: commit")?;
+            Ok(id)
+        })
+    }
+
     fn insert_new_chunks(&mut self, chunks: Vec<NewChunk>) -> Result<(), StorageError> {
         let batch_size = self.batch_size;
         self.with_conn(async move |conn| {
@@ -451,8 +488,11 @@ impl SchedulerStorage for PostgresStorage {
             let mut schema_ids: BTreeSet<SchemaId> = wa.schema_ids();
             schema_ids.extend(bundle_schema_ids);
             let schema_ids: Vec<SchemaId> = schema_ids.into_iter().collect();
-            let bundle = SchemaBundle::from_schemas(
+            // The read section carries content, not just ids: the portal validates queries against
+            // it, and it moves the BundleId so a caching client notices a promote.
+            let bundle = SchemaBundle::from_sections(
                 scheduler_metadata::pg::schema::load_schemas(conn, Some(&schema_ids)).await?,
+                schema::active_read_schemas(conn).await?,
             );
             Ok::<_, StorageError>((wa, bundle))
         })

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -489,17 +489,14 @@ impl SchedulerStorage for PostgresStorage {
             let mut schema_ids: BTreeSet<SchemaId> = wa.schema_ids();
             schema_ids.extend(bundle_schema_ids);
             let schema_ids: Vec<SchemaId> = schema_ids.into_iter().collect();
-            // Datasets from the same in-transaction scan the write ids came from, so the read
-            // section covers the routable window without a second pass over `chunks` — unioned with
-            // the assignment's own datasets for the same reason `schema_ids` starts from
-            // `wa.schema_ids()`: the scan runs before `apply_deltas_and_swap` stamps
-            // `applied_at_worker_assignment_id`, so a chunk placed for the FIRST time this cycle is
-            // named by the assignment while its row still reads as never-entered.
+            // Datasets from the same scan the write ids came from, unioned with the assignment's own
+            // for the reason `schema_ids` starts at `wa.schema_ids()`: the scan runs before
+            // `apply_deltas_and_swap` stamps `applied_at_worker_assignment_id`, so a chunk placed for
+            // the first time this cycle still reads as never-entered.
             let mut routable: BTreeSet<&str> = bundle_datasets.iter().map(|d| d.as_str()).collect();
             routable.extend(wa.chunks.values().map(|chunk| chunk.dataset.as_str()));
             let routable_datasets: Vec<&str> = routable.into_iter().collect();
-            // The read section carries content, not just ids: the portal validates queries against
-            // it, and it moves the BundleId so a caching client notices a promote.
+
             let bundle = SchemaBundle::from_sections(
                 scheduler_metadata::pg::schema::load_schemas(conn, Some(&schema_ids)).await?,
                 schema::read_schemas_for_datasets(conn, &routable_datasets).await?,
@@ -557,16 +554,15 @@ impl SchedulerStorage for PostgresStorage {
             phase::promote_eligible_chunks(&mut tx, new_pa_id, confirmed_up_to).await?;
             phase::drop_marked_chunks(&mut tx, new_pa_id).await?;
 
-            // The whole artifact is assembled inside the transaction: the chunk set, the eviction
-            // that trims it, its routing, and its read-schema references now share one commit. It
-            // also makes the eviction's un-promotes transactional, closing the window where a crash
-            // between the commit and the eviction left chunks promoted that the assignment dropped.
+            // Assembled inside the transaction so the chunk set, the eviction that trims it, its
+            // routing and its read references share one commit — which also makes the eviction's
+            // un-promotes transactional, closing a crash window that left chunks promoted after the
+            // assignment dropped them.
             let mut chunks = phase::fetch_portal_visible_chunks(&mut tx).await?;
             // Settle overlaps in memory over the visible set we just fetched (see
             // `evict_portal_overlaps`), keeping the assignment disjoint without a per-promotion probe.
             phase::evict_portal_overlaps(&mut tx, &mut chunks).await?;
-            // Resolved from the POST-eviction chunk set, so the reference is exactly scoped to the
-            // datasets this assignment actually names — no prune, no superset to reconcile.
+            // From the post-eviction set, so the reference needs no pruning to match what is named.
             let named: Vec<&str> = chunks
                 .values()
                 .map(|chunk| chunk.dataset.as_str())

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -260,6 +260,7 @@ impl SchedulerStorage for PostgresStorage {
         })
     }
 
+    #[cfg(test)]
     fn load_schemas(
         &self,
         schema_ids: Option<&[crate::scheduler_storage::SchemaId]>,
@@ -277,6 +278,7 @@ impl SchedulerStorage for PostgresStorage {
         })
     }
 
+    #[cfg(test)]
     fn promote_read_schema(
         &mut self,
         dataset: &str,

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -456,11 +456,9 @@ impl SchedulerStorage for PostgresStorage {
             phase::write_future_ideal(&mut tx, &ideal_mappings, batch_size).await?;
             phase::apply_deltas_and_swap(&mut tx, new_wa_id, &evicted).await?;
 
-            // The write-schema ids this round's bundle covers: the routable window from the scan,
-            // plus the new ideal's chunks — the scan ran before this cycle stamped first-placed
-            // chunks, so they must be added from the in-memory mapping (same reason the old
-            // in-cycle bundle unioned `wa.schema_ids()`). Committed atomically with the
-            // assignment; a shortage returns before this point, freezing the previous set.
+            // The round's bundle write ids: the scanned window plus the new ideal's chunks — the
+            // scan ran before this cycle stamped first-placed chunks, so those come from the
+            // in-memory mapping.
             let published_schema_ids: Vec<SchemaId> =
                 {
                     let mut ids = bundle_schema_ids;

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -499,7 +499,7 @@ impl SchedulerStorage for PostgresStorage {
 
             let bundle = SchemaBundle::from_sections(
                 scheduler_metadata::pg::schema::load_schemas(conn, Some(&schema_ids)).await?,
-                schema::read_schemas_for_datasets(conn, &routable_datasets).await?,
+                schema::read_schemas_by_id(conn, &routable_datasets).await?,
             );
             Ok::<_, StorageError>((wa, bundle))
         })
@@ -569,7 +569,7 @@ impl SchedulerStorage for PostgresStorage {
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect();
-            let read_schemas = schema::portal_read_schema_refs(&mut tx, &named).await?;
+            let read_schemas = schema::read_schema_ids_by_dataset(&mut tx, &named).await?;
             let chunk_workers = phase::fetch_confirmed_routing(&mut tx).await?;
             let workers = phase::fetch_portal_workers(&mut tx).await?;
 

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -456,12 +456,12 @@ impl SchedulerStorage for PostgresStorage {
             phase::write_future_ideal(&mut tx, &ideal_mappings, batch_size).await?;
             phase::apply_deltas_and_swap(&mut tx, new_wa_id, &evicted).await?;
 
-            // The round's bundle write ids — what the generator's window query would return right
-            // after this commit. Scanned window plus the new ideal's chunks: the scan ran before
-            // this cycle stamped first-placed chunks, so those come from the in-memory mapping.
-            // Deliberately wider than the new assignment — a chunk the ideal just dropped is still
-            // routable while draining (ADR 0002), so its schema stays until it tombstones and the
-            // next scan sheds it.
+            // The round's bundle write ids — the routable window as of this commit, which is what
+            // the generator publishes until the next success. Scanned window plus the new ideal's
+            // chunks: the scan ran before this cycle stamped first-placed chunks, so those come
+            // from the in-memory mapping. Deliberately wider than the new assignment — a chunk the
+            // ideal just dropped is still routable while draining (ADR 0002), so its schema stays
+            // until it tombstones and the next success's scan sheds it.
             let published_schema_ids: Vec<SchemaId> =
                 {
                     let mut ids = bundle_schema_ids;

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -269,21 +269,9 @@ impl SchedulerStorage for PostgresStorage {
         })
     }
 
-    fn active_schema_bundle(
-        &self,
-    ) -> Result<BTreeMap<crate::scheduler_storage::SchemaId, DatasetSchema>, StorageError> {
+    fn generate_schema_bundle(&self) -> Result<SchemaBundle, StorageError> {
         self.with_conn_ref(async move |conn| {
-            schema::active_schema_bundle(conn)
-                .await
-                .map_err(StorageError::from)
-        })
-    }
-
-    fn active_read_schemas(
-        &self,
-    ) -> Result<BTreeMap<crate::scheduler_storage::ReadSchemaId, DatasetSchema>, StorageError> {
-        self.with_conn_ref(async move |conn| {
-            schema::active_read_schemas(conn)
+            schema::generate_bundle(conn)
                 .await
                 .map_err(StorageError::from)
         })
@@ -391,7 +379,7 @@ impl SchedulerStorage for PostgresStorage {
         config: &A::Config,
         now: Tick,
         m_ticks: u64,
-    ) -> Result<(WorkerAssignment, SchemaBundle), StorageError>
+    ) -> Result<WorkerAssignment, StorageError>
     where
         A: SchedulingAlgorithm + Send + Sync,
     {
@@ -424,7 +412,6 @@ impl SchedulerStorage for PostgresStorage {
                 committed_placement,
                 published: published_chunks,
                 bundle_schema_ids,
-                bundle_datasets,
             } = phase::fetch_active_chunks_with_placement(&mut tx).await?;
 
             // Confirmed routing for the eviction victim-ordering hint (best-effort). Read in the same
@@ -469,6 +456,21 @@ impl SchedulerStorage for PostgresStorage {
             phase::write_future_ideal(&mut tx, &ideal_mappings, batch_size).await?;
             phase::apply_deltas_and_swap(&mut tx, new_wa_id, &evicted).await?;
 
+            // The write-schema ids this round's bundle covers: the routable window from the scan,
+            // plus the new ideal's chunks — the scan ran before this cycle stamped first-placed
+            // chunks, so they must be added from the in-memory mapping (same reason the old
+            // in-cycle bundle unioned `wa.schema_ids()`). Committed atomically with the
+            // assignment; a shortage returns before this point, freezing the previous set.
+            let published_schema_ids: Vec<SchemaId> =
+                {
+                    let mut ids = bundle_schema_ids;
+                    ids.extend(ideal_mappings.iter().filter_map(|(pk, _)| {
+                        published_chunks.get(pk).map(|chunk| chunk.schema_id)
+                    }));
+                    ids.into_iter().collect()
+                };
+            phase::persist_assignment_schemas(&mut tx, &published_schema_ids).await?;
+
             tx.commit().await.context("run_scheduling_cycle: commit")?;
 
             let wa = phase::build_worker_assignment(
@@ -480,10 +482,7 @@ impl SchedulerStorage for PostgresStorage {
                 published_chunks,
             )
             .await?;
-
-            let bundle =
-                schema::build_bundle(conn, &wa, bundle_schema_ids, &bundle_datasets).await?;
-            Ok::<_, StorageError>((wa, bundle))
+            Ok::<_, StorageError>(wa)
         })
     }
 

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -481,26 +481,8 @@ impl SchedulerStorage for PostgresStorage {
             )
             .await?;
 
-            // Bundle covers the assignment's chunks (ideal ∪ stale) plus every chunk in its
-            // routable window — entered a worker assignment, not yet tombstoned — so a chunk the
-            // latest assignment dropped but an earlier confirmed entry still routes to keeps its
-            // schema (ADR 0002). Only the content load hits the DB, and schema content is
-            // immutable per id, so the by-id read is safe under concurrent writers.
-            let mut schema_ids: BTreeSet<SchemaId> = wa.schema_ids();
-            schema_ids.extend(bundle_schema_ids);
-            let schema_ids: Vec<SchemaId> = schema_ids.into_iter().collect();
-            // Datasets from the same scan the write ids came from, unioned with the assignment's own
-            // for the reason `schema_ids` starts at `wa.schema_ids()`: the scan runs before
-            // `apply_deltas_and_swap` stamps `applied_at_worker_assignment_id`, so a chunk placed for
-            // the first time this cycle still reads as never-entered.
-            let mut routable: BTreeSet<&str> = bundle_datasets.iter().map(|d| d.as_str()).collect();
-            routable.extend(wa.chunks.values().map(|chunk| chunk.dataset.as_str()));
-            let routable_datasets: Vec<&str> = routable.into_iter().collect();
-
-            let bundle = SchemaBundle::from_sections(
-                scheduler_metadata::pg::schema::load_schemas(conn, Some(&schema_ids)).await?,
-                schema::read_schemas_by_id(conn, &routable_datasets).await?,
-            );
+            let bundle =
+                schema::build_bundle(conn, &wa, bundle_schema_ids, &bundle_datasets).await?;
             Ok::<_, StorageError>((wa, bundle))
         })
     }

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -424,6 +424,7 @@ impl SchedulerStorage for PostgresStorage {
                 committed_placement,
                 published: published_chunks,
                 bundle_schema_ids,
+                bundle_datasets,
             } = phase::fetch_active_chunks_with_placement(&mut tx).await?;
 
             // Confirmed routing for the eviction victim-ordering hint (best-effort). Read in the same
@@ -488,11 +489,20 @@ impl SchedulerStorage for PostgresStorage {
             let mut schema_ids: BTreeSet<SchemaId> = wa.schema_ids();
             schema_ids.extend(bundle_schema_ids);
             let schema_ids: Vec<SchemaId> = schema_ids.into_iter().collect();
+            // Datasets from the same in-transaction scan the write ids came from, so the read
+            // section covers the routable window without a second pass over `chunks` — unioned with
+            // the assignment's own datasets for the same reason `schema_ids` starts from
+            // `wa.schema_ids()`: the scan runs before `apply_deltas_and_swap` stamps
+            // `applied_at_worker_assignment_id`, so a chunk placed for the FIRST time this cycle is
+            // named by the assignment while its row still reads as never-entered.
+            let mut routable: BTreeSet<&str> = bundle_datasets.iter().map(|d| d.as_str()).collect();
+            routable.extend(wa.chunks.values().map(|chunk| chunk.dataset.as_str()));
+            let routable_datasets: Vec<&str> = routable.into_iter().collect();
             // The read section carries content, not just ids: the portal validates queries against
             // it, and it moves the BundleId so a caching client notices a promote.
             let bundle = SchemaBundle::from_sections(
                 scheduler_metadata::pg::schema::load_schemas(conn, Some(&schema_ids)).await?,
-                schema::active_read_schemas(conn).await?,
+                schema::read_schemas_for_datasets(conn, &routable_datasets).await?,
             );
             Ok::<_, StorageError>((wa, bundle))
         })

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -465,7 +465,10 @@ impl SchedulerStorage for PostgresStorage {
                     ids.extend(ideal_mappings.iter().filter_map(|(pk, _)| {
                         published_chunks.get(pk).map(|chunk| chunk.schema_id)
                     }));
-                    ids.into_iter().collect()
+                    let mut ids: Vec<SchemaId> = ids.into_iter().collect();
+                    // Sorted for a deterministic bind and sequential inserts into the PK index.
+                    ids.sort_unstable();
+                    ids
                 };
             phase::persist_assignment_schemas(&mut tx, &published_schema_ids).await?;
 

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -547,22 +547,34 @@ impl SchedulerStorage for PostgresStorage {
             phase::promote_eligible_chunks(&mut tx, new_pa_id, confirmed_up_to).await?;
             phase::drop_marked_chunks(&mut tx, new_pa_id).await?;
 
-            tx.commit().await.context("run_visibility_cycle: commit")?;
-
-            let mut chunks = phase::fetch_portal_visible_chunks(conn).await?;
+            // The whole artifact is assembled inside the transaction: the chunk set, the eviction
+            // that trims it, its routing, and its read-schema references now share one commit. It
+            // also makes the eviction's un-promotes transactional, closing the window where a crash
+            // between the commit and the eviction left chunks promoted that the assignment dropped.
+            let mut chunks = phase::fetch_portal_visible_chunks(&mut tx).await?;
             // Settle overlaps in memory over the visible set we just fetched (see
             // `evict_portal_overlaps`), keeping the assignment disjoint without a per-promotion probe.
-            // The eviction's un-promotes are written back before the routing fetch, so its
-            // server-side visibility predicate sees the same set as `chunks`.
-            phase::evict_portal_overlaps(conn, &mut chunks).await?;
-            let chunk_workers = phase::fetch_confirmed_routing(conn).await?;
-            let workers = phase::fetch_portal_workers(conn).await?;
+            phase::evict_portal_overlaps(&mut tx, &mut chunks).await?;
+            // Resolved from the POST-eviction chunk set, so the reference is exactly scoped to the
+            // datasets this assignment actually names — no prune, no superset to reconcile.
+            let named: Vec<&str> = chunks
+                .values()
+                .map(|chunk| chunk.dataset.as_str())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            let read_schemas = schema::portal_read_schema_refs(&mut tx, &named).await?;
+            let chunk_workers = phase::fetch_confirmed_routing(&mut tx).await?;
+            let workers = phase::fetch_portal_workers(&mut tx).await?;
+
+            tx.commit().await.context("run_visibility_cycle: commit")?;
 
             Ok::<_, StorageError>(phase::assemble_portal_assignment(
                 new_pa_id,
                 chunks,
                 chunk_workers,
                 workers,
+                read_schemas,
             ))
         })
     }

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -456,9 +456,12 @@ impl SchedulerStorage for PostgresStorage {
             phase::write_future_ideal(&mut tx, &ideal_mappings, batch_size).await?;
             phase::apply_deltas_and_swap(&mut tx, new_wa_id, &evicted).await?;
 
-            // The round's bundle write ids: the scanned window plus the new ideal's chunks — the
-            // scan ran before this cycle stamped first-placed chunks, so those come from the
-            // in-memory mapping.
+            // The round's bundle write ids — what the generator's window query would return right
+            // after this commit. Scanned window plus the new ideal's chunks: the scan ran before
+            // this cycle stamped first-placed chunks, so those come from the in-memory mapping.
+            // Deliberately wider than the new assignment — a chunk the ideal just dropped is still
+            // routable while draining (ADR 0002), so its schema stays until it tombstones and the
+            // next scan sheds it.
             let published_schema_ids: Vec<SchemaId> =
                 {
                     let mut ids = bundle_schema_ids;

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -146,9 +146,8 @@ pub(super) struct ActiveChunks {
     pub(super) published: FxHashMap<ChunkPk, WorkerAssignmentChunk>,
     /// schema_ids of every chunk that has entered a worker assignment and is not yet tombstoned (ADR 0002)
     pub(super) bundle_schema_ids: BTreeSet<SchemaId>,
-    /// Datasets of those same chunks — the routable window at dataset granularity. Collected here,
-    /// in the scan the cycle already performs, so the bundle's read section costs a keyed lookup
-    /// instead of a per-dataset existence proof over `chunks`.
+    /// The same chunks' datasets. Collected in this scan so the bundle's read section is a keyed
+    /// lookup rather than a per-dataset existence proof over `chunks`.
     pub(super) bundle_datasets: BTreeSet<crate::types::DatasetId>,
 }
 

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -1,13 +1,13 @@
 //! Phase helpers for [`PostgresStorage::run_scheduling_cycle`], run inside the
 //! cycle's transaction, plus the post-commit [`build_worker_assignment`] read.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use anyhow::{Context, Result};
 use futures::TryStreamExt;
 use itertools::Itertools as _;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use semver::Version;
 use sqlx::postgres::PgConnection;
 use sqlx::{Postgres, Transaction};
@@ -170,7 +170,9 @@ pub(super) struct ActiveChunks {
     pub(super) published: FxHashMap<ChunkPk, WorkerAssignmentChunk>,
     /// schema_ids of every chunk that has entered a worker assignment and is not yet tombstoned
     /// (ADR 0002) — the input, with the new ideal's ids, to the persisted assignment-schema set.
-    pub(super) bundle_schema_ids: BTreeSet<SchemaId>,
+    /// Hashed, not ordered: millions of per-row inserts, a few hundred distinct ids, no reader of
+    /// the order.
+    pub(super) bundle_schema_ids: FxHashSet<SchemaId>,
 }
 
 /// Reads every active chunk — registered, and neither `rejected` nor removed (tombstoned) — spanning
@@ -209,7 +211,7 @@ pub(super) async fn fetch_active_chunks_with_placement(
         current_placement: CurrentPlacement::default(),
         committed_placement: CurrentPlacement::default(),
         published: FxHashMap::default(),
-        bundle_schema_ids: BTreeSet::new(),
+        bundle_schema_ids: FxHashSet::default(),
     };
     let mut count = 0u64;
     while let Some(mut row) = stream

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -61,10 +61,10 @@ pub(super) async fn open_worker_assignment(
     Ok(id)
 }
 
-/// Replace `sched_worker_assignment_schemas` with `schema_ids` — the write-schema ids the round's
-/// bundle covers, computed in Rust from data the cycle already holds (never derived server-side
-/// from the placement tables; that would scan millions of rows for a few hundred ids). Runs in the
-/// cycle's transaction, so a shortage freezes the previous set by never reaching this write.
+/// Replace `sched_worker_assignment_schemas` with `schema_ids`, computed in Rust from data the
+/// cycle already holds — deriving them server-side from the placement tables would scan millions
+/// of rows for a few hundred ids. In the cycle's transaction, so a shortage freezes the previous
+/// set by never reaching this write.
 pub(super) async fn persist_assignment_schemas(
     tx: &mut Transaction<'_, Postgres>,
     schema_ids: &[SchemaId],

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -146,6 +146,10 @@ pub(super) struct ActiveChunks {
     pub(super) published: FxHashMap<ChunkPk, WorkerAssignmentChunk>,
     /// schema_ids of every chunk that has entered a worker assignment and is not yet tombstoned (ADR 0002)
     pub(super) bundle_schema_ids: BTreeSet<SchemaId>,
+    /// Datasets of those same chunks — the routable window at dataset granularity. Collected here,
+    /// in the scan the cycle already performs, so the bundle's read section costs a keyed lookup
+    /// instead of a per-dataset existence proof over `chunks`.
+    pub(super) bundle_datasets: BTreeSet<crate::types::DatasetId>,
 }
 
 /// Reads every active chunk — registered, and neither `rejected` nor removed (tombstoned) — spanning
@@ -185,6 +189,7 @@ pub(super) async fn fetch_active_chunks_with_placement(
         committed_placement: CurrentPlacement::default(),
         published: FxHashMap::default(),
         bundle_schema_ids: BTreeSet::new(),
+        bundle_datasets: BTreeSet::new(),
     };
     let mut count = 0u64;
     while let Some(mut row) = stream
@@ -205,6 +210,7 @@ pub(super) async fn fetch_active_chunks_with_placement(
             .push((pk, AlgoChunk::new(&chunk, row.is_portal_visible)));
         if row.entered_worker_assignment {
             out.bundle_schema_ids.insert(chunk.schema_id);
+            out.bundle_datasets.insert(chunk.dataset.clone());
         }
         out.published.insert(pk, chunk);
         count += 1;

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -61,6 +61,30 @@ pub(super) async fn open_worker_assignment(
     Ok(id)
 }
 
+/// Replace `sched_worker_assignment_schemas` with `schema_ids` — the write-schema ids the round's
+/// bundle covers, computed in Rust from data the cycle already holds (never derived server-side
+/// from the placement tables; that would scan millions of rows for a few hundred ids). Runs in the
+/// cycle's transaction, so a shortage freezes the previous set by never reaching this write.
+pub(super) async fn persist_assignment_schemas(
+    tx: &mut Transaction<'_, Postgres>,
+    schema_ids: &[SchemaId],
+) -> Result<()> {
+    let mut timer = PhaseTimer::new("run_scheduling_cycle:persist_assignment_schemas");
+    sqlx::query("DELETE FROM sched_worker_assignment_schemas")
+        .execute(&mut **tx)
+        .await
+        .context("persist_assignment_schemas: clear")?;
+    sqlx::query(
+        "INSERT INTO sched_worker_assignment_schemas (schema_id) SELECT * FROM UNNEST($1::int[])",
+    )
+    .bind(schema_ids)
+    .execute(&mut **tx)
+    .await
+    .context("persist_assignment_schemas: insert")?;
+    timer.stmt(schema_ids.len() as u64);
+    Ok(())
+}
+
 /// Tombstone chunks whose portal-drop landed at least `m_ticks` ago, stamping the drop tick.
 pub(super) async fn tombstone_expired_chunks(
     tx: &mut Transaction<'_, Postgres>,
@@ -144,11 +168,9 @@ pub(super) struct ActiveChunks {
     /// Full-column decode of the active rows, reused by the post-commit
     /// [`build_worker_assignment`] so it needn't re-read the chunks; shares `for_algo`'s `Arc`s.
     pub(super) published: FxHashMap<ChunkPk, WorkerAssignmentChunk>,
-    /// schema_ids of every chunk that has entered a worker assignment and is not yet tombstoned (ADR 0002)
+    /// schema_ids of every chunk that has entered a worker assignment and is not yet tombstoned
+    /// (ADR 0002) — the input, with the new ideal's ids, to the persisted assignment-schema set.
     pub(super) bundle_schema_ids: BTreeSet<SchemaId>,
-    /// The same chunks' datasets. Collected in this scan so the bundle's read section is a keyed
-    /// lookup rather than a per-dataset existence proof over `chunks`.
-    pub(super) bundle_datasets: BTreeSet<crate::types::DatasetId>,
 }
 
 /// Reads every active chunk — registered, and neither `rejected` nor removed (tombstoned) — spanning
@@ -188,7 +210,6 @@ pub(super) async fn fetch_active_chunks_with_placement(
         committed_placement: CurrentPlacement::default(),
         published: FxHashMap::default(),
         bundle_schema_ids: BTreeSet::new(),
-        bundle_datasets: BTreeSet::new(),
     };
     let mut count = 0u64;
     while let Some(mut row) = stream
@@ -209,7 +230,6 @@ pub(super) async fn fetch_active_chunks_with_placement(
             .push((pk, AlgoChunk::new(&chunk, row.is_portal_visible)));
         if row.entered_worker_assignment {
             out.bundle_schema_ids.insert(chunk.schema_id);
-            out.bundle_datasets.insert(chunk.dataset.clone());
         }
         out.published.insert(pk, chunk);
         count += 1;

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -6,38 +6,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, Result};
 use sqlx::postgres::PgConnection;
 
-use crate::scheduler_storage::{ReadSchemaId, SchemaBundle, SchemaId, WorkerAssignment};
-use crate::types::{DatasetId, DatasetSchema};
+use sqlx::Connection;
 
-/// Schemas of chunks placed on a worker at some point and not yet tombstoned. Portal-served chunks
-/// are already covered: portal promotion requires prior worker placement, and tombstoning requires
-/// a prior portal drop. The outer `EXISTS` is a semi-join: for each schema it walks the
-/// `chunks_schema_id` index and probes `sched_chunk_metadata` by PK, stopping at the first live
-/// chunk. Cheap when a schema has any live chunk; a fully-drained schema costs a full scan of its
-/// chunks to prove the negative.
-///
-/// Approximate on purpose: a chunk that already drained off every worker still counts until
-/// `dropped_from_worker_assignment_at` is stamped, which only ever widens the bundle, never
-/// narrows it.
-pub(super) async fn active_schema_bundle(
-    conn: &mut PgConnection,
-) -> Result<BTreeMap<SchemaId, DatasetSchema>> {
-    let mut timer = crate::metrics::PhaseTimer::new("active_schema_bundle");
-    let rows: Vec<(SchemaId, sqlx::types::Json<DatasetSchema>)> = sqlx::query_as(
-        "SELECT s.id, s.schema FROM schemas s WHERE EXISTS ( \
-             SELECT 1 FROM chunks c \
-             JOIN sched_chunk_metadata m ON m.chunk_pk = c.chunk_pk \
-             WHERE c.schema_id = s.id \
-               AND m.applied_at_worker_assignment_id IS NOT NULL \
-               AND m.dropped_from_worker_assignment_at IS NULL \
-         )",
-    )
-    .fetch_all(conn)
-    .await
-    .context("active_schema_bundle")?;
-    timer.stmt(rows.len() as u64);
-    Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
-}
+use crate::scheduler_storage::{ReadSchemaId, SchemaBundle, SchemaId};
+use crate::types::DatasetSchema;
 
 /// Each named dataset's current read-schema id, for the portal assignment to publish.
 ///
@@ -107,66 +79,65 @@ pub(super) async fn read_schemas_by_id(
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
-/// [`read_schemas_by_id`] over the whole routable window, for callers without one already —
-/// the trait method, used by tests. The cycle uses the keyed form; both must select the same window.
+/// The generator: one bundle from committed rows alone, identical under success, shortage, and on
+/// a fresh process. Write section: the routable window (ADR 0002) ∪ the persisted set of the last
+/// successful assignment — the window alone can shrink below what the frozen published assignment
+/// still names, since Phase A keeps tombstoning during a shortage. Read section: the CURRENT read
+/// schema of every dataset either side references, so a promote always reaches the next bundle.
 ///
-/// Enumerating forward reads better than a per-dataset negative but measured no cheaper (~358 vs
-/// ~350 buffers on 50K tombstoned rows): no index matches the routable predicate, so either shape
-/// seq-scans `sched_chunk_metadata`. Acceptable only because no production path calls this — the
-/// cycle reads 2 buffers. The same missing index is why `fetch_portal_visible_chunks` scans that
-/// table every visibility cycle.
-pub(super) async fn active_read_schemas(
-    conn: &mut PgConnection,
-) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>> {
-    let mut timer = crate::metrics::PhaseTimer::new("active_read_schemas");
-    let rows: Vec<(ReadSchemaId, sqlx::types::Json<DatasetSchema>)> = sqlx::query_as(
-        "SELECT DISTINCT r.id, r.schema \
-         FROM sched_chunk_metadata m \
-         JOIN chunks c ON c.chunk_pk = m.chunk_pk \
-         JOIN read_schemas r ON r.dataset_id = c.dataset_id AND r.superseded_at IS NULL \
-         WHERE m.applied_at_worker_assignment_id IS NOT NULL \
-           AND m.dropped_from_worker_assignment_at IS NULL",
+/// One `REPEATABLE READ, READ ONLY` transaction: both sections and the persisted set are read from
+/// a single snapshot, so a cycle or promote landing concurrently (the WIP service branch runs this
+/// from a different loop than the scheduler's) cannot skew them against each other.
+///
+/// Loads are strict: a window or persisted id whose `schemas` row is missing is an error, not an
+/// omission — under the soft-then-hard-delete policy a silent shrink here would republish a bundle
+/// that quietly dropped a schema consumers still resolve.
+pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBundle> {
+    let _timer = crate::metrics::Timer::new("generate_schema_bundle");
+    let mut tx = conn.begin().await.context("generate_bundle: begin")?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        .execute(&mut *tx)
+        .await
+        .context("generate_bundle: set isolation")?;
+
+    // Window: distinct (schema id, dataset name) over chunks that entered a worker assignment and
+    // are not yet tombstoned.
+    let window: Vec<(SchemaId, String)> = sqlx::query_as(
+        "SELECT DISTINCT c.schema_id, d.name          FROM sched_chunk_metadata m          JOIN chunks c ON c.chunk_pk = m.chunk_pk          JOIN datasets d ON d.id = c.dataset_id          WHERE m.applied_at_worker_assignment_id IS NOT NULL            AND m.dropped_from_worker_assignment_at IS NULL",
     )
-    .fetch_all(conn)
+    .fetch_all(&mut *tx)
     .await
-    .context("active_read_schemas")?;
-    timer.stmt(rows.len() as u64);
-    Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
-}
+    .context("generate_bundle: window")?;
 
-/// The bundle to freeze with `assignment`: write schemas for every chunk in its routable window, and
-/// the current read schema of every dataset there.
-///
-/// `scanned_*` are what the cycle's own chunk scan saw. Both are unioned with the assignment's own
-/// chunks, because the scan runs before `apply_deltas_and_swap` stamps
-/// `applied_at_worker_assignment_id` — a chunk placed for the first time this cycle is named by the
-/// assignment while its row still reads as never-entered.
-///
-/// The window is deliberately wider than "currently held": a chunk the latest assignment dropped can
-/// still be routed off an earlier confirmed entry, so its schema must stay resolvable (ADR 0002).
-/// Only content loads hit the DB here, and content is immutable per id, so reading it after the
-/// cycle's commit is safe under concurrent writers.
-pub(super) async fn build_bundle(
-    conn: &mut PgConnection,
-    assignment: &WorkerAssignment,
-    scanned_schema_ids: BTreeSet<SchemaId>,
-    scanned_datasets: &BTreeSet<DatasetId>,
-) -> Result<SchemaBundle> {
-    let mut schema_ids = scanned_schema_ids;
-    schema_ids.extend(assignment.schema_ids());
+    // Persisted set of the last successful assignment; datasets via the schema's own dataset (the
+    // `chunks_schema_same_dataset` FK makes that exactly the chunk's dataset).
+    let persisted: Vec<(SchemaId, String)> = sqlx::query_as(
+        "SELECT w.schema_id, d.name          FROM sched_worker_assignment_schemas w          JOIN schemas s ON s.id = w.schema_id          JOIN datasets d ON d.id = s.dataset_id",
+    )
+    .fetch_all(&mut *tx)
+    .await
+    .context("generate_bundle: persisted set")?;
+
+    let mut schema_ids: BTreeSet<SchemaId> = BTreeSet::new();
+    let mut datasets: BTreeSet<String> = BTreeSet::new();
+    for (id, dataset) in window.into_iter().chain(persisted) {
+        schema_ids.insert(id);
+        datasets.insert(dataset);
+    }
     let schema_ids: Vec<SchemaId> = schema_ids.into_iter().collect();
+    let dataset_refs: Vec<&str> = datasets.iter().map(String::as_str).collect();
 
-    let mut datasets: BTreeSet<&str> = scanned_datasets.iter().map(|d| d.as_str()).collect();
-    datasets.extend(
-        assignment
-            .chunks
-            .values()
-            .map(|chunk| chunk.dataset.as_str()),
-    );
-    let datasets: Vec<&str> = datasets.into_iter().collect();
+    let schemas = scheduler_metadata::pg::schema::load_schemas(&mut tx, Some(&schema_ids)).await?;
+    let missing: Vec<SchemaId> = schema_ids
+        .iter()
+        .filter(|id| !schemas.contains_key(id))
+        .copied()
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!("generate_bundle: schemas table is missing referenced ids {missing:?}");
+    }
+    let read_schemas = read_schemas_by_id(&mut tx, &dataset_refs).await?;
 
-    Ok(SchemaBundle::from_sections(
-        scheduler_metadata::pg::schema::load_schemas(conn, Some(&schema_ids)).await?,
-        read_schemas_by_id(conn, &datasets).await?,
-    ))
+    tx.commit().await.context("generate_bundle: commit")?;
+    Ok(SchemaBundle::from_sections(schemas, read_schemas))
 }

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -63,10 +63,11 @@ pub(super) async fn read_schemas_by_id(
 }
 
 /// One bundle from committed rows alone — identical under success, shortage, and on a fresh
-/// process. Write section: routable window ∪ the persisted set (the window alone can shrink below
-/// what the frozen assignment names — Phase A keeps tombstoning during a shortage). Read section:
-/// the CURRENT read schema of every referenced dataset. One `REPEATABLE READ, READ ONLY` snapshot;
-/// strict loads — a referenced id with no `schemas` row is an error, never a silent shrink.
+/// process. Write section: the persisted set of the last successful cycle, which by construction
+/// equals the routable window at that commit and always covers it afterwards (window entry requires
+/// a stamp only a successful cycle writes; tombstoning only shrinks it). Read section: the CURRENT
+/// read schema of every referenced dataset. One `REPEATABLE READ, READ ONLY` snapshot; strict
+/// loads — a referenced id with no `schemas` row is an error, never a silent shrink.
 pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBundle> {
     let _timer = crate::metrics::Timer::new("generate_schema_bundle");
     let mut tx = conn.begin().await.context("generate_bundle: begin")?;
@@ -75,17 +76,10 @@ pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBun
         .await
         .context("generate_bundle: set isolation")?;
 
-    // (schema id, dataset name) over window ∪ persisted; the persisted arm resolves its dataset
-    // through the schema row (`chunks_schema_same_dataset` makes that the chunk's own dataset).
+    // A few hundred rows by PK joins; the dataset comes through the schema row
+    // (`chunks_schema_same_dataset` makes that the chunk's own dataset).
     let refs: Vec<(SchemaId, String)> = sqlx::query_as(
-        "SELECT DISTINCT c.schema_id, d.name \
-         FROM sched_chunk_metadata m \
-         JOIN chunks c ON c.chunk_pk = m.chunk_pk \
-         JOIN datasets d ON d.id = c.dataset_id \
-         WHERE m.applied_at_worker_assignment_id IS NOT NULL \
-           AND m.dropped_from_worker_assignment_at IS NULL \
-         UNION \
-         SELECT w.schema_id, d.name \
+        "SELECT w.schema_id, d.name \
          FROM sched_worker_assignment_schemas w \
          JOIN schemas s ON s.id = w.schema_id \
          JOIN datasets d ON d.id = s.dataset_id",
@@ -94,12 +88,7 @@ pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBun
     .await
     .context("generate_bundle: collect refs")?;
 
-    let schema_ids: Vec<SchemaId> = refs
-        .iter()
-        .map(|(id, _)| *id)
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect();
+    let schema_ids: Vec<SchemaId> = refs.iter().map(|(id, _)| *id).collect();
     let datasets: BTreeSet<&str> = refs.iter().map(|(_, d)| d.as_str()).collect();
     let dataset_refs: Vec<&str> = datasets.into_iter().collect();
 

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -73,28 +73,65 @@ pub(super) async fn portal_read_schema_refs(
         .collect())
 }
 
-/// The current read schema of every dataset with a chunk in the same routable window
-/// [`active_schema_bundle`] uses. Scoping to that window (rather than to every row in `datasets`)
-/// is what lets the read section shrink: a decommissioned dataset drops out once its last chunk is
-/// tombstoned, on the same clock as its write schemas.
+/// The current read schema of each named dataset, id and content together — the bundle's read
+/// section. The caller passes the datasets of the routable window it already scanned, so this is a
+/// keyed lookup over a handful of rows.
+///
+/// Deliberately NOT a per-dataset `EXISTS` over `chunks`. A read schema is a dataset-level pointer
+/// that no chunk need be written under, so the natural predicate is "does this dataset have a live
+/// chunk" — and proving that *negative* for a retired dataset means walking every one of its chunk
+/// rows, every cycle, forever: nothing deletes `datasets` or `chunks` rows, and no index matches
+/// the routable predicate. (Contrast [`active_schema_bundle`], whose probe is per-*schema* and
+/// rides the purpose-built `chunks_schema_id` index.) Taking the answer from the cycle's own scan
+/// costs nothing and cannot drift from it.
 ///
 /// Id and content come from one statement, so there is no resolve-then-load gap a concurrent
 /// promote could open. A promote landing either side of it costs one cycle of freshness, never
 /// resolvability.
+pub(super) async fn read_schemas_for_datasets(
+    conn: &mut PgConnection,
+    datasets: &[&str],
+) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>> {
+    let mut timer = crate::metrics::PhaseTimer::new("read_schemas_for_datasets");
+    if datasets.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let rows: Vec<(ReadSchemaId, sqlx::types::Json<DatasetSchema>)> = sqlx::query_as(
+        "SELECT r.id, r.schema FROM read_schemas r \
+         JOIN datasets d ON d.id = r.dataset_id \
+         WHERE r.superseded_at IS NULL AND d.name = ANY($1)",
+    )
+    .bind(datasets)
+    .fetch_all(conn)
+    .await
+    .context("read_schemas_for_datasets")?;
+    timer.stmt(rows.len() as u64);
+    Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
+}
+
+/// [`read_schemas_for_datasets`] over the whole routable window, for callers that have not already
+/// scanned it — the `SchedulerStorage` trait method, used by tests and by
+/// [`SchemaBundle::generate`](crate::scheduler_storage::SchemaBundle). The scheduling cycle uses
+/// the keyed form; both must select the same window.
+///
+/// Enumerating forward (metadata → chunks → read_schemas) rather than proving a per-dataset
+/// negative reads better, but measured on 50K tombstoned rows it is **not** cheaper: no index
+/// matches `applied_at_worker_assignment_id IS NOT NULL AND dropped_from_worker_assignment_at IS
+/// NULL`, so either shape seq-scans `sched_chunk_metadata` (~358 vs ~350 buffers). That is fine
+/// here because no production path calls this — the cycle passes its own dataset set and reads 2
+/// buffers — but do not reach for this form expecting it to scale. The same missing index is why
+/// `fetch_portal_visible_chunks` already scans that table every visibility cycle.
 pub(super) async fn active_read_schemas(
     conn: &mut PgConnection,
 ) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>> {
     let mut timer = crate::metrics::PhaseTimer::new("active_read_schemas");
     let rows: Vec<(ReadSchemaId, sqlx::types::Json<DatasetSchema>)> = sqlx::query_as(
-        "SELECT r.id, r.schema FROM read_schemas r \
-         WHERE r.superseded_at IS NULL \
-           AND EXISTS ( \
-               SELECT 1 FROM chunks c \
-               JOIN sched_chunk_metadata m ON m.chunk_pk = c.chunk_pk \
-               WHERE c.dataset_id = r.dataset_id \
-                 AND m.applied_at_worker_assignment_id IS NOT NULL \
-                 AND m.dropped_from_worker_assignment_at IS NULL \
-           )",
+        "SELECT DISTINCT r.id, r.schema \
+         FROM sched_chunk_metadata m \
+         JOIN chunks c ON c.chunk_pk = m.chunk_pk \
+         JOIN read_schemas r ON r.dataset_id = c.dataset_id AND r.superseded_at IS NULL \
+         WHERE m.applied_at_worker_assignment_id IS NOT NULL \
+           AND m.dropped_from_worker_assignment_at IS NULL",
     )
     .fetch_all(conn)
     .await

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -39,6 +39,40 @@ pub(super) async fn active_schema_bundle(
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
+/// The current read-schema *id* of each named dataset — the reference a portal assignment
+/// publishes. Driven by the exact dataset list the caller derived from its (post-eviction) chunk
+/// set, so it is total over that set by construction: a dataset with visible chunks and no read
+/// row yields `None`, which is a published answer, not an omission.
+///
+/// Ids only, no payload: the content travels in the bundle, built in a different transaction, so
+/// there is nothing here for the id to need atomic consistency with. That is why this can be a
+/// plain indexed lookup over a handful of rows rather than a per-dataset `EXISTS` over `chunks` —
+/// the latter costs O(chunks) per *retired* dataset, every cycle, forever, since nothing deletes
+/// `datasets` rows and no index matches the portal-visible predicate.
+pub(super) async fn portal_read_schema_refs(
+    conn: &mut PgConnection,
+    datasets: &[&str],
+) -> Result<BTreeMap<crate::types::DatasetId, Option<ReadSchemaId>>> {
+    let mut timer = crate::metrics::PhaseTimer::new("portal_read_schema_refs");
+    if datasets.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let rows: Vec<(String, Option<ReadSchemaId>)> = sqlx::query_as(
+        "SELECT d.name, r.id FROM datasets d \
+         LEFT JOIN read_schemas r ON r.dataset_id = d.id AND r.superseded_at IS NULL \
+         WHERE d.name = ANY($1)",
+    )
+    .bind(datasets)
+    .fetch_all(conn)
+    .await
+    .context("portal_read_schema_refs")?;
+    timer.stmt(rows.len() as u64);
+    Ok(rows
+        .into_iter()
+        .map(|(name, id)| (std::sync::Arc::new(name), id))
+        .collect())
+}
+
 /// The current read schema of every dataset with a chunk in the same routable window
 /// [`active_schema_bundle`] uses. Scoping to that window (rather than to every row in `datasets`)
 /// is what lets the read section shrink: a decommissioned dataset drops out once its last chunk is

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -39,17 +39,20 @@ pub(super) async fn active_schema_bundle(
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
-/// Each named dataset's current read-schema id, for the portal assignment to publish. Keyed on the
-/// caller's post-eviction chunk set, so it is total over that set: a dataset with no read row yields
-/// `None`, which is an answer, not an omission.
+/// Each named dataset's current read-schema id, for the portal assignment to publish.
+///
+/// Driven from `datasets` with a LEFT JOIN, so the result is TOTAL over the named set: a dataset
+/// with no read row yields `None`. That is what makes "never promoted" publishable and distinct from
+/// a key the backend failed to produce. Compare [`read_schemas_by_id`], which inner-joins because a
+/// dataset without a read schema has no payload to carry.
 ///
 /// Ids only — the content travels in the bundle, built in another transaction, so there is nothing
 /// here for the id to be atomically consistent with.
-pub(super) async fn portal_read_schema_refs(
+pub(super) async fn read_schema_ids_by_dataset(
     conn: &mut PgConnection,
     datasets: &[&str],
 ) -> Result<BTreeMap<crate::types::DatasetId, Option<ReadSchemaId>>> {
-    let mut timer = crate::metrics::PhaseTimer::new("portal_read_schema_refs");
+    let mut timer = crate::metrics::PhaseTimer::new("read_schema_ids_by_dataset");
     if datasets.is_empty() {
         return Ok(BTreeMap::new());
     }
@@ -61,7 +64,7 @@ pub(super) async fn portal_read_schema_refs(
     .bind(datasets)
     .fetch_all(conn)
     .await
-    .context("portal_read_schema_refs")?;
+    .context("read_schema_ids_by_dataset")?;
     timer.stmt(rows.len() as u64);
     Ok(rows
         .into_iter()
@@ -69,8 +72,11 @@ pub(super) async fn portal_read_schema_refs(
         .collect())
 }
 
-/// The bundle's read section: id and content for each named dataset. The caller passes the datasets
-/// from the routable window it already scanned, making this a keyed lookup.
+/// The bundle's read section: payloads keyed by id, for the named datasets. The caller passes the
+/// routable window it already scanned, making this a keyed lookup.
+///
+/// Inner join, unlike [`read_schema_ids_by_dataset`]: a dataset with no read schema contributes no
+/// payload, and the bundle is keyed by id, so there is no slot for an absent one.
 ///
 /// Not a per-dataset `EXISTS` over `chunks`. A read schema is a dataset-level pointer no chunk need
 /// be written under, so the predicate would be "has this dataset a live chunk" — and proving that
@@ -80,11 +86,11 @@ pub(super) async fn portal_read_schema_refs(
 ///
 /// One statement, so no concurrent promote can open a resolve-then-load gap; a promote either side
 /// of it costs a cycle of freshness, never resolvability.
-pub(super) async fn read_schemas_for_datasets(
+pub(super) async fn read_schemas_by_id(
     conn: &mut PgConnection,
     datasets: &[&str],
 ) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>> {
-    let mut timer = crate::metrics::PhaseTimer::new("read_schemas_for_datasets");
+    let mut timer = crate::metrics::PhaseTimer::new("read_schemas_by_id");
     if datasets.is_empty() {
         return Ok(BTreeMap::new());
     }
@@ -96,12 +102,12 @@ pub(super) async fn read_schemas_for_datasets(
     .bind(datasets)
     .fetch_all(conn)
     .await
-    .context("read_schemas_for_datasets")?;
+    .context("read_schemas_by_id")?;
     timer.stmt(rows.len() as u64);
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
-/// [`read_schemas_for_datasets`] over the whole routable window, for callers without one already —
+/// [`read_schemas_by_id`] over the whole routable window, for callers without one already —
 /// the trait method, used by tests. The cycle uses the keyed form; both must select the same window.
 ///
 /// Enumerating forward reads better than a per-dataset negative but measured no cheaper (~358 vs

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -1,13 +1,13 @@
 //! Scheduler-side schema probe over `sched_chunk_metadata`: which read schemas are still in play.
 //! Joins a scheduler-owned table, so it lives here rather than in `scheduler-metadata`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use sqlx::postgres::PgConnection;
 
-use crate::scheduler_storage::{ReadSchemaId, SchemaId};
-use crate::types::DatasetSchema;
+use crate::scheduler_storage::{ReadSchemaId, SchemaBundle, SchemaId, WorkerAssignment};
+use crate::types::{DatasetId, DatasetSchema};
 
 /// Schemas of chunks placed on a worker at some point and not yet tombstoned. Portal-served chunks
 /// are already covered: portal promotion requires prior worker placement, and tombstoning requires
@@ -132,4 +132,41 @@ pub(super) async fn active_read_schemas(
     .context("active_read_schemas")?;
     timer.stmt(rows.len() as u64);
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
+}
+
+/// The bundle to freeze with `assignment`: write schemas for every chunk in its routable window, and
+/// the current read schema of every dataset there.
+///
+/// `scanned_*` are what the cycle's own chunk scan saw. Both are unioned with the assignment's own
+/// chunks, because the scan runs before `apply_deltas_and_swap` stamps
+/// `applied_at_worker_assignment_id` — a chunk placed for the first time this cycle is named by the
+/// assignment while its row still reads as never-entered.
+///
+/// The window is deliberately wider than "currently held": a chunk the latest assignment dropped can
+/// still be routed off an earlier confirmed entry, so its schema must stay resolvable (ADR 0002).
+/// Only content loads hit the DB here, and content is immutable per id, so reading it after the
+/// cycle's commit is safe under concurrent writers.
+pub(super) async fn build_bundle(
+    conn: &mut PgConnection,
+    assignment: &WorkerAssignment,
+    scanned_schema_ids: BTreeSet<SchemaId>,
+    scanned_datasets: &BTreeSet<DatasetId>,
+) -> Result<SchemaBundle> {
+    let mut schema_ids = scanned_schema_ids;
+    schema_ids.extend(assignment.schema_ids());
+    let schema_ids: Vec<SchemaId> = schema_ids.into_iter().collect();
+
+    let mut datasets: BTreeSet<&str> = scanned_datasets.iter().map(|d| d.as_str()).collect();
+    datasets.extend(
+        assignment
+            .chunks
+            .values()
+            .map(|chunk| chunk.dataset.as_str()),
+    );
+    let datasets: Vec<&str> = datasets.into_iter().collect();
+
+    Ok(SchemaBundle::from_sections(
+        scheduler_metadata::pg::schema::load_schemas(conn, Some(&schema_ids)).await?,
+        read_schemas_by_id(conn, &datasets).await?,
+    ))
 }

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -39,16 +39,12 @@ pub(super) async fn active_schema_bundle(
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
-/// The current read-schema *id* of each named dataset — the reference a portal assignment
-/// publishes. Driven by the exact dataset list the caller derived from its (post-eviction) chunk
-/// set, so it is total over that set by construction: a dataset with visible chunks and no read
-/// row yields `None`, which is a published answer, not an omission.
+/// Each named dataset's current read-schema id, for the portal assignment to publish. Keyed on the
+/// caller's post-eviction chunk set, so it is total over that set: a dataset with no read row yields
+/// `None`, which is an answer, not an omission.
 ///
-/// Ids only, no payload: the content travels in the bundle, built in a different transaction, so
-/// there is nothing here for the id to need atomic consistency with. That is why this can be a
-/// plain indexed lookup over a handful of rows rather than a per-dataset `EXISTS` over `chunks` —
-/// the latter costs O(chunks) per *retired* dataset, every cycle, forever, since nothing deletes
-/// `datasets` rows and no index matches the portal-visible predicate.
+/// Ids only — the content travels in the bundle, built in another transaction, so there is nothing
+/// here for the id to be atomically consistent with.
 pub(super) async fn portal_read_schema_refs(
     conn: &mut PgConnection,
     datasets: &[&str],
@@ -73,21 +69,17 @@ pub(super) async fn portal_read_schema_refs(
         .collect())
 }
 
-/// The current read schema of each named dataset, id and content together — the bundle's read
-/// section. The caller passes the datasets of the routable window it already scanned, so this is a
-/// keyed lookup over a handful of rows.
+/// The bundle's read section: id and content for each named dataset. The caller passes the datasets
+/// from the routable window it already scanned, making this a keyed lookup.
 ///
-/// Deliberately NOT a per-dataset `EXISTS` over `chunks`. A read schema is a dataset-level pointer
-/// that no chunk need be written under, so the natural predicate is "does this dataset have a live
-/// chunk" — and proving that *negative* for a retired dataset means walking every one of its chunk
-/// rows, every cycle, forever: nothing deletes `datasets` or `chunks` rows, and no index matches
-/// the routable predicate. (Contrast [`active_schema_bundle`], whose probe is per-*schema* and
-/// rides the purpose-built `chunks_schema_id` index.) Taking the answer from the cycle's own scan
-/// costs nothing and cannot drift from it.
+/// Not a per-dataset `EXISTS` over `chunks`. A read schema is a dataset-level pointer no chunk need
+/// be written under, so the predicate would be "has this dataset a live chunk" — and proving that
+/// negative for a retired dataset walks all its chunk rows, every cycle, forever, since nothing
+/// deletes `datasets` or `chunks` and no index matches the routable predicate. (Contrast
+/// [`active_schema_bundle`]: its probe is per-*schema* and rides `chunks_schema_id`.)
 ///
-/// Id and content come from one statement, so there is no resolve-then-load gap a concurrent
-/// promote could open. A promote landing either side of it costs one cycle of freshness, never
-/// resolvability.
+/// One statement, so no concurrent promote can open a resolve-then-load gap; a promote either side
+/// of it costs a cycle of freshness, never resolvability.
 pub(super) async fn read_schemas_for_datasets(
     conn: &mut PgConnection,
     datasets: &[&str],
@@ -109,18 +101,14 @@ pub(super) async fn read_schemas_for_datasets(
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
-/// [`read_schemas_for_datasets`] over the whole routable window, for callers that have not already
-/// scanned it — the `SchedulerStorage` trait method, used by tests and by
-/// [`SchemaBundle::generate`](crate::scheduler_storage::SchemaBundle). The scheduling cycle uses
-/// the keyed form; both must select the same window.
+/// [`read_schemas_for_datasets`] over the whole routable window, for callers without one already —
+/// the trait method, used by tests. The cycle uses the keyed form; both must select the same window.
 ///
-/// Enumerating forward (metadata → chunks → read_schemas) rather than proving a per-dataset
-/// negative reads better, but measured on 50K tombstoned rows it is **not** cheaper: no index
-/// matches `applied_at_worker_assignment_id IS NOT NULL AND dropped_from_worker_assignment_at IS
-/// NULL`, so either shape seq-scans `sched_chunk_metadata` (~358 vs ~350 buffers). That is fine
-/// here because no production path calls this — the cycle passes its own dataset set and reads 2
-/// buffers — but do not reach for this form expecting it to scale. The same missing index is why
-/// `fetch_portal_visible_chunks` already scans that table every visibility cycle.
+/// Enumerating forward reads better than a per-dataset negative but measured no cheaper (~358 vs
+/// ~350 buffers on 50K tombstoned rows): no index matches the routable predicate, so either shape
+/// seq-scans `sched_chunk_metadata`. Acceptable only because no production path calls this — the
+/// cycle reads 2 buffers. The same missing index is why `fetch_portal_visible_chunks` scans that
+/// table every visibility cycle.
 pub(super) async fn active_read_schemas(
     conn: &mut PgConnection,
 ) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>> {

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -62,12 +62,10 @@ pub(super) async fn read_schemas_by_id(
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
-/// One bundle from committed rows alone — identical under success, shortage, and on a fresh
-/// process. Write section: the persisted set of the last successful cycle, which by construction
-/// equals the routable window at that commit and always covers it afterwards (window entry requires
-/// a stamp only a successful cycle writes; tombstoning only shrinks it). Read section: the CURRENT
-/// read schema of every referenced dataset. One `REPEATABLE READ, READ ONLY` snapshot; strict
-/// loads — a referenced id with no `schemas` row is an error, never a silent shrink.
+/// Postgres body of `SchedulerStorage::generate_schema_bundle` (contract there). One
+/// `REPEATABLE READ, READ ONLY` snapshot, so the persisted set and both loads cannot skew against
+/// each other. Covering proof: window entry requires a stamp only a successful cycle writes, and
+/// tombstoning only shrinks it.
 pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBundle> {
     let _timer = crate::metrics::Timer::new("generate_schema_bundle");
     let mut tx = conn.begin().await.context("generate_bundle: begin")?;

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result};
 use sqlx::postgres::PgConnection;
 
-use crate::scheduler_storage::SchemaId;
+use crate::scheduler_storage::{ReadSchemaId, SchemaId};
 use crate::types::DatasetSchema;
 
 /// Schemas of chunks placed on a worker at some point and not yet tombstoned. Portal-served chunks
@@ -35,6 +35,36 @@ pub(super) async fn active_schema_bundle(
     .fetch_all(conn)
     .await
     .context("active_schema_bundle")?;
+    timer.stmt(rows.len() as u64);
+    Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
+}
+
+/// The current read schema of every dataset with a chunk in the same routable window
+/// [`active_schema_bundle`] uses. Scoping to that window (rather than to every row in `datasets`)
+/// is what lets the read section shrink: a decommissioned dataset drops out once its last chunk is
+/// tombstoned, on the same clock as its write schemas.
+///
+/// Id and content come from one statement, so there is no resolve-then-load gap a concurrent
+/// promote could open. A promote landing either side of it costs one cycle of freshness, never
+/// resolvability.
+pub(super) async fn active_read_schemas(
+    conn: &mut PgConnection,
+) -> Result<BTreeMap<ReadSchemaId, DatasetSchema>> {
+    let mut timer = crate::metrics::PhaseTimer::new("active_read_schemas");
+    let rows: Vec<(ReadSchemaId, sqlx::types::Json<DatasetSchema>)> = sqlx::query_as(
+        "SELECT r.id, r.schema FROM read_schemas r \
+         WHERE r.superseded_at IS NULL \
+           AND EXISTS ( \
+               SELECT 1 FROM chunks c \
+               JOIN sched_chunk_metadata m ON m.chunk_pk = c.chunk_pk \
+               WHERE c.dataset_id = r.dataset_id \
+                 AND m.applied_at_worker_assignment_id IS NOT NULL \
+                 AND m.dropped_from_worker_assignment_at IS NULL \
+           )",
+    )
+    .fetch_all(conn)
+    .await
+    .context("active_read_schemas")?;
     timer.stmt(rows.len() as u64);
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -80,18 +80,14 @@ pub(super) async fn read_schemas_by_id(
 }
 
 /// The generator: one bundle from committed rows alone, identical under success, shortage, and on
-/// a fresh process. Write section: the routable window (ADR 0002) ∪ the persisted set of the last
-/// successful assignment — the window alone can shrink below what the frozen published assignment
-/// still names, since Phase A keeps tombstoning during a shortage. Read section: the CURRENT read
-/// schema of every dataset either side references, so a promote always reaches the next bundle.
+/// a fresh process. Write section: the routable window ∪ the persisted set of the last successful
+/// assignment (the window alone can shrink below what the frozen assignment names — Phase A keeps
+/// tombstoning during a shortage). Read section: the CURRENT read schema of every dataset either
+/// side references, so a promote always reaches the next bundle.
 ///
-/// One `REPEATABLE READ, READ ONLY` transaction: both sections and the persisted set are read from
-/// a single snapshot, so a cycle or promote landing concurrently (the WIP service branch runs this
-/// from a different loop than the scheduler's) cannot skew them against each other.
-///
-/// Loads are strict: a window or persisted id whose `schemas` row is missing is an error, not an
-/// omission — under the soft-then-hard-delete policy a silent shrink here would republish a bundle
-/// that quietly dropped a schema consumers still resolve.
+/// One `REPEATABLE READ, READ ONLY` transaction: everything is read from a single snapshot, so a
+/// concurrent cycle or promote cannot skew the sections against each other. Loads are strict — a
+/// referenced id whose `schemas` row is missing is an error, never a silent shrink.
 pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBundle> {
     let _timer = crate::metrics::Timer::new("generate_schema_bundle");
     let mut tx = conn.begin().await.context("generate_bundle: begin")?;
@@ -100,32 +96,34 @@ pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBun
         .await
         .context("generate_bundle: set isolation")?;
 
-    // Window: distinct (schema id, dataset name) over chunks that entered a worker assignment and
-    // are not yet tombstoned.
-    let window: Vec<(SchemaId, String)> = sqlx::query_as(
-        "SELECT DISTINCT c.schema_id, d.name          FROM sched_chunk_metadata m          JOIN chunks c ON c.chunk_pk = m.chunk_pk          JOIN datasets d ON d.id = c.dataset_id          WHERE m.applied_at_worker_assignment_id IS NOT NULL            AND m.dropped_from_worker_assignment_at IS NULL",
+    // (schema id, dataset name) over the window ∪ the persisted set. The persisted arm resolves
+    // its dataset through the schema row — `chunks_schema_same_dataset` makes that the chunk's own
+    // dataset.
+    let refs: Vec<(SchemaId, String)> = sqlx::query_as(
+        "SELECT DISTINCT c.schema_id, d.name \
+         FROM sched_chunk_metadata m \
+         JOIN chunks c ON c.chunk_pk = m.chunk_pk \
+         JOIN datasets d ON d.id = c.dataset_id \
+         WHERE m.applied_at_worker_assignment_id IS NOT NULL \
+           AND m.dropped_from_worker_assignment_at IS NULL \
+         UNION \
+         SELECT w.schema_id, d.name \
+         FROM sched_worker_assignment_schemas w \
+         JOIN schemas s ON s.id = w.schema_id \
+         JOIN datasets d ON d.id = s.dataset_id",
     )
     .fetch_all(&mut *tx)
     .await
-    .context("generate_bundle: window")?;
+    .context("generate_bundle: collect refs")?;
 
-    // Persisted set of the last successful assignment; datasets via the schema's own dataset (the
-    // `chunks_schema_same_dataset` FK makes that exactly the chunk's dataset).
-    let persisted: Vec<(SchemaId, String)> = sqlx::query_as(
-        "SELECT w.schema_id, d.name          FROM sched_worker_assignment_schemas w          JOIN schemas s ON s.id = w.schema_id          JOIN datasets d ON d.id = s.dataset_id",
-    )
-    .fetch_all(&mut *tx)
-    .await
-    .context("generate_bundle: persisted set")?;
-
-    let mut schema_ids: BTreeSet<SchemaId> = BTreeSet::new();
-    let mut datasets: BTreeSet<String> = BTreeSet::new();
-    for (id, dataset) in window.into_iter().chain(persisted) {
-        schema_ids.insert(id);
-        datasets.insert(dataset);
-    }
-    let schema_ids: Vec<SchemaId> = schema_ids.into_iter().collect();
-    let dataset_refs: Vec<&str> = datasets.iter().map(String::as_str).collect();
+    let schema_ids: Vec<SchemaId> = refs
+        .iter()
+        .map(|(id, _)| *id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let datasets: BTreeSet<&str> = refs.iter().map(|(_, d)| d.as_str()).collect();
+    let dataset_refs: Vec<&str> = datasets.into_iter().collect();
 
     let schemas = scheduler_metadata::pg::schema::load_schemas(&mut tx, Some(&schema_ids)).await?;
     let missing: Vec<SchemaId> = schema_ids

--- a/src/scheduler_storage/postgres/schema.rs
+++ b/src/scheduler_storage/postgres/schema.rs
@@ -11,15 +11,9 @@ use sqlx::Connection;
 use crate::scheduler_storage::{ReadSchemaId, SchemaBundle, SchemaId};
 use crate::types::DatasetSchema;
 
-/// Each named dataset's current read-schema id, for the portal assignment to publish.
-///
-/// Driven from `datasets` with a LEFT JOIN, so the result is TOTAL over the named set: a dataset
-/// with no read row yields `None`. That is what makes "never promoted" publishable and distinct from
-/// a key the backend failed to produce. Compare [`read_schemas_by_id`], which inner-joins because a
-/// dataset without a read schema has no payload to carry.
-///
-/// Ids only — the content travels in the bundle, built in another transaction, so there is nothing
-/// here for the id to be atomically consistent with.
+/// Each named dataset's current read-schema id, for the portal assignment to publish. LEFT JOIN
+/// from `datasets`, so the result is TOTAL over the named set — `None` means "never promoted",
+/// distinct from a key the backend failed to produce. Ids only; the content travels in the bundle.
 pub(super) async fn read_schema_ids_by_dataset(
     conn: &mut PgConnection,
     datasets: &[&str],
@@ -44,20 +38,9 @@ pub(super) async fn read_schema_ids_by_dataset(
         .collect())
 }
 
-/// The bundle's read section: payloads keyed by id, for the named datasets. The caller passes the
-/// routable window it already scanned, making this a keyed lookup.
-///
-/// Inner join, unlike [`read_schema_ids_by_dataset`]: a dataset with no read schema contributes no
-/// payload, and the bundle is keyed by id, so there is no slot for an absent one.
-///
-/// Not a per-dataset `EXISTS` over `chunks`. A read schema is a dataset-level pointer no chunk need
-/// be written under, so the predicate would be "has this dataset a live chunk" — and proving that
-/// negative for a retired dataset walks all its chunk rows, every cycle, forever, since nothing
-/// deletes `datasets` or `chunks` and no index matches the routable predicate. (Contrast
-/// [`active_schema_bundle`]: its probe is per-*schema* and rides `chunks_schema_id`.)
-///
-/// One statement, so no concurrent promote can open a resolve-then-load gap; a promote either side
-/// of it costs a cycle of freshness, never resolvability.
+/// The bundle's read section: current read-schema payloads keyed by id, for the named datasets.
+/// Inner join, unlike [`read_schema_ids_by_dataset`] — a dataset with no read schema has no slot in
+/// an id-keyed map. One statement, so a concurrent promote costs freshness, never resolvability.
 pub(super) async fn read_schemas_by_id(
     conn: &mut PgConnection,
     datasets: &[&str],
@@ -79,15 +62,11 @@ pub(super) async fn read_schemas_by_id(
     Ok(rows.into_iter().map(|(id, json)| (id, json.0)).collect())
 }
 
-/// The generator: one bundle from committed rows alone, identical under success, shortage, and on
-/// a fresh process. Write section: the routable window ∪ the persisted set of the last successful
-/// assignment (the window alone can shrink below what the frozen assignment names — Phase A keeps
-/// tombstoning during a shortage). Read section: the CURRENT read schema of every dataset either
-/// side references, so a promote always reaches the next bundle.
-///
-/// One `REPEATABLE READ, READ ONLY` transaction: everything is read from a single snapshot, so a
-/// concurrent cycle or promote cannot skew the sections against each other. Loads are strict — a
-/// referenced id whose `schemas` row is missing is an error, never a silent shrink.
+/// One bundle from committed rows alone — identical under success, shortage, and on a fresh
+/// process. Write section: routable window ∪ the persisted set (the window alone can shrink below
+/// what the frozen assignment names — Phase A keeps tombstoning during a shortage). Read section:
+/// the CURRENT read schema of every referenced dataset. One `REPEATABLE READ, READ ONLY` snapshot;
+/// strict loads — a referenced id with no `schemas` row is an error, never a silent shrink.
 pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBundle> {
     let _timer = crate::metrics::Timer::new("generate_schema_bundle");
     let mut tx = conn.begin().await.context("generate_bundle: begin")?;
@@ -96,9 +75,8 @@ pub(super) async fn generate_bundle(conn: &mut PgConnection) -> Result<SchemaBun
         .await
         .context("generate_bundle: set isolation")?;
 
-    // (schema id, dataset name) over the window ∪ the persisted set. The persisted arm resolves
-    // its dataset through the schema row — `chunks_schema_same_dataset` makes that the chunk's own
-    // dataset.
+    // (schema id, dataset name) over window ∪ persisted; the persisted arm resolves its dataset
+    // through the schema row (`chunks_schema_same_dataset` makes that the chunk's own dataset).
     let refs: Vec<(SchemaId, String)> = sqlx::query_as(
         "SELECT DISTINCT c.schema_id, d.name \
          FROM sched_chunk_metadata m \

--- a/src/scheduler_storage/postgres/tests/correction_tests.rs
+++ b/src/scheduler_storage/postgres/tests/correction_tests.rs
@@ -36,7 +36,6 @@ fn schedule_all(
     storage
         .run_scheduling_cycle(&algorithm, &(), at, 60)
         .expect("scheduling succeeds")
-        .0
         .id
 }
 

--- a/src/scheduler_storage/postgres/tests/drain_tests.rs
+++ b/src/scheduler_storage/postgres/tests/drain_tests.rs
@@ -57,7 +57,7 @@ impl DrainFixture {
             ignore_reliability: true,
         };
         self.storage.register_new_chunks().unwrap();
-        let (wa, _) = self
+        let wa = self
             .storage
             .run_scheduling_cycle(
                 &MultistepAlgorithm::new(UniformWeight),

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -5,8 +5,6 @@
 
 use std::collections::BTreeMap;
 
-use sqlx::Connection;
-
 use super::{current_schema_id, fresh_storage, register_chunk};
 use crate::scheduler_storage::algorithm::IdealMapping;
 use crate::scheduler_storage::postgres::PostgresStorage;
@@ -15,8 +13,8 @@ use crate::scheduler_storage::test_harness::utils::{
     StaticSchedulingAlgorithm, dataset, new_dataset, schema_with_tables, worker,
 };
 use crate::scheduler_storage::{
-    BundleId, ChunkPk, DatasetPk, SchedulerStorage, SchemaBundle, SchemaId, StorageError,
-    WorkerAssignment, WorkerPk,
+    BundleId, ChunkPk, SchedulerStorage, SchemaBundle, SchemaId, StorageError, WorkerAssignment,
+    WorkerPk,
 };
 use crate::types::{DatasetSchema, TableSchema};
 
@@ -85,26 +83,6 @@ fn set_chunk_tables_present(
             .execute(&mut *conn)
             .await
             .unwrap();
-            Ok::<_, StorageError>(())
-        })
-        .unwrap();
-}
-
-/// Promote a read schema, as `PUT /datasets/{name}/read-schema` does.
-fn promote_read_schema(storage: &mut PostgresStorage, ds: String, schema: DatasetSchema) {
-    storage
-        .with_conn(async move |conn| {
-            let dataset_id: DatasetPk =
-                sqlx::query_scalar("SELECT id FROM datasets WHERE name = $1")
-                    .bind(&ds)
-                    .fetch_one(&mut *conn)
-                    .await
-                    .unwrap();
-            let mut tx = conn.begin().await.unwrap();
-            scheduler_metadata::pg::schema::promote_read_schema(&mut tx, dataset_id, &schema)
-                .await
-                .unwrap();
-            tx.commit().await.unwrap();
             Ok::<_, StorageError>(())
         })
         .unwrap();
@@ -251,7 +229,9 @@ fn schema_bundle_carries_the_current_read_schema() {
 
     // A table set no write schema has, so its presence is unambiguous.
     let read_schema = schema_with_tables(&["blocks", "logs"]);
-    promote_read_schema(&mut storage, dataset("ds"), read_schema.clone());
+    storage
+        .promote_read_schema(&dataset("ds"), read_schema.clone())
+        .expect("promote read schema");
     assert_eq!(
         current_read_schema(&mut storage, dataset("ds")).as_ref(),
         Some(&read_schema),
@@ -291,7 +271,9 @@ fn first_placement_cycle_carries_the_read_schema() {
         .expect("insert dataset");
     let pk = register_chunk(&mut storage, "ds", 1, 100);
     let read_schema = schema_with_tables(&["blocks", "logs"]);
-    promote_read_schema(&mut storage, dataset("ds"), read_schema.clone());
+    storage
+        .promote_read_schema(&dataset("ds"), read_schema.clone())
+        .expect("promote read schema");
     let workers = one_worker(&mut storage);
 
     // Nothing has stamped this chunk as entered yet.

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -115,7 +115,7 @@ fn schedule(
     schedule_with_bundle(storage, chunk_pks, worker_ids, at).0
 }
 
-/// [`schedule`], keeping the bundle instead of dropping it.
+/// [`schedule`], also generating the bundle the round would publish.
 fn schedule_with_bundle(
     storage: &mut PostgresStorage,
     chunk_pks: &[ChunkPk],
@@ -126,9 +126,11 @@ fn schedule_with_bundle(
     let workers: Vec<WorkerPk> = worker_ids.to_vec();
     let mapping: IdealMapping = chunk_pks.iter().map(|&pk| (pk, workers.clone())).collect();
     let algorithm = StaticSchedulingAlgorithm { mapping };
-    storage
+    let wa = storage
         .run_scheduling_cycle(&algorithm, &(), at, 60)
-        .expect("scheduling succeeds")
+        .expect("scheduling succeeds");
+    let bundle = storage.generate_schema_bundle().expect("generate bundle");
+    (wa, bundle)
 }
 
 fn one_worker(storage: &mut PostgresStorage) -> Vec<WorkerPk> {
@@ -188,7 +190,7 @@ fn active_schema_bundle_holds_only_in_play_schemas() {
 
     // Place only "a"; "b" stays registered but unplaced (in no worker or portal assignment).
     let wa = schedule(&mut storage, &[a_pk], &workers, 100);
-    let bundle = SchemaBundle::generate(&storage).unwrap();
+    let bundle = storage.generate_schema_bundle().unwrap();
     // Whole-bundle content: exactly a's schema decoded from jsonb; b's is excluded, unplaced.
     assert_eq!(
         bundle.schemas(),
@@ -201,7 +203,7 @@ fn active_schema_bundle_holds_only_in_play_schemas() {
     storage.confirm_worker_assignment(wa.id, 100).unwrap();
     storage.run_visibility_cycle(150).unwrap();
     assert_eq!(
-        SchemaBundle::generate(&storage).unwrap().id(),
+        storage.generate_schema_bundle().unwrap().id(),
         bundle.id(),
         "portal-served keeps the same in-play schema set",
     );

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -88,23 +88,6 @@ fn set_chunk_tables_present(
         .unwrap();
 }
 
-/// The `superseded_at IS NULL` row; `None` if never promoted.
-fn current_read_schema(storage: &mut PostgresStorage, ds: String) -> Option<DatasetSchema> {
-    storage
-        .with_conn(async move |conn| {
-            let row: Option<sqlx::types::Json<DatasetSchema>> = sqlx::query_scalar(
-                "SELECT r.schema FROM read_schemas r JOIN datasets d ON d.id = r.dataset_id \
-                 WHERE d.name = $1 AND r.superseded_at IS NULL",
-            )
-            .bind(&ds)
-            .fetch_optional(&mut *conn)
-            .await
-            .unwrap();
-            Ok::<_, StorageError>(row.map(|j| j.0))
-        })
-        .unwrap()
-}
-
 /// Place every given chunk on every given worker and run one cycle.
 fn schedule(
     storage: &mut PostgresStorage,
@@ -234,12 +217,6 @@ fn schema_bundle_carries_the_current_read_schema() {
     storage
         .promote_read_schema(&dataset("ds"), read_schema.clone())
         .expect("promote read schema");
-    assert_eq!(
-        current_read_schema(&mut storage, dataset("ds")).as_ref(),
-        Some(&read_schema),
-        "the promote landed — the dataset does have a current read schema",
-    );
-
     let (_, after) = schedule_with_bundle(&mut storage, &[pk], &workers, 200);
     assert_eq!(
         after.read_schemas().values().collect::<Vec<_>>(),

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -209,8 +209,8 @@ fn active_schema_bundle_holds_only_in_play_schemas() {
     );
 }
 
-/// The bundle carries the current read schema alongside the write schemas, and a promote moves the
-/// fingerprint — without that movement a caching portal never invalidates.
+/// A promote lands in the bundle's read section and moves the fingerprint — without that movement a
+/// caching portal never invalidates.
 #[test]
 fn schema_bundle_carries_the_current_read_schema() {
     let mut storage = fresh_storage("bundle_read_schema");
@@ -258,16 +258,10 @@ fn schema_bundle_carries_the_current_read_schema() {
     );
 }
 
-/// A dataset placed for the first time this cycle must still reach the bundle. The scan runs before
-/// `apply_deltas_and_swap` stamps `applied_at_worker_assignment_id`, so the chunk reads as
-/// never-entered and the scan alone misses its dataset — the reason the write side starts from
-/// `wa.schema_ids()`.
-///
-/// The order is the whole point: [`schema_bundle_carries_the_current_read_schema`] promotes after a
-/// cycle has already stamped the chunk, so it cannot catch this.
-///
-/// The bug was found by the Postgres sim sweeps, which failed with an empty read section; this is the
-/// deterministic case written afterwards to pin it.
+/// A dataset placed for the first time in a cycle must still reach that round's bundle. The order —
+/// promote, THEN first placement — is the point: the sibling test promotes after a cycle has
+/// stamped the chunk, so it cannot catch this. Found by the Postgres sim sweeps (empty read
+/// section); pinned here.
 #[test]
 fn first_placement_cycle_carries_the_read_schema() {
     let mut storage = fresh_storage("bundle_first_placement");

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -90,8 +90,7 @@ fn set_chunk_tables_present(
         .unwrap();
 }
 
-/// Make `schema` the dataset's current READ schema, as the metadata service's admin path
-/// (`PUT /datasets/{name}/read-schema`) does — the scheduler exposes no API of its own for it.
+/// Promote a read schema, as `PUT /datasets/{name}/read-schema` does.
 fn promote_read_schema(storage: &mut PostgresStorage, ds: String, schema: DatasetSchema) {
     storage
         .with_conn(async move |conn| {
@@ -111,7 +110,7 @@ fn promote_read_schema(storage: &mut PostgresStorage, ds: String, schema: Datase
         .unwrap();
 }
 
-/// The dataset's current read schema (`superseded_at IS NULL`); `None` if never promoted.
+/// The `superseded_at IS NULL` row; `None` if never promoted.
 fn current_read_schema(storage: &mut PostgresStorage, ds: String) -> Option<DatasetSchema> {
     storage
         .with_conn(async move |conn| {
@@ -138,7 +137,7 @@ fn schedule(
     schedule_with_bundle(storage, chunk_pks, worker_ids, at).0
 }
 
-/// [`schedule`], keeping the bundle frozen with the assignment instead of dropping it.
+/// [`schedule`], keeping the bundle instead of dropping it.
 fn schedule_with_bundle(
     storage: &mut PostgresStorage,
     chunk_pks: &[ChunkPk],
@@ -230,10 +229,8 @@ fn active_schema_bundle_holds_only_in_play_schemas() {
     );
 }
 
-/// The bundle carries the dataset's current READ schema — what a portal validates queries against —
-/// alongside the WRITE schemas its chunks are pinned to, and promoting one moves the fingerprint.
-/// That movement is what lets a portal cache the bundle and re-fetch only when the set changed;
-/// without it a promote is invisible and the cache never invalidates.
+/// The bundle carries the current read schema alongside the write schemas, and a promote moves the
+/// fingerprint — without that movement a caching portal never invalidates.
 #[test]
 fn schema_bundle_carries_the_current_read_schema() {
     let mut storage = fresh_storage("bundle_read_schema");
@@ -252,7 +249,7 @@ fn schema_bundle_carries_the_current_read_schema() {
         "the bundle starts as exactly the placed chunk's write schema",
     );
 
-    // A read schema whose table set no write schema has, so its presence would be unambiguous.
+    // A table set no write schema has, so its presence is unambiguous.
     let read_schema = schema_with_tables(&["blocks", "logs"]);
     promote_read_schema(&mut storage, dataset("ds"), read_schema.clone());
     assert_eq!(
@@ -279,16 +276,13 @@ fn schema_bundle_carries_the_current_read_schema() {
     );
 }
 
-/// A dataset placed for the FIRST time in this cycle must still get its read schema into the
-/// bundle. The cycle's chunk scan runs before `apply_deltas_and_swap` stamps
-/// `applied_at_worker_assignment_id`, so a first-placement chunk still reads as never-entered and
-/// the routable-window scan alone misses its dataset — exactly as it misses its write schema, which
-/// is why the write side starts from `wa.schema_ids()` rather than from the scan.
+/// A dataset placed for the first time this cycle must still reach the bundle. The scan runs before
+/// `apply_deltas_and_swap` stamps `applied_at_worker_assignment_id`, so the chunk reads as
+/// never-entered and the scan alone misses its dataset — the reason the write side starts from
+/// `wa.schema_ids()`.
 ///
-/// [`schema_bundle_carries_the_current_read_schema`] cannot catch this: it promotes after a cycle
-/// has already stamped the chunk. The order here — promote, THEN place for the first time — is the
-/// whole point. Found by the Postgres sims (empty read section on the first-placement cycle);
-/// pinned deterministically here.
+/// The order is the whole point: [`schema_bundle_carries_the_current_read_schema`] promotes after a
+/// cycle has already stamped the chunk, so it cannot catch this.
 #[test]
 fn first_placement_cycle_carries_the_read_schema() {
     let mut storage = fresh_storage("bundle_first_placement");
@@ -300,7 +294,7 @@ fn first_placement_cycle_carries_the_read_schema() {
     promote_read_schema(&mut storage, dataset("ds"), read_schema.clone());
     let workers = one_worker(&mut storage);
 
-    // The very first cycle to place this chunk: nothing has stamped it as entered yet.
+    // Nothing has stamped this chunk as entered yet.
     let (wa, bundle) = schedule_with_bundle(&mut storage, &[pk], &workers, 100);
     assert!(
         wa.chunks.contains_key(&pk),

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -154,11 +154,10 @@ fn chunk_tables_present_is_returned_with_schema_id() {
     );
 }
 
-/// `active_schema_bundle` (the DB predicate) holds exactly the in-play schemas: a worker-held
-/// (then portal-served) chunk's schema is included, an unplaced chunk's is excluded, and the id is
-/// content-addressed over that set.
+/// The bundle holds exactly the in-play schemas: a worker-held (then portal-served) chunk's schema
+/// is included, an unplaced chunk's is excluded, and the id is content-addressed over that set.
 #[test]
-fn active_schema_bundle_holds_only_in_play_schemas() {
+fn bundle_holds_only_in_play_schemas() {
     let mut storage = fresh_storage("active_bundle");
     storage
         .insert_new_datasets(vec![

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -112,7 +112,13 @@ fn schedule(
     worker_ids: &[WorkerPk],
     at: u64,
 ) -> WorkerAssignment {
-    schedule_with_bundle(storage, chunk_pks, worker_ids, at).0
+    storage.register_new_chunks().expect("register new chunks");
+    let workers: Vec<WorkerPk> = worker_ids.to_vec();
+    let mapping: IdealMapping = chunk_pks.iter().map(|&pk| (pk, workers.clone())).collect();
+    let algorithm = StaticSchedulingAlgorithm { mapping };
+    storage
+        .run_scheduling_cycle(&algorithm, &(), at, 60)
+        .expect("scheduling succeeds")
 }
 
 /// [`schedule`], also generating the bundle the round would publish.
@@ -122,13 +128,7 @@ fn schedule_with_bundle(
     worker_ids: &[WorkerPk],
     at: u64,
 ) -> (WorkerAssignment, SchemaBundle) {
-    storage.register_new_chunks().expect("register new chunks");
-    let workers: Vec<WorkerPk> = worker_ids.to_vec();
-    let mapping: IdealMapping = chunk_pks.iter().map(|&pk| (pk, workers.clone())).collect();
-    let algorithm = StaticSchedulingAlgorithm { mapping };
-    let wa = storage
-        .run_scheduling_cycle(&algorithm, &(), at, 60)
-        .expect("scheduling succeeds");
+    let wa = schedule(storage, chunk_pks, worker_ids, at);
     let bundle = storage.generate_schema_bundle().expect("generate bundle");
     (wa, bundle)
 }

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -279,6 +279,40 @@ fn schema_bundle_carries_the_current_read_schema() {
     );
 }
 
+/// A dataset placed for the FIRST time in this cycle must still get its read schema into the
+/// bundle. The cycle's chunk scan runs before `apply_deltas_and_swap` stamps
+/// `applied_at_worker_assignment_id`, so a first-placement chunk still reads as never-entered and
+/// the routable-window scan alone misses its dataset — exactly as it misses its write schema, which
+/// is why the write side starts from `wa.schema_ids()` rather than from the scan.
+///
+/// [`schema_bundle_carries_the_current_read_schema`] cannot catch this: it promotes after a cycle
+/// has already stamped the chunk. The order here — promote, THEN place for the first time — is the
+/// whole point. Found by the Postgres sims (empty read section on the first-placement cycle);
+/// pinned deterministically here.
+#[test]
+fn first_placement_cycle_carries_the_read_schema() {
+    let mut storage = fresh_storage("bundle_first_placement");
+    storage
+        .insert_new_datasets(vec![new_dataset("ds", schema_with_tables(&["blocks"]))])
+        .expect("insert dataset");
+    let pk = register_chunk(&mut storage, "ds", 1, 100);
+    let read_schema = schema_with_tables(&["blocks", "logs"]);
+    promote_read_schema(&mut storage, dataset("ds"), read_schema.clone());
+    let workers = one_worker(&mut storage);
+
+    // The very first cycle to place this chunk: nothing has stamped it as entered yet.
+    let (wa, bundle) = schedule_with_bundle(&mut storage, &[pk], &workers, 100);
+    assert!(
+        wa.chunks.contains_key(&pk),
+        "precondition: the assignment names the chunk on this very cycle",
+    );
+    assert_eq!(
+        bundle.read_schemas().values().collect::<Vec<_>>(),
+        vec![&read_schema],
+        "the dataset is named by this assignment, so its read schema must be in the paired bundle",
+    );
+}
+
 #[test]
 fn load_schemas_returns_by_id_or_all() {
     let mut storage = fresh_storage("schema_load");

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -5,27 +5,20 @@
 
 use std::collections::BTreeMap;
 
+use sqlx::Connection;
+
 use super::{current_schema_id, fresh_storage, register_chunk};
 use crate::scheduler_storage::algorithm::IdealMapping;
 use crate::scheduler_storage::postgres::PostgresStorage;
 use crate::scheduler_storage::test_harness::inspect::StorageInspect;
 use crate::scheduler_storage::test_harness::utils::{
-    StaticSchedulingAlgorithm, dataset, new_dataset, worker,
+    StaticSchedulingAlgorithm, dataset, new_dataset, schema_with_tables, worker,
 };
 use crate::scheduler_storage::{
-    BundleId, ChunkPk, SchedulerStorage, SchemaBundle, SchemaId, StorageError, WorkerAssignment,
-    WorkerPk,
+    BundleId, ChunkPk, DatasetPk, SchedulerStorage, SchemaBundle, SchemaId, StorageError,
+    WorkerAssignment, WorkerPk,
 };
 use crate::types::{DatasetSchema, TableSchema};
-
-fn schema_with_tables(tables: &[&str]) -> DatasetSchema {
-    DatasetSchema::new(
-        tables
-            .iter()
-            .map(|t| ((*t).to_owned(), TableSchema::default()))
-            .collect(),
-    )
-}
 
 fn schema_one_table(table: &str, fields: &[&str], default_fields: &[&str]) -> DatasetSchema {
     let mut tables = BTreeMap::new();
@@ -97,6 +90,44 @@ fn set_chunk_tables_present(
         .unwrap();
 }
 
+/// Make `schema` the dataset's current READ schema, as the metadata service's admin path
+/// (`PUT /datasets/{name}/read-schema`) does — the scheduler exposes no API of its own for it.
+fn promote_read_schema(storage: &mut PostgresStorage, ds: String, schema: DatasetSchema) {
+    storage
+        .with_conn(async move |conn| {
+            let dataset_id: DatasetPk =
+                sqlx::query_scalar("SELECT id FROM datasets WHERE name = $1")
+                    .bind(&ds)
+                    .fetch_one(&mut *conn)
+                    .await
+                    .unwrap();
+            let mut tx = conn.begin().await.unwrap();
+            scheduler_metadata::pg::schema::promote_read_schema(&mut tx, dataset_id, &schema)
+                .await
+                .unwrap();
+            tx.commit().await.unwrap();
+            Ok::<_, StorageError>(())
+        })
+        .unwrap();
+}
+
+/// The dataset's current read schema (`superseded_at IS NULL`); `None` if never promoted.
+fn current_read_schema(storage: &mut PostgresStorage, ds: String) -> Option<DatasetSchema> {
+    storage
+        .with_conn(async move |conn| {
+            let row: Option<sqlx::types::Json<DatasetSchema>> = sqlx::query_scalar(
+                "SELECT r.schema FROM read_schemas r JOIN datasets d ON d.id = r.dataset_id \
+                 WHERE d.name = $1 AND r.superseded_at IS NULL",
+            )
+            .bind(&ds)
+            .fetch_optional(&mut *conn)
+            .await
+            .unwrap();
+            Ok::<_, StorageError>(row.map(|j| j.0))
+        })
+        .unwrap()
+}
+
 /// Place every given chunk on every given worker and run one cycle.
 fn schedule(
     storage: &mut PostgresStorage,
@@ -104,6 +135,16 @@ fn schedule(
     worker_ids: &[WorkerPk],
     at: u64,
 ) -> WorkerAssignment {
+    schedule_with_bundle(storage, chunk_pks, worker_ids, at).0
+}
+
+/// [`schedule`], keeping the bundle frozen with the assignment instead of dropping it.
+fn schedule_with_bundle(
+    storage: &mut PostgresStorage,
+    chunk_pks: &[ChunkPk],
+    worker_ids: &[WorkerPk],
+    at: u64,
+) -> (WorkerAssignment, SchemaBundle) {
     storage.register_new_chunks().expect("register new chunks");
     let workers: Vec<WorkerPk> = worker_ids.to_vec();
     let mapping: IdealMapping = chunk_pks.iter().map(|&pk| (pk, workers.clone())).collect();
@@ -111,7 +152,6 @@ fn schedule(
     storage
         .run_scheduling_cycle(&algorithm, &(), at, 60)
         .expect("scheduling succeeds")
-        .0
 }
 
 fn one_worker(storage: &mut PostgresStorage) -> Vec<WorkerPk> {
@@ -177,7 +217,8 @@ fn active_schema_bundle_holds_only_in_play_schemas() {
         bundle.schemas(),
         &BTreeMap::from([(a_schema, schema_with_tables(&["blocks"]))]),
     );
-    assert_eq!(bundle.id(), BundleId::from_schema_ids([a_schema]));
+    // No read schema promoted, so the read section is empty.
+    assert_eq!(bundle.id(), BundleId::from_sections([a_schema], []));
 
     // Promote "a" to the portal — still in play, so the set is unchanged.
     storage.confirm_worker_assignment(wa.id, 100).unwrap();
@@ -186,6 +227,55 @@ fn active_schema_bundle_holds_only_in_play_schemas() {
         SchemaBundle::generate(&storage).unwrap().id(),
         bundle.id(),
         "portal-served keeps the same in-play schema set",
+    );
+}
+
+/// The bundle carries the dataset's current READ schema — what a portal validates queries against —
+/// alongside the WRITE schemas its chunks are pinned to, and promoting one moves the fingerprint.
+/// That movement is what lets a portal cache the bundle and re-fetch only when the set changed;
+/// without it a promote is invisible and the cache never invalidates.
+#[test]
+fn schema_bundle_carries_the_current_read_schema() {
+    let mut storage = fresh_storage("bundle_read_schema");
+    let write_schema = schema_with_tables(&["blocks"]);
+    storage
+        .insert_new_datasets(vec![new_dataset("ds", write_schema.clone())])
+        .expect("insert dataset");
+    let pk = register_chunk(&mut storage, "ds", 1, 100);
+    let write_schema_id = current_schema_id(&mut storage, dataset("ds"));
+    let workers = one_worker(&mut storage);
+
+    let (_, before) = schedule_with_bundle(&mut storage, &[pk], &workers, 100);
+    assert_eq!(
+        before.schemas(),
+        &BTreeMap::from([(write_schema_id, write_schema)]),
+        "the bundle starts as exactly the placed chunk's write schema",
+    );
+
+    // A read schema whose table set no write schema has, so its presence would be unambiguous.
+    let read_schema = schema_with_tables(&["blocks", "logs"]);
+    promote_read_schema(&mut storage, dataset("ds"), read_schema.clone());
+    assert_eq!(
+        current_read_schema(&mut storage, dataset("ds")).as_ref(),
+        Some(&read_schema),
+        "the promote landed — the dataset does have a current read schema",
+    );
+
+    let (_, after) = schedule_with_bundle(&mut storage, &[pk], &workers, 200);
+    assert_eq!(
+        after.read_schemas().values().collect::<Vec<_>>(),
+        vec![&read_schema],
+        "the bundle carries the current read schema, so a portal can resolve it",
+    );
+    assert_eq!(
+        after.schemas(),
+        before.schemas(),
+        "and the write section is untouched — the two are separate id spaces",
+    );
+    assert_ne!(
+        after.id(),
+        before.id(),
+        "the fingerprint moves, so a portal caching the bundle knows to re-fetch",
     );
 }
 

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -263,6 +263,9 @@ fn schema_bundle_carries_the_current_read_schema() {
 ///
 /// The order is the whole point: [`schema_bundle_carries_the_current_read_schema`] promotes after a
 /// cycle has already stamped the chunk, so it cannot catch this.
+///
+/// The bug was found by the Postgres sim sweeps, which failed with an empty read section; this is the
+/// deterministic case written afterwards to pin it.
 #[test]
 fn first_placement_cycle_carries_the_read_schema() {
     let mut storage = fresh_storage("bundle_first_placement");

--- a/src/scheduler_storage/postgres/visibility.rs
+++ b/src/scheduler_storage/postgres/visibility.rs
@@ -1,7 +1,7 @@
 //! Phase helpers for [`PostgresStorage::run_visibility_cycle`] and
 //! [`PostgresStorage::confirm_worker_assignment`].
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use anyhow::{Context, Result};
 use sqlx::postgres::PgConnection;
@@ -462,11 +462,23 @@ pub(super) fn assemble_portal_assignment(
     chunks: BTreeMap<ChunkPk, WorkerAssignmentChunk>,
     chunk_workers: BTreeMap<ChunkPk, Vec<WorkerPk>>,
     workers: BTreeMap<WorkerPk, AssignmentWorker>,
+    read_schemas: BTreeMap<crate::types::DatasetId, Option<crate::scheduler_storage::ReadSchemaId>>,
 ) -> PortalAssignment {
-    PortalAssignment {
+    let assignment = PortalAssignment {
         id,
         chunk_workers,
         chunks,
         workers,
-    }
+        read_schemas,
+    };
+    debug_assert_eq!(
+        assignment
+            .read_schemas
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        assignment.named_datasets(),
+        "read_schemas must be exactly the datasets the chunk set names",
+    );
+    assignment
 }

--- a/src/scheduler_storage/schema_bundle.rs
+++ b/src/scheduler_storage/schema_bundle.rs
@@ -1,9 +1,6 @@
 //! Schemas published alongside an assignment: the WRITE schemas its chunks pin, and the current
-//! READ schemas of the datasets in play. Built from the assignment's own chunks, so the two can't
-//! drift.
-//!
-//! [`BundleId`] covers both sections, so a promote moves it — that is what lets a portal cache the
-//! bundle and re-fetch only on a change.
+//! READ schemas of the datasets in play. [`BundleId`] covers both sections, so a promote moves it —
+//! what lets a portal cache the bundle and re-fetch only on a change.
 
 use std::collections::BTreeMap;
 
@@ -15,12 +12,9 @@ use crate::types::DatasetSchema;
 /// Pins the encoding: a future format change becomes a different id, not a silent collision.
 const BUNDLE_ID_DOMAIN: &[u8] = b"sqd.schema-bundle.v1";
 
-/// SHA-256 over the bundle's sorted ids. Ids are content-deduped serials, so equal ids ⇒ equal
-/// content — within one database, not across them.
-///
-/// Each section is hashed behind its own tag and length: `schemas.id` and `read_schemas.id` are
-/// independent `SERIAL`s handing out the same integers, so a flat hash would let write-3 and
-/// read-3 collide. Ids are never reused, so an id in a published bundle keeps its meaning.
+/// SHA-256 over the bundle's sorted ids (content-deduped serials: equal ids ⇒ equal content within
+/// one database). Sections are hashed behind per-section tags — the two id spaces are independent
+/// `SERIAL`s, so a flat hash would let write-3 and read-3 collide.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BundleId([u8; 32]);
 

--- a/src/scheduler_storage/schema_bundle.rs
+++ b/src/scheduler_storage/schema_bundle.rs
@@ -172,43 +172,24 @@ impl SchemaBundle {
 
 /// Both variants must reach the caller rather than degrade to a shorter file list: a worker acts on
 /// that list, and a missing file reads as legitimate absence, not as an error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum ChunkFilesError {
     /// Pinned schema absent from the bundle — the state ADR 0002 exists to prevent.
+    #[error("chunk pins schema {schema_id}, absent from the bundle — no file set can be derived")]
     SchemaMissing { schema_id: SchemaId },
     /// Bitmap length ≠ the pinned schema's table count. Reached by re-pinning a chunk without
     /// recomputing the bitmap: bits shift onto the wrong tables, and positions past the end read as
     /// "absent".
+    #[error(
+        "tables_present has {bitmap_len} bits but pinned schema {schema_id} has {tables} tables — \
+         the bitmap indexes a different table list"
+    )]
     BitmapArity {
         schema_id: SchemaId,
         bitmap_len: usize,
         tables: usize,
     },
 }
-
-impl std::fmt::Display for ChunkFilesError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SchemaMissing { schema_id } => write!(
-                f,
-                "chunk pins schema {schema_id}, which is absent from the bundle — its file set \
-                 cannot be derived"
-            ),
-            Self::BitmapArity {
-                schema_id,
-                bitmap_len,
-                tables,
-            } => write!(
-                f,
-                "chunk's tables_present has {bitmap_len} bits but pinned schema {schema_id} has \
-                 {tables} tables — the bitmap was resolved against a different schema, so its bits \
-                 index the wrong tables"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for ChunkFilesError {}
 
 /// `None` = every table present. It records no schema, so it can't be arity-checked: re-pinning a
 /// NULL-bitmap chunk to a superset schema would claim files it lacks. A re-pin must therefore

--- a/src/scheduler_storage/schema_bundle.rs
+++ b/src/scheduler_storage/schema_bundle.rs
@@ -1,10 +1,9 @@
-//! The dataset schemas a published assignment reference, with a content [`BundleId`] clients use
-//! to detect changes. Two sections: the WRITE schemas the assignment's chunks are pinned to (built
-//! from those chunks and frozen with the assignment, so the two can't drift) and the current READ
-//! schemas of the datasets in play.
+//! Schemas published alongside an assignment: the WRITE schemas its chunks pin, and the current
+//! READ schemas of the datasets in play. Built from the assignment's own chunks, so the two can't
+//! drift.
 //!
-//! The fingerprint covers both, so promoting a read schema moves it — that is what lets a portal
-//! cache the bundle and re-fetch only when the set actually changed.
+//! [`BundleId`] covers both sections, so a promote moves it — that is what lets a portal cache the
+//! bundle and re-fetch only on a change.
 
 use std::collections::BTreeMap;
 
@@ -15,26 +14,20 @@ use super::{ReadSchemaId, SchemaId, WorkerAssignmentChunk};
 use super::{SchedulerStorage, StorageError};
 use crate::types::DatasetSchema;
 
-/// Domain tag: keeps this fingerprint from colliding with any other SHA-256 over id lists, and
-/// pins the encoding so a future format change is a different id rather than a silent collision.
+/// Pins the encoding: a future format change becomes a different id, not a silent collision.
 const BUNDLE_ID_DOMAIN: &[u8] = b"sqd.schema-bundle.v1";
 
-/// Content id of a [`SchemaBundle`]: SHA-256 over its sorted write- and read-schema ids. Ids are
-/// content-deduped serials, so equal ids ⇒ equal content — but only within one storage instance,
-/// not across DBs.
+/// SHA-256 over the bundle's sorted ids. Ids are content-deduped serials, so equal ids ⇒ equal
+/// content — within one database, not across them.
 ///
-/// The two sections are hashed separately, each length-prefixed behind its own tag. `schemas.id`
-/// and `read_schemas.id` are independent `SERIAL`s that hand out the same small integers, so a
-/// flat hash over both would let write-{3} and read-{3} collide; the tags and lengths make the
-/// section a value carries part of its identity. Primary keys are never reused, so an id in an
-/// already-published bundle can never later mean a different schema.
+/// Each section is hashed behind its own tag and length: `schemas.id` and `read_schemas.id` are
+/// independent `SERIAL`s handing out the same integers, so a flat hash would let write-3 and
+/// read-3 collide. Ids are never reused, so an id in a published bundle keeps its meaning.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BundleId([u8; 32]);
 
 impl BundleId {
-    /// `SchemaBundle` is the only production caller for now, and its ids come pre-sorted from a
-    /// `BTreeMap` — order isn't normalized here, so a caller with unsorted ids must sort first
-    /// (checked in debug builds).
+    /// Ids must arrive sorted (they do, from a `BTreeMap`); order isn't normalised here.
     pub(crate) fn from_sections(
         write_ids: impl IntoIterator<Item = SchemaId>,
         read_ids: impl IntoIterator<Item = ReadSchemaId>,
@@ -79,7 +72,6 @@ impl std::fmt::Debug for BundleId {
     }
 }
 
-/// In debug builds, catch a caller passing ids a `BTreeMap` didn't already sort.
 fn debug_assert_sorted(ids: impl Iterator<Item = i32>, section: &str) {
     #[cfg(debug_assertions)]
     {
@@ -92,9 +84,8 @@ fn debug_assert_sorted(ids: impl Iterator<Item = i32>, section: &str) {
     let _ = (ids, section);
 }
 
-/// Two sections: the WRITE schemas chunks are pinned to (a worker derives a chunk's file set from
-/// them) and the current READ schemas (what a portal validates queries against). They key on
-/// disjoint id spaces and are never interchangeable — see [`BundleId`].
+/// Workers derive file sets from the write section; portals validate queries against the read one.
+/// The two key on disjoint id spaces — see [`BundleId`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaBundle {
     id: BundleId,
@@ -103,7 +94,6 @@ pub struct SchemaBundle {
 }
 
 impl SchemaBundle {
-    /// Wrap the assignment's schemas and stamp the content id.
     pub(crate) fn from_sections(
         schemas: BTreeMap<SchemaId, DatasetSchema>,
         read_schemas: BTreeMap<ReadSchemaId, DatasetSchema>,
@@ -116,8 +106,7 @@ impl SchemaBundle {
         }
     }
 
-    /// Snapshot of the in-play schemas for tests; production uses the bundle returned from
-    /// `run_scheduling_cycle`.
+    /// For tests; production takes the bundle from `run_scheduling_cycle`.
     #[cfg(test)]
     pub(crate) fn generate(storage: &impl SchedulerStorage) -> Result<Self, StorageError> {
         Ok(Self::from_sections(
@@ -156,10 +145,8 @@ impl SchemaBundle {
 
     /// The chunk's `<table>.parquet` files, from its pinned schema and `tables_present` bitmap.
     ///
-    /// The bitmap is positional over the pinned schema's tables in sorted-name order, so it is only
-    /// meaningful against the exact schema it was resolved under. A length disagreement proves it
-    /// is being read against a different table list and is refused — see
-    /// [`ChunkFilesError::BitmapArity`].
+    /// The bitmap is positional over that schema's tables in sorted-name order, so a length
+    /// mismatch means it was resolved against a different table list — refused, not applied.
     pub fn chunk_files(
         &self,
         chunk: &WorkerAssignmentChunk,
@@ -183,18 +170,15 @@ impl SchemaBundle {
     }
 }
 
-/// Why a chunk's file set could not be derived. Both variants are invariant violations the caller
-/// surfaces rather than papers over: a wrong file list is worse than none, because the worker acts
-/// on it — a missing file reads as legitimate absence rather than as an error.
+/// Both variants must reach the caller rather than degrade to a shorter file list: a worker acts on
+/// that list, and a missing file reads as legitimate absence, not as an error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChunkFilesError {
-    /// The chunk's pinned schema is absent from the bundle, so its file set cannot be described at
-    /// all (the condition ADR 0002 exists to prevent).
+    /// Pinned schema absent from the bundle — the state ADR 0002 exists to prevent.
     SchemaMissing { schema_id: SchemaId },
-    /// The presence bitmap's length disagrees with the pinned schema's table count, so its bits
-    /// index a different table list than the one being applied. Reached by re-pinning a chunk to a
-    /// schema with a different table set without recomputing the bitmap: bits would silently shift
-    /// onto the wrong tables, and positions past the end would read as "legitimately absent".
+    /// Bitmap length ≠ the pinned schema's table count. Reached by re-pinning a chunk without
+    /// recomputing the bitmap: bits shift onto the wrong tables, and positions past the end read as
+    /// "absent".
     BitmapArity {
         schema_id: SchemaId,
         bitmap_len: usize,
@@ -226,15 +210,11 @@ impl std::fmt::Display for ChunkFilesError {
 
 impl std::error::Error for ChunkFilesError {}
 
-/// A schema's `<table>.parquet` files, filtered by a chunk's table-presence bitmap.
+/// `None` = every table present. It records no schema, so it can't be arity-checked: re-pinning a
+/// NULL-bitmap chunk to a superset schema would claim files it lacks. A re-pin must therefore
+/// materialise NULL into an explicit bitmap first.
 ///
-/// `None` = every table present. That sentinel carries no record of which schema produced it, so
-/// unlike an explicit bitmap it cannot be arity-checked: re-pinning a NULL-bitmap chunk to a
-/// *superset* schema silently claims files the chunk does not have. Anything that re-pins must
-/// therefore materialise NULL into an explicit bitmap first.
-///
-/// Precondition: an explicit bitmap's length equals `schema.tables().len()` — checked by
-/// [`SchemaBundle::chunk_files`], the only caller.
+/// Precondition (checked by the only caller): an explicit bitmap's length is `tables().len()`.
 fn chunk_files(schema: &DatasetSchema, bitmap: Option<&bit_vec::BitVec>) -> Vec<String> {
     schema
         .tables()
@@ -319,16 +299,13 @@ mod tests {
         );
     }
 
-    /// A bitmap is positional over one exact schema. If its length disagrees with the pinned
-    /// schema's table count it was resolved against a different table list, and applying it anyway
-    /// yields a plausible-but-wrong file set with no error — the failure mode that makes re-pinning
-    /// a chunk to a different table set unsafe. Both directions must be refused.
+    /// Applying a mismatched bitmap yields a plausible-but-wrong file set with no error — the
+    /// failure mode that makes re-pinning unsafe. Both directions must be refused.
     #[test]
     fn chunk_files_rejects_a_bitmap_of_the_wrong_arity() {
         let b = bundle(&[(1, schema(&["blocks", "logs", "transactions"]))]);
 
-        // Too short — as if the chunk were written under a 2-table schema and re-pinned to this
-        // one. Previously `transactions` silently read as "legitimately absent".
+        // Too short, as if re-pinned from a 2-table schema: `transactions` used to read as absent.
         assert_eq!(
             b.chunk_files(&chunk(1, Some(bit_vec::BitVec::from_elem(2, true)))),
             Err(ChunkFilesError::BitmapArity {
@@ -337,8 +314,7 @@ mod tests {
                 tables: 3,
             }),
         );
-        // Too long — the extra bits were silently ignored, so a table the chunk does carry could be
-        // dropped and every position after the divergence means the wrong table.
+        // Too long: extra bits used to be ignored, so positions could mean the wrong table.
         assert_eq!(
             b.chunk_files(&chunk(1, Some(bit_vec::BitVec::from_elem(4, true)))),
             Err(ChunkFilesError::BitmapArity {
@@ -347,7 +323,6 @@ mod tests {
                 tables: 3,
             }),
         );
-        // Exact arity is the only accepted explicit bitmap.
         assert_eq!(
             b.chunk_files(&chunk(1, Some(bit_vec::BitVec::from_elem(3, true))))
                 .map(|files| files.len()),
@@ -355,8 +330,7 @@ mod tests {
         );
     }
 
-    /// The NULL sentinel has no arity to check, so it is accepted against any schema — the residual
-    /// hazard a re-pin has to close by materialising it into an explicit bitmap first.
+    /// NULL has no arity to check, so it passes against any schema — the residue a re-pin must close.
     #[test]
     fn chunk_files_accepts_the_null_bitmap_against_any_schema() {
         let b = bundle(&[(1, schema(&["blocks", "logs"]))]);
@@ -379,9 +353,8 @@ mod tests {
         assert_ne!(write_only(&[1]), write_only(&[2]));
     }
 
-    /// The two id spaces are independent SERIALs handing out the same integers, so the fingerprint
-    /// must distinguish which section an id sits in — otherwise promoting a read schema whose id
-    /// happens to match a write id would leave the bundle looking unchanged.
+    /// Without per-section tagging, promoting a read schema whose id matches a write id would leave
+    /// the fingerprint unchanged.
     #[test]
     fn bundle_id_separates_the_two_sections() {
         assert_ne!(write_only(&[3]), read_only(&[3]));

--- a/src/scheduler_storage/schema_bundle.rs
+++ b/src/scheduler_storage/schema_bundle.rs
@@ -10,8 +10,6 @@ use std::collections::BTreeMap;
 use sha2::{Digest, Sha256};
 
 use super::{ReadSchemaId, SchemaId, WorkerAssignmentChunk};
-#[cfg(test)]
-use super::{SchedulerStorage, StorageError};
 use crate::types::DatasetSchema;
 
 /// Pins the encoding: a future format change becomes a different id, not a silent collision.
@@ -104,15 +102,6 @@ impl SchemaBundle {
             schemas,
             read_schemas,
         }
-    }
-
-    /// For tests; production takes the bundle from `run_scheduling_cycle`.
-    #[cfg(test)]
-    pub(crate) fn generate(storage: &impl SchedulerStorage) -> Result<Self, StorageError> {
-        Ok(Self::from_sections(
-            storage.active_schema_bundle()?,
-            storage.active_read_schemas()?,
-        ))
     }
 
     pub fn id(&self) -> BundleId {

--- a/src/scheduler_storage/schema_bundle.rs
+++ b/src/scheduler_storage/schema_bundle.rs
@@ -154,17 +154,87 @@ impl SchemaBundle {
         self.read_schemas.contains_key(&id)
     }
 
-    /// The chunk's `<table>.parquet` files from its pinned schema and `tables_present` bitmap.
-    /// `None` if the schema is absent from the bundle (an invariant violation the caller surfaces).
-    pub fn chunk_files(&self, chunk: &WorkerAssignmentChunk) -> Option<Vec<String>> {
-        self.schemas
-            .get(&chunk.schema_id)
-            .map(|schema| chunk_files(schema, chunk.tables_present.as_ref()))
+    /// The chunk's `<table>.parquet` files, from its pinned schema and `tables_present` bitmap.
+    ///
+    /// The bitmap is positional over the pinned schema's tables in sorted-name order, so it is only
+    /// meaningful against the exact schema it was resolved under. A length disagreement proves it
+    /// is being read against a different table list and is refused — see
+    /// [`ChunkFilesError::BitmapArity`].
+    pub fn chunk_files(
+        &self,
+        chunk: &WorkerAssignmentChunk,
+    ) -> Result<Vec<String>, ChunkFilesError> {
+        let schema_id = chunk.schema_id;
+        let schema = self
+            .schemas
+            .get(&schema_id)
+            .ok_or(ChunkFilesError::SchemaMissing { schema_id })?;
+        let tables = schema.tables().len();
+        if let Some(bitmap) = chunk.tables_present.as_ref()
+            && bitmap.len() != tables
+        {
+            return Err(ChunkFilesError::BitmapArity {
+                schema_id,
+                bitmap_len: bitmap.len(),
+                tables,
+            });
+        }
+        Ok(chunk_files(schema, chunk.tables_present.as_ref()))
     }
 }
 
-/// A schema's `<table>.parquet` files, filtered by a chunk's table-presence bitmap (`None` = all
-/// tables).
+/// Why a chunk's file set could not be derived. Both variants are invariant violations the caller
+/// surfaces rather than papers over: a wrong file list is worse than none, because the worker acts
+/// on it — a missing file reads as legitimate absence rather than as an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkFilesError {
+    /// The chunk's pinned schema is absent from the bundle, so its file set cannot be described at
+    /// all (the condition ADR 0002 exists to prevent).
+    SchemaMissing { schema_id: SchemaId },
+    /// The presence bitmap's length disagrees with the pinned schema's table count, so its bits
+    /// index a different table list than the one being applied. Reached by re-pinning a chunk to a
+    /// schema with a different table set without recomputing the bitmap: bits would silently shift
+    /// onto the wrong tables, and positions past the end would read as "legitimately absent".
+    BitmapArity {
+        schema_id: SchemaId,
+        bitmap_len: usize,
+        tables: usize,
+    },
+}
+
+impl std::fmt::Display for ChunkFilesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SchemaMissing { schema_id } => write!(
+                f,
+                "chunk pins schema {schema_id}, which is absent from the bundle — its file set \
+                 cannot be derived"
+            ),
+            Self::BitmapArity {
+                schema_id,
+                bitmap_len,
+                tables,
+            } => write!(
+                f,
+                "chunk's tables_present has {bitmap_len} bits but pinned schema {schema_id} has \
+                 {tables} tables — the bitmap was resolved against a different schema, so its bits \
+                 index the wrong tables"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ChunkFilesError {}
+
+/// A schema's `<table>.parquet` files, filtered by a chunk's table-presence bitmap.
+///
+/// `None` = every table present. That sentinel carries no record of which schema produced it, so
+/// unlike an explicit bitmap it cannot be arity-checked: re-pinning a NULL-bitmap chunk to a
+/// *superset* schema silently claims files the chunk does not have. Anything that re-pins must
+/// therefore materialise NULL into an explicit bitmap first.
+///
+/// Precondition: an explicit bitmap's length equals `schema.tables().len()` — checked by
+/// [`SchemaBundle::chunk_files`], the only caller.
 fn chunk_files(schema: &DatasetSchema, bitmap: Option<&bit_vec::BitVec>) -> Vec<String> {
     schema
         .tables()
@@ -236,16 +306,61 @@ mod tests {
         let mask = bit_vec::BitVec::from_fn(3, |i| i != 1);
         assert_eq!(
             b.chunk_files(&chunk(1, Some(mask))),
-            Some(vec![
+            Ok(vec![
                 "blocks.parquet".to_owned(),
                 "transactions.parquet".to_owned(),
             ])
         );
         assert_eq!(
             b.chunk_files(&chunk(99, None)),
-            None,
-            "unknown schema → None"
+            Err(ChunkFilesError::SchemaMissing {
+                schema_id: SchemaId(99)
+            }),
         );
+    }
+
+    /// A bitmap is positional over one exact schema. If its length disagrees with the pinned
+    /// schema's table count it was resolved against a different table list, and applying it anyway
+    /// yields a plausible-but-wrong file set with no error — the failure mode that makes re-pinning
+    /// a chunk to a different table set unsafe. Both directions must be refused.
+    #[test]
+    fn chunk_files_rejects_a_bitmap_of_the_wrong_arity() {
+        let b = bundle(&[(1, schema(&["blocks", "logs", "transactions"]))]);
+
+        // Too short — as if the chunk were written under a 2-table schema and re-pinned to this
+        // one. Previously `transactions` silently read as "legitimately absent".
+        assert_eq!(
+            b.chunk_files(&chunk(1, Some(bit_vec::BitVec::from_elem(2, true)))),
+            Err(ChunkFilesError::BitmapArity {
+                schema_id: SchemaId(1),
+                bitmap_len: 2,
+                tables: 3,
+            }),
+        );
+        // Too long — the extra bits were silently ignored, so a table the chunk does carry could be
+        // dropped and every position after the divergence means the wrong table.
+        assert_eq!(
+            b.chunk_files(&chunk(1, Some(bit_vec::BitVec::from_elem(4, true)))),
+            Err(ChunkFilesError::BitmapArity {
+                schema_id: SchemaId(1),
+                bitmap_len: 4,
+                tables: 3,
+            }),
+        );
+        // Exact arity is the only accepted explicit bitmap.
+        assert_eq!(
+            b.chunk_files(&chunk(1, Some(bit_vec::BitVec::from_elem(3, true))))
+                .map(|files| files.len()),
+            Ok(3),
+        );
+    }
+
+    /// The NULL sentinel has no arity to check, so it is accepted against any schema — the residual
+    /// hazard a re-pin has to close by materialising it into an explicit bitmap first.
+    #[test]
+    fn chunk_files_accepts_the_null_bitmap_against_any_schema() {
+        let b = bundle(&[(1, schema(&["blocks", "logs"]))]);
+        assert_eq!(b.chunk_files(&chunk(1, None)).map(|f| f.len()), Ok(2));
     }
 
     fn write_only(ids: &[i32]) -> BundleId {

--- a/src/scheduler_storage/schema_bundle.rs
+++ b/src/scheduler_storage/schema_bundle.rs
@@ -1,18 +1,33 @@
-//! The dataset schemas the chunks of a worker assignment reference, with a content [`BundleId`]
-//! clients can use to detect changes. Built from the assignment's own chunks and frozen with it —
-//! the two stay paired.
+//! The dataset schemas a published assignment reference, with a content [`BundleId`] clients use
+//! to detect changes. Two sections: the WRITE schemas the assignment's chunks are pinned to (built
+//! from those chunks and frozen with the assignment, so the two can't drift) and the current READ
+//! schemas of the datasets in play.
+//!
+//! The fingerprint covers both, so promoting a read schema moves it — that is what lets a portal
+//! cache the bundle and re-fetch only when the set actually changed.
 
 use std::collections::BTreeMap;
 
 use sha2::{Digest, Sha256};
 
+use super::{ReadSchemaId, SchemaId, WorkerAssignmentChunk};
 #[cfg(test)]
 use super::{SchedulerStorage, StorageError};
-use super::{SchemaId, WorkerAssignmentChunk};
 use crate::types::DatasetSchema;
 
-/// Content id of a [`SchemaBundle`]: SHA-256 over its sorted `schema_id`s. Ids are content-deduped
-/// serials, so equal ids ⇒ equal content — but only within one storage instance, not across DBs.
+/// Domain tag: keeps this fingerprint from colliding with any other SHA-256 over id lists, and
+/// pins the encoding so a future format change is a different id rather than a silent collision.
+const BUNDLE_ID_DOMAIN: &[u8] = b"sqd.schema-bundle.v1";
+
+/// Content id of a [`SchemaBundle`]: SHA-256 over its sorted write- and read-schema ids. Ids are
+/// content-deduped serials, so equal ids ⇒ equal content — but only within one storage instance,
+/// not across DBs.
+///
+/// The two sections are hashed separately, each length-prefixed behind its own tag. `schemas.id`
+/// and `read_schemas.id` are independent `SERIAL`s that hand out the same small integers, so a
+/// flat hash over both would let write-{3} and read-{3} collide; the tags and lengths make the
+/// section a value carries part of its identity. Primary keys are never reused, so an id in an
+/// already-published bundle can never later mean a different schema.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BundleId([u8; 32]);
 
@@ -20,19 +35,25 @@ impl BundleId {
     /// `SchemaBundle` is the only production caller for now, and its ids come pre-sorted from a
     /// `BTreeMap` — order isn't normalized here, so a caller with unsorted ids must sort first
     /// (checked in debug builds).
-    pub(crate) fn from_schema_ids(ids: impl IntoIterator<Item = SchemaId>) -> Self {
-        let ids: Vec<SchemaId> = ids.into_iter().collect();
-        #[cfg(debug_assertions)]
-        {
-            let mut sorted = ids.clone();
-            sorted.sort_unstable();
-            debug_assert_eq!(
-                ids, sorted,
-                "from_schema_ids: caller must pass pre-sorted ids"
-            );
-        }
+    pub(crate) fn from_sections(
+        write_ids: impl IntoIterator<Item = SchemaId>,
+        read_ids: impl IntoIterator<Item = ReadSchemaId>,
+    ) -> Self {
+        let write_ids: Vec<SchemaId> = write_ids.into_iter().collect();
+        let read_ids: Vec<ReadSchemaId> = read_ids.into_iter().collect();
+        debug_assert_sorted(write_ids.iter().map(|id| id.0), "write");
+        debug_assert_sorted(read_ids.iter().map(|id| id.0), "read");
+
         let mut hasher = Sha256::new();
-        for id in &ids {
+        hasher.update(BUNDLE_ID_DOMAIN);
+        hasher.update(b"w");
+        hasher.update((write_ids.len() as u64).to_le_bytes());
+        for id in &write_ids {
+            hasher.update(id.0.to_le_bytes());
+        }
+        hasher.update(b"r");
+        hasher.update((read_ids.len() as u64).to_le_bytes());
+        for id in &read_ids {
             hasher.update(id.0.to_le_bytes());
         }
         Self(hasher.finalize().into())
@@ -58,24 +79,51 @@ impl std::fmt::Debug for BundleId {
     }
 }
 
+/// In debug builds, catch a caller passing ids a `BTreeMap` didn't already sort.
+fn debug_assert_sorted(ids: impl Iterator<Item = i32>, section: &str) {
+    #[cfg(debug_assertions)]
+    {
+        let ids: Vec<i32> = ids.collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        debug_assert_eq!(ids, sorted, "{section} ids must be pre-sorted");
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = (ids, section);
+}
+
+/// Two sections: the WRITE schemas chunks are pinned to (a worker derives a chunk's file set from
+/// them) and the current READ schemas (what a portal validates queries against). They key on
+/// disjoint id spaces and are never interchangeable — see [`BundleId`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaBundle {
     id: BundleId,
     schemas: BTreeMap<SchemaId, DatasetSchema>,
+    read_schemas: BTreeMap<ReadSchemaId, DatasetSchema>,
 }
 
 impl SchemaBundle {
     /// Wrap the assignment's schemas and stamp the content id.
-    pub(crate) fn from_schemas(schemas: BTreeMap<SchemaId, DatasetSchema>) -> Self {
-        let id = BundleId::from_schema_ids(schemas.keys().copied());
-        Self { id, schemas }
+    pub(crate) fn from_sections(
+        schemas: BTreeMap<SchemaId, DatasetSchema>,
+        read_schemas: BTreeMap<ReadSchemaId, DatasetSchema>,
+    ) -> Self {
+        let id = BundleId::from_sections(schemas.keys().copied(), read_schemas.keys().copied());
+        Self {
+            id,
+            schemas,
+            read_schemas,
+        }
     }
 
     /// Snapshot of the in-play schemas for tests; production uses the bundle returned from
     /// `run_scheduling_cycle`.
     #[cfg(test)]
     pub(crate) fn generate(storage: &impl SchedulerStorage) -> Result<Self, StorageError> {
-        Ok(Self::from_schemas(storage.active_schema_bundle()?))
+        Ok(Self::from_sections(
+            storage.active_schema_bundle()?,
+            storage.active_read_schemas()?,
+        ))
     }
 
     pub fn id(&self) -> BundleId {
@@ -86,20 +134,24 @@ impl SchemaBundle {
         &self.schemas
     }
 
+    pub fn read_schemas(&self) -> &BTreeMap<ReadSchemaId, DatasetSchema> {
+        &self.read_schemas
+    }
+
     pub fn get(&self, id: SchemaId) -> Option<&DatasetSchema> {
         self.schemas.get(&id)
+    }
+
+    pub fn get_read(&self, id: ReadSchemaId) -> Option<&DatasetSchema> {
+        self.read_schemas.get(&id)
     }
 
     pub fn contains(&self, id: SchemaId) -> bool {
         self.schemas.contains_key(&id)
     }
 
-    pub fn len(&self) -> usize {
-        self.schemas.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.schemas.is_empty()
+    pub fn contains_read(&self, id: ReadSchemaId) -> bool {
+        self.read_schemas.contains_key(&id)
     }
 
     /// The chunk's `<table>.parquet` files from its pinned schema and `tables_present` bitmap.
@@ -146,7 +198,7 @@ mod tests {
             .iter()
             .map(|(id, s)| (SchemaId(*id), s.clone()))
             .collect();
-        SchemaBundle::from_schemas(schemas)
+        SchemaBundle::from_sections(schemas, BTreeMap::new())
     }
 
     fn chunk(schema_id: i32, tables_present: Option<bit_vec::BitVec>) -> WorkerAssignmentChunk {
@@ -196,26 +248,42 @@ mod tests {
         );
     }
 
+    fn write_only(ids: &[i32]) -> BundleId {
+        BundleId::from_sections(ids.iter().map(|i| SchemaId(*i)), [])
+    }
+
+    fn read_only(ids: &[i32]) -> BundleId {
+        BundleId::from_sections([], ids.iter().map(|i| ReadSchemaId(*i)))
+    }
+
     #[test]
     fn bundle_id_is_content_addressed() {
         // Deterministic and set-sensitive.
-        assert_eq!(
-            BundleId::from_schema_ids([SchemaId(1), SchemaId(2)]),
-            BundleId::from_schema_ids([SchemaId(1), SchemaId(2)]),
-        );
+        assert_eq!(write_only(&[1, 2]), write_only(&[1, 2]));
+        assert_ne!(write_only(&[1]), write_only(&[1, 2]));
+        assert_ne!(write_only(&[1]), write_only(&[2]));
+    }
+
+    /// The two id spaces are independent SERIALs handing out the same integers, so the fingerprint
+    /// must distinguish which section an id sits in — otherwise promoting a read schema whose id
+    /// happens to match a write id would leave the bundle looking unchanged.
+    #[test]
+    fn bundle_id_separates_the_two_sections() {
+        assert_ne!(write_only(&[3]), read_only(&[3]));
         assert_ne!(
-            BundleId::from_schema_ids([SchemaId(1)]),
-            BundleId::from_schema_ids([SchemaId(1), SchemaId(2)]),
+            BundleId::from_sections([SchemaId(1)], [ReadSchemaId(2)]),
+            BundleId::from_sections([SchemaId(1), SchemaId(2)], []),
         );
+        // Adding a read schema moves the fingerprint even though the write section is untouched.
         assert_ne!(
-            BundleId::from_schema_ids([SchemaId(1)]),
-            BundleId::from_schema_ids([SchemaId(2)]),
+            write_only(&[1]),
+            BundleId::from_sections([SchemaId(1)], [ReadSchemaId(1)]),
         );
     }
 
     #[test]
-    #[should_panic(expected = "caller must pass pre-sorted ids")]
-    fn from_schema_ids_rejects_unsorted_input() {
-        BundleId::from_schema_ids([SchemaId(2), SchemaId(1)]);
+    #[should_panic(expected = "read ids must be pre-sorted")]
+    fn from_sections_rejects_unsorted_input() {
+        BundleId::from_sections([], [ReadSchemaId(2), ReadSchemaId(1)]);
     }
 }

--- a/src/scheduler_storage/test_harness/utils.rs
+++ b/src/scheduler_storage/test_harness/utils.rs
@@ -35,6 +35,17 @@ pub fn dataset(name: &str) -> String {
     format!("s3://{name}")
 }
 
+/// A schema with the named tables, each with no fields — enough to exercise table-set membership
+/// and the bundle's content-dedup without pinning field lists.
+pub fn schema_with_tables(tables: &[&str]) -> DatasetSchema {
+    DatasetSchema::new(
+        tables
+            .iter()
+            .map(|t| ((*t).to_owned(), crate::types::TableSchema::default()))
+            .collect(),
+    )
+}
+
 /// A [`NewDataset`] for the trait's `insert_new_datasets`. These fixtures keep `location == name`
 /// (both the `s3://`-prefixed string), matching how [`chunk`] references its dataset.
 pub fn new_dataset(name: &str, schema: DatasetSchema) -> NewDataset {

--- a/tools/reshuffle_sim/src/multistep.rs
+++ b/tools/reshuffle_sim/src/multistep.rs
@@ -239,7 +239,7 @@ impl MultistepScheduler {
             self.clock,
             M_TICKS,
         ) {
-            Ok((assignment, _bundle)) => assignment,
+            Ok(assignment) => assignment,
             Err(StorageError::Shortage) => {
                 return Ok(CycleResult::Shortage(
                     "scheduling shortage: worker capacity cannot satisfy all replication floors \


### PR DESCRIPTION
# What is this PR about?

Read schemas — what a portal validates queries against — never reached the schema bundle, and `BundleId` hashed write-schema ids only, so promoting one changed nothing observable. Fixing that surfaced a second, worse gap: the bundle was only built when placement succeeded, so during a capacity shortage a newly promoted read schema could stay unpublishable indefinitely while the visibility cycle kept telling portals to use it. This PR closes both.

### The bundle carries read schemas

- `SchemaBundle` gains a read section, kept separate from the write map — `schemas.id` and `read_schemas.id` are independent SERIALs that hand out the same integers. `BundleId` hashes both sections behind per-section tags, so a promote moves the fingerprint; that movement is what lets a portal cache the bundle and re-fetch only when something changed.
- `PortalAssignment` carries `read_schemas: BTreeMap<DatasetId, Option<ReadSchemaId>>` — resolved inside the visibility transaction, with an entry for every dataset its chunks name (`None` = never promoted, distinct from a lookup failure). The chunk fetch and overlap eviction moved inside that transaction, so the whole artifact is committed as one unit.

### The bundle is produced every round, shortage or not

- Bundle generation moved out of `run_scheduling_cycle` into a standalone `generate_schema_bundle(&self)`, built from committed database rows only — the result is the same whether the last cycle placed, failed on capacity, or the process restarted in between. `run_scheduling_cycle` returns just the `WorkerAssignment`; `Err(Shortage)` is unchanged.
- New table `sched_worker_assignment_schemas`: the write-schema ids the last successful round's bundle covered — a few hundred ids, computed from data the cycle already holds in memory (never by re-scanning the placement tables) and committed **in the same transaction as the assignment**. A capacity shortage returns before this write, so the set stays frozen together with the assignment it describes. The generator combines it with the read pointers as they are *now*, which is how a promote reaches the very next bundle even while placement keeps failing. The table's foreign key also means a schema row still referenced by the published assignment cannot be hard-deleted later.
- The generator initially also scanned chunk metadata for the same ids; that scan was proven redundant (a chunk can only enter the covered set through a successful cycle, which also refreshes the table) and removed. Generation now reads a few hundred rows by primary key.

### Tests can now catch this class of bug

- The simulation gained a promote-read-schema action that can land between cycles, as ingesters do in production, and a strict check: every read schema a portal is told to use must be resolvable in the bundle published alongside. Any violation fails the test run — the temporary exemption that kept the suites green while the bug was open is deleted.
- The shortage regression was found by the property tests themselves: with the exemption removed, the churn simulation failed on its first case, and the failing sequence was automatically shrunk to seven steps under genuine capacity pressure. That sequence is recorded as a permanent test (in-memory and Postgres variants). Re-introducing the old freeze makes it fail again with the original error, so the test genuinely guards the fix.
- `chunk_files` now returns `Result` and rejects a `tables_present` bitmap whose length disagrees with the pinned schema's table count — previously that produced a plausible but wrong file list with no error. Every error variant has a test that triggers it.

### Hardening along the way

- `promote_read_schema` and `load_schemas` are compiled only for tests (`#[cfg(test)]`): production code has no write access to the read registry, keeping the metadata service its single writer.
- Schema lookups in the generator fail loudly if a referenced row is missing, instead of silently producing a smaller bundle — relevant once rows can be deleted.
- A dataset placed for the first time in a cycle was missing from that round's bundle; found by the Postgres simulations, fixed, and covered by a dedicated test.
- The per-chunk id collection uses a hash set (millions of inserts, a few hundred distinct values), and the visibility cycle resolves read-schema ids with an indexed lookup instead of a per-dataset existence scan (measured: 2 pages read instead of ~350 on a 50K-chunk fixture).
- `docs/schema-bundle-lifecycle.md`, ADR-0002 and `docs/mvcc-schema.md` updated to the new behaviour; the API contract is documented once, on the trait.

### Not included, on purpose

- Publishing the bundle (a pointer in `network_state`) is handled separately.
- The partial index for the portal-visible predicate on `sched_chunk_metadata` stays deferred — the generator no longer needs it; `fetch_portal_visible_chunks` pays the same scan it did before this PR.
- Re-pinning a chunk's write schema and merging the two schema id spaces were analysed and deferred.

### Testing

170 storage tests, 98 simulation tests (all property sweeps with the strict check), `cargo check --workspace --all-targets` clean, clippy clean. A one-hour continuous property-test run (62 iterations over both backends, fresh randomness each iteration) passed against the mid-branch state.
