### PR TITLE
feat(multistep): Long-running scheduler service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,6 +2988,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-s3",
+ "axum",
  "bit-vec",
  "bytesize",
  "chrono",
@@ -3028,6 +3029,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 [features]
 default = []
 # The MVCC chunk-lifecycle storage / multi-step scheduler (Postgres backend + sim tests).
-mvcc-chunks = ["dep:sqlx", "dep:bit-vec", "dep:humantime", "dep:scheduler-metadata", "sqd-assignments/mvcc-chunks"]
+mvcc-chunks = ["dep:sqlx", "dep:bit-vec", "dep:humantime", "dep:scheduler-metadata", "dep:tokio-util", "dep:axum", "sqd-assignments/mvcc-chunks"]
 # Exposes the Postgres testcontainer harness (`scheduler_storage::test_harness::pg_harness`) to other
 # crates — e.g. reshuffle-sim. Implies the Postgres backend. The crate's own tests get the harness via
 # `cfg(test)` + dev-dependencies, so they don't need this feature.
@@ -60,6 +60,8 @@ sqd-assignments = { git = "https://github.com/subsquid/sqd-network.git", rev = "
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }
+tokio-util = { version = "0.7", optional = true }
+axum = { version = "0.8", optional = true }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "parking_lot"] }
 secrecy = { version = "0.10.3", features = ["serde"] }

--- a/crates/metadata-service/src/handlers.rs
+++ b/crates/metadata-service/src/handlers.rs
@@ -187,7 +187,9 @@ pub async fn get_read_schema(
 
 /// Report chunks the ingester has written to storage. A 2xx means durably accepted: the overlap
 /// decision happens in this call (see ADR 0003), so the ingester can safely resume past the
-/// reported range. Re-sending a batch is safe — already-present ids come back as duplicates.
+/// reported range. Admission stays scheduler-side: the chunk is `pending` until the scheduler's
+/// own sweep gives it scheduling metadata. Re-sending a batch is safe — already-present ids come
+/// back as duplicates.
 #[utoipa::path(post, path = "/datasets/{name}/chunks", tag = "chunks",
     params(("name" = String, Path, description = "Dataset name")),
     request_body = InsertChunksRequest,

--- a/crates/scheduler-metadata/migrations/0001_sched_tables.sql
+++ b/crates/scheduler-metadata/migrations/0001_sched_tables.sql
@@ -270,3 +270,14 @@ CREATE OR REPLACE TRIGGER chunk_corrections_same_dataset
 CREATE INDEX IF NOT EXISTS chunk_corrections_pending_by_new_chunk
     ON chunk_corrections (new_chunk_pk)
     WHERE applied_at_portal_assignment_id IS NULL;
+
+-- Leadership fencing. `epoch` is the token: a leader bumps it when it connects, and every
+-- scheduler write transaction re-reads it FOR SHARE, so a demoted instance's writes are refused
+-- instead of racing the new leader's. leader_pid is diagnostics only — pids get reused.
+CREATE TABLE IF NOT EXISTS sched_leadership (
+    only_row   BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (only_row),  -- PK + CHECK: at most one row
+    epoch      BIGINT  NOT NULL DEFAULT 0,
+    leader_pid INTEGER
+);
+
+INSERT INTO sched_leadership DEFAULT VALUES ON CONFLICT DO NOTHING;

--- a/crates/scheduler-metadata/src/error.rs
+++ b/crates/scheduler-metadata/src/error.rs
@@ -13,6 +13,10 @@ pub enum StorageError {
     #[error("another scheduler instance is already running for this database")]
     AlreadyRunning,
 
+    /// Lost leadership: a newer instance claimed the epoch. The connection is healthy; retrying is wrong.
+    #[error("fenced out: another scheduler instance claimed a newer leadership epoch")]
+    FencedOut,
+
     #[error("database error: {0:#}")]
     Database(anyhow::Error),
 
@@ -97,11 +101,13 @@ impl From<StorageError> for IngestError {
             StorageError::Database(err) => Self::Database(err),
             StorageError::LockTimeout => Self::DatasetBusy,
             // None of these arise on ingest paths: PgIngest runs no cycle, takes no singleton lock,
-            // inserts ON CONFLICT DO NOTHING, and Serialization is intercepted as ConcurrentSchemaChange
-            // in promote_read_schema's REPEATABLE READ tx. Folded to Database, but listed explicitly
-            // (not `_`) so a new StorageError variant breaks the build instead of silently 500ing.
+            // holds no leadership epoch, inserts ON CONFLICT DO NOTHING, and Serialization is
+            // intercepted as ConcurrentSchemaChange in promote_read_schema's REPEATABLE READ tx.
+            // Folded to Database, but listed explicitly (not `_`) so a new StorageError variant
+            // breaks the build instead of silently 500ing.
             e @ (StorageError::Shortage
             | StorageError::AlreadyRunning
+            | StorageError::FencedOut
             | StorageError::ChunkAlreadyExists
             | StorageError::Serialization) => Self::Database(anyhow::Error::new(e)),
         }

--- a/crates/scheduler-metadata/src/pg/rows.rs
+++ b/crates/scheduler-metadata/src/pg/rows.rs
@@ -29,12 +29,12 @@ pub(crate) fn is_unique_violation(err: &sqlx::Error) -> bool {
 }
 
 /// SQLSTATE `40001` (`serialization_failure`); `sqlx::ErrorKind` has no variant for it, so match the code directly.
-pub(crate) fn is_serialization_failure(err: &sqlx::Error) -> bool {
+pub fn is_serialization_failure(err: &sqlx::Error) -> bool {
     err.as_database_error().and_then(|db| db.code()).as_deref() == Some("40001")
 }
 
 /// SQLSTATE `55P03` (`lock_not_available`): a `lock_timeout` expiry, matched by code like `40001` above.
-pub(crate) fn is_lock_timeout(err: &sqlx::Error) -> bool {
+pub fn is_lock_timeout(err: &sqlx::Error) -> bool {
     err.as_database_error().and_then(|db| db.code()).as_deref() == Some("55P03")
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,14 +31,15 @@ work. **This page is the single source of truth for what is actually built and w
 6. **[assignment-wire-format.md](assignment-wire-format.md)** — what the split worker/portal
    assignments should actually carry on the wire, traced against real consumers in worker-rs and
    sqd-portal.
-7. **[metadata-service.md](metadata-service.md)** — the ingestion write path: a shared crate owning
-   the ingest SQL, and an HTTP service in front of it, so ~300 ingesters don't each talk to
-   Postgres directly.
+7. **[metadata-service-api.md](metadata-service-api.md)** — the ingestion write path: a shared
+   crate owning the ingest SQL, and an HTTP service in front of it, so ~300 ingesters don't each
+   talk to Postgres directly.
 
 ## Status & limitations
 
 **The whole subsystem is a work in progress: gated behind the `mvcc-chunks` cargo feature, driven
-only by the simulation harness and tests, and *not* wired into the production `controller.rs`.**
+by the simulation harness, tests, and a compute-and-log service skeleton (`RunMode::Service`) —
+*not* wired into the production `controller.rs`.**
 Production still runs the legacy scheduler in `src/scheduling.rs` (analysed in
 [chunk-reshuffling.md](chunk-reshuffling.md)).
 
@@ -54,14 +55,14 @@ built.
 | Chunk corrections (1-to-1 same-range swaps) | ✅ | Both backends; property-tested. |
 | Deferred removal / stale mappings (`ideal ∪ stale`) | ✅ | Both backends. |
 | Capacity-aware placement (footprint charge, credit-held-free, bounded-load spill, essentials-first) | ✅ | `Reconcile` in `multistep_scheduler/mod.rs`. |
-| X% promotion threshold (quorum) | 🧪 | Computed by the sim's worker fleet; the storage core only consumes a precomputed confirmation watermark. No production quorum logic. |
+| X% promotion threshold (quorum) | ✅ | Production quorum in the service's worker-status task: watermark = highest assignment id echoed (`last_applied_assignment_id` ping column, collector's `mvcc-chunks` build) by ≥X% of online workers, `--confirmation-quorum-pct` (default 90; 0 = confirm latest unconditionally). End-to-end inert until assignments are published — workers can't echo ids they never received. The storage core still just consumes the computed watermark. |
 | Replica-sufficiency **drain gate** (capacity-aware "rule 2") | 📐 | Drains expire on the M-tick timer only. |
 | Replica-sufficiency **promotion gate** (capacity-aware "rule 3") | 📐 | Promotion is gated on assignment confirmation, not on a confirmed-copy count. |
 | Production wiring (`controller.rs`) | 📐 | Subsystem is sim-only behind `mvcc-chunks`. |
 | Worker/portal assignment content divergence | 📐 | Both wire formats still encode the identical legacy blob. See [assignment-wire-format.md](assignment-wire-format.md). |
 | Backpressure / under-replication observability counters | 📐 | `NotEnoughCapacity` error exists; the per-cycle metrics surface does not. |
 | Non-overlap enforcement (no overlapping chunk ranges per dataset) | ✅ | Registration-time rejection + promotion backstop, both backends. See [nonoverlap-promotion-gate.md](nonoverlap-promotion-gate.md). |
-| Ingestion write path (shared crate + metadata service) | 📐 | The storage's ingestion entry points have no production caller. See [metadata-service.md](metadata-service.md). |
+| Ingestion write path (shared crate + metadata service) | ✅ | `crates/metadata-service`, integration-tested; not yet deployed. Admission stays scheduler-side (`register_new_chunks`); the scheduler-side corrections half has no service caller. See [metadata-service-api.md](metadata-service-api.md). |
 
 ### Known limitations and open questions
 

--- a/docs/metadata-service-api.md
+++ b/docs/metadata-service-api.md
@@ -21,7 +21,7 @@ Responses:
 
 ## `POST /datasets/{name}/chunks`
 
-Report chunks the ingester has written to storage. A 2xx means durably accepted: the overlap decision happens in this call (see ADR 0003), so the ingester can safely resume past the reported range. Re-sending a batch is safe — already-present ids come back as duplicates.
+Report chunks the ingester has written to storage. A 2xx means durably accepted: the overlap decision happens in this call (see ADR 0003), so the ingester can safely resume past the reported range. Admission stays scheduler-side: the chunk is `pending` until the scheduler's own sweep gives it scheduling metadata. Re-sending a batch is safe — already-present ids come back as duplicates.
 
 Path parameters:
 - `name` (string) — Dataset name

--- a/docs/mvcc-schema.md
+++ b/docs/mvcc-schema.md
@@ -1,6 +1,6 @@
 # MVCC storage — schema reference
 
-Table definitions live in `crates/scheduler-metadata/migrations/0001_sched_tables.sql`. The protocol these tables serve is
+Table definitions live in `crates/scheduler-metadata/migrations/`. The protocol these tables serve is
 described in [mvcc-storage.md](mvcc-storage.md).
 
 **Time is logical ticks, not wall-clock.** Every `created_at` / `marked_for_removal` /
@@ -23,7 +23,7 @@ a logical grace window, not minutes.
   climbs; narrowing it would save ~4% of what the other two do and puts an unrecoverable wrap at
   the end of the road.
 
-**Single scheduler.** Only one scheduler instance may operate at a time, enforced by a Postgres
+**Single scheduler.** Only one scheduler instance may operate at a time, admitted by a Postgres
 advisory lock acquired at startup:
 
 ```sql
@@ -33,10 +33,13 @@ SELECT pg_try_advisory_lock(hashtext('network-scheduler:' || current_database())
 `true` = acquired; `false` = another scheduler holds it (the backend returns
 `StorageError::AlreadyRunning`). Released automatically when the connection closes.
 
+The lock is admission, not enforcement: write exclusivity rests on the
+[sched_leadership](#sched_leadership) epoch, which every scheduler write transaction verifies.
+
 ## Shared tables
 
-Shared across the ingester, backfill process, and the scheduler. Chunk data is immutable after
-insertion.
+Shared between the ingestion write path (metadata-service) and the scheduler. Chunk data is
+immutable after insertion.
 
 ### datasets
 
@@ -79,10 +82,10 @@ CREATE TABLE schemas (
 
 ### chunks
 
-Chunk catalog. The ingester inserts new chunks here; the backfill process also inserts replacement
-chunks here atomically as part of `register_correction` (see [chunk_corrections](#chunk_corrections)
-below). `registered_at` is the only wall-clock column in the schema — set by the ingester at
-insertion time, outside the scheduler's logical-tick model.
+Chunk catalog. The ingestion write path inserts new chunks — reorg corrections insert replacement
+chunks atomically with their [chunk_corrections](#chunk_corrections) link — and the scheduler's
+chunk discovery inserts chunks found in S3. `registered_at` is the only wall-clock column in the
+schema — set at insertion time, outside the scheduler's logical-tick model.
 
 ```sql
 CREATE TABLE chunks (
@@ -125,10 +128,10 @@ future MVCC assignment builder needn't recover them from S3. `registered_at` is 
 
 ### chunk_corrections
 
-Written by the backfill process via the scheduler's `register_correction` API, which atomically
-inserts the replacement chunk into `chunks` and the correction record here. The scheduler reads
-pending rows during the visibility cycle and stamps `applied_at_portal_assignment_id` when the
-correction fires. See [mvcc-storage.md](mvcc-storage.md), "Corrections".
+Written by the ingestion write path, atomically with the replacement chunk's `chunks` row. The
+scheduler reads pending rows during the visibility cycle and stamps
+`applied_at_portal_assignment_id` when the correction fires. See
+[mvcc-storage.md](mvcc-storage.md), "Corrections".
 
 ```sql
 CREATE TABLE chunk_corrections (
@@ -172,8 +175,8 @@ with `CorrectionRejected` (see [nonoverlap-promotion-gate.md](nonoverlap-promoti
 
 ## Scheduler tables
 
-All `sched_*` tables are written exclusively by the scheduler. No external process reads or writes
-them directly.
+All `sched_*` tables are written exclusively by the scheduler; other processes may read some of
+the metadata for debugging purposes.
 
 **Two id sequences.** Worker and portal assignments are independent streams, so each has its own
 sequence and every referencing column targets exactly one of them. This makes the distinction
@@ -195,6 +198,24 @@ CREATE TABLE sched_portal_assignments (
     confirmed_up_to INT    NOT NULL
 );
 ```
+
+### sched_leadership
+
+The fencing token, one row, seeded by the migration. Each scheduler that wins the startup lock
+bumps `epoch`; every scheduler write transaction then re-reads it `FOR SHARE` and aborts
+(`StorageError::FencedOut`) if it no longer matches the epoch that transaction's writer started
+under. So a superseded instance cannot write behind a live leader's back, and the row lock makes a
+new leader's claim wait for in-flight writes. Reads are not fenced.
+
+```sql
+CREATE TABLE sched_leadership (
+    only_row   BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (only_row),  -- PK + CHECK: at most one row
+    epoch      BIGINT  NOT NULL DEFAULT 0,
+    leader_pid INTEGER
+);
+```
+
+`leader_pid` is diagnostics only — pids get reused, so it identifies nothing by itself.
 
 ### sched_chunk_metadata
 
@@ -247,11 +268,11 @@ scope and the anchor's storage differ:
 ### sched_workers
 
 Worker registry. The scheduler periodically syncs the active set from ClickHouse: new workers are
-inserted, returning workers reactivated (`inactive_since` → NULL), absent workers marked stale
-(`inactive_since` set), and workers stale past a GC horizon are deleted. When a worker is marked
-departed (absent from the active set) its `sched_stale_mappings` rows are deleted too (no point
-draining for a worker that no longer serves) — done on departure-detection in `update_worker_set`,
-ahead of the eventual GC of the worker row.
+inserted, returning workers reactivated (`inactive_since` → NULL), absent workers marked inactive
+(`inactive_since` set). Cleanup is keyed on that state: inactive workers' `sched_stale_mappings`
+rows are deleted by the next scheduling cycle (no point draining for a worker that no longer
+serves), and worker rows inactive past the GC horizon are deleted (leftover stale rows cascade
+with them).
 
 ```sql
 CREATE TABLE sched_workers (

--- a/docs/mvcc-storage.md
+++ b/docs/mvcc-storage.md
@@ -30,8 +30,9 @@ two id tables, so a mix-up is caught at code-review time, not by the engine.
 ## Invariants
 
 1. **Single scheduler.** Only one scheduler instance may compute assignments at a time.
-   Concurrent schedulers would corrupt the lifecycle state. Enforced by a Postgres advisory lock
-   acquired at startup (see [mvcc-schema.md](mvcc-schema.md)).
+   Concurrent schedulers would corrupt the lifecycle state. Enforced by a leadership epoch checked
+   inside every write transaction, behind a startup advisory lock (see
+   [mvcc-schema.md](mvcc-schema.md)).
 
 2. **Two-phase publishing.** A chunk reaches portals only after workers confirm holding it, and a
    worker deletes data only after portals have stopped routing to it. This is the guarantee the
@@ -200,8 +201,9 @@ treats "pending" as `applied_at_portal_assignment_id IS NULL`, so completed rows
 
 ### Registration
 
-Corrections are registered out of band by the **backfill/ingestion process**, not by the
-scheduler's cycles. That process submits the replacement chunk together with the old chunk it
+Corrections are registered out of band through the ingestion write path (metadata-service), never
+by the scheduler's cycles; the scheduler only consumes them (the visibility cycle applies ready
+corrections). Registration submits the replacement chunk together with the old chunk it
 supersedes; the replacement (in the old chunk's dataset) and the `chunk_corrections` record are
 committed **atomically**.
 
@@ -345,16 +347,19 @@ When a chunk is removed entirely via the chunk-level mechanism (`dropped_from_wo
 set — gate A), its stale rows and ideal row go too; the whole-chunk removal supersedes any per-pair
 holdover.
 
-**Worker departures** (`update_worker_set`): a departed worker's stale rows are dropped — its
-copies left with it — and its ideal rows wait for the next cycle's diff. One guard runs at the
-same moment. A departure shrinks the confirmation quorum, so the watermark can pass an assignment
-whose sole recipients never applied it — a *vacuous* confirmation that step 4's expiry would then
-act on, deleting the fleet's only fetched copy (Invariant 2 broken at pair granularity). So if a
-chunk's committed-ideal holders are now all departed, its active stale holders are **re-promoted**
-into the committed ideal: the superseded copy becomes a first-class holder again — counted by the
-retention floor, never expiring — before Invariant 4's clock can destroy it. Excess copies shed as
-ordinary drains in later cycles; a rejoining recipient re-downloads via the normal confirmed
-handoff.
+**Worker departures**: `update_worker_set` only *marks* them (`inactive_since` — status columns,
+nothing else), so the status sync runs concurrently with a cycle. The mapping consequences are
+settled in phase A of every scheduling cycle, keyed on that state: a departed worker's stale rows
+are dropped — its copies left with it — and its ideal rows wait for the cycle's diff. One guard
+runs at the same moment. A departure shrinks the confirmation quorum, so the watermark can pass an
+assignment whose sole recipients never applied it — a *vacuous* confirmation that step 4's expiry
+would then act on, deleting the fleet's only fetched copy (Invariant 2 broken at pair
+granularity). So if a chunk's committed-ideal holders are now all departed, its active stale
+holders are **re-promoted** into the committed ideal: the superseded copy becomes a first-class
+holder again — counted by the retention floor, never expiring — structurally before step 4's
+expiry runs in the same phase (the rescue precedes the reaper), so Invariant 4's clock can never
+destroy it first. Excess copies shed as ordinary drains in later cycles; a rejoining recipient
+re-downloads via the normal confirmed handoff.
 
 **Publish** (when building the worker assignment): `sched_ideal_chunk_workers` unioned with the
 **entire** `sched_stale_mappings` table (pending and draining), deduplicated per chunk.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,9 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationSeconds, serde_as};
 
-use crate::types::ChunkWeight;
+#[cfg(feature = "mvcc-chunks")]
+use crate::scheduler_storage::postgres::{DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT};
+use crate::types::{ChunkWeight, SchedulingConfig};
 
 #[derive(Parser, Debug)]
 #[command(name = "SQD Network Scheduler")]
@@ -26,8 +28,9 @@ pub struct Args {
     )]
     pub config: PathBuf,
 
-    /// Run mode: prod (with ClickHouse) or cli (with state file)
-    /// Take into account that both modes utilise S3
+    /// Run mode: prod (with ClickHouse), cli (with state file), or service (long-running
+    /// multistep scheduler; `mvcc-chunks` builds only).
+    /// Take into account that all modes utilise S3
     #[arg(short, long, default_value = "prod")]
     pub mode: RunMode,
 
@@ -51,9 +54,9 @@ pub struct Args {
     #[arg(
         long,
         env = "DATABASE_URL",
-        required_if_eq("multistep_scheduler", "true")
+        required_if_eq_any([("multistep_scheduler", "true"), ("mode", "service")])
     )]
-    pub database_url: Option<String>,
+    pub database_url: Option<Secret>,
 
     /// Multistep drain window (the MVCC "M"): how long a dropped `(chunk, worker)` pair keeps being
     /// served after leaving the portal assignment.
@@ -66,6 +69,59 @@ pub struct Args {
     #[cfg(feature = "mvcc-chunks")]
     #[arg(long, env = "MULTISTEP_WORKER_GC", default_value = "24h", value_parser = humantime::parse_duration)]
     pub multistep_worker_gc: Duration,
+
+    /// Service mode: interval between scheduling cycles.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_SCHEDULE_INTERVAL", default_value = "20m", value_parser = humantime::parse_duration)]
+    pub schedule_interval: Duration,
+
+    /// Service mode: interval between worker-set refreshes from ClickHouse.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_WORKER_UPDATE_INTERVAL", default_value = "7m", value_parser = humantime::parse_duration)]
+    pub worker_update_interval: Duration,
+
+    /// Service mode: interval between S3 chunk-discovery passes.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_CHUNK_DISCOVERY_INTERVAL", default_value = "10m", value_parser = humantime::parse_duration)]
+    pub chunk_discovery_interval: Duration,
+
+    /// Service mode: how often an idle task checks that its Postgres connection is still alive,
+    /// so a connection that dies between ticks is caught in seconds rather than at the next tick.
+    /// 0 disables the check.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_CONNECTION_PROBE_INTERVAL", default_value = "30s", value_parser = humantime::parse_duration)]
+    pub connection_probe_interval: Duration,
+
+    /// Service mode: cap on one connection liveness round trip. Exceeding it means the connection
+    /// is gone, which is fatal to the task, so it must comfortably clear a healthy round trip.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_CONNECTION_PING_TIMEOUT", default_value = "5s", value_parser = humantime::parse_duration)]
+    pub connection_ping_timeout: Duration,
+
+    /// Cap on a leadership claim's wait for an in-flight fenced transaction to commit (see
+    /// `DEFAULT_CLAIM_LOCK_TIMEOUT`). Exceeding it surfaces as "already running", i.e. retry as a
+    /// candidate — a hung startup hides worse than a retryable failure.
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_LEADERSHIP_CLAIM_TIMEOUT", default_value_t = DEFAULT_CLAIM_LOCK_TIMEOUT.into())]
+    pub leadership_claim_timeout: humantime::Duration,
+
+    /// Rows per batched write to Postgres — bounds the memory and statement size of the scheduler's
+    /// bulk writes (see `DEFAULT_BATCH_SIZE`).
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_BATCH_SIZE", default_value_t = DEFAULT_BATCH_SIZE)]
+    pub batch_size: usize,
+
+    /// Service mode: address for the ops surface (`/metrics`, `/health`, `/ready`).
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_OPS_ADDR", default_value = "0.0.0.0:9090")]
+    pub ops_addr: std::net::SocketAddr,
+
+    /// Service mode: percentage of online workers that must echo an assignment id in their pings
+    /// before the confirmation watermark advances to it. 0 confirms the latest assignment
+    /// unconditionally (no worker acks — dev/bootstrap only).
+    #[cfg(feature = "mvcc-chunks")]
+    #[arg(long, env = "MULTISTEP_CONFIRMATION_QUORUM_PCT", default_value_t = 90, value_parser = clap::value_parser!(u8).range(..=100))]
+    pub confirmation_quorum_pct: u8,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -74,6 +130,9 @@ pub enum RunMode {
     Prod,
     /// CLI mode with static configuration file
     Cli,
+    /// Long-running multistep (MVCC) scheduler service
+    #[cfg(feature = "mvcc-chunks")]
+    Service,
 }
 
 #[derive(clap::Args, Debug)]
@@ -85,7 +144,7 @@ pub struct S3Args {
     aws_access_key_id: String,
 
     #[arg(env, hide = true)]
-    aws_secret_access_key: String,
+    aws_secret_access_key: Secret,
 
     #[arg(env, hide = true, default_value = "auto")]
     aws_region: String,
@@ -93,14 +152,14 @@ pub struct S3Args {
 
 #[derive(clap::Args, Debug)]
 pub struct ClickhouseArgs {
-    #[arg(long, env, required_if_eq("mode", "prod"))]
+    #[arg(long, env, required_if_eq_any([("mode", "prod"), ("mode", "service")]))]
     pub clickhouse_url: Option<String>,
-    #[arg(long, env, required_if_eq("mode", "prod"))]
+    #[arg(long, env, required_if_eq_any([("mode", "prod"), ("mode", "service")]))]
     pub clickhouse_database: Option<String>,
-    #[arg(long, env, required_if_eq("mode", "prod"))]
+    #[arg(long, env, required_if_eq_any([("mode", "prod"), ("mode", "service")]))]
     pub clickhouse_user: Option<String>,
-    #[arg(long, env, required_if_eq("mode", "prod"))]
-    pub clickhouse_password: Option<String>,
+    #[arg(long, env, required_if_eq_any([("mode", "prod"), ("mode", "service")]))]
+    pub clickhouse_password: Option<Secret>,
 }
 
 impl S3Args {
@@ -123,20 +182,12 @@ pub struct Config {
     #[serde(rename = "worker_inactive_timeout_sec")]
     pub worker_inactive_timeout: Duration,
 
-    #[serde(default)]
-    pub ignore_reliability: bool,
-
-    pub worker_storage_bytes: u64,
+    /// Knobs for both scheduler generations; flattened, so the config-file keys stay top-level
+    /// (`worker_storage_bytes`, `saturation`, `min_replication`, `ignore_reliability`).
+    #[serde(flatten)]
+    pub scheduling: SchedulingConfig,
 
     pub worker_stale_bytes: u64,
-
-    pub min_replication: u16,
-
-    /// The fraction of the worker storage that is actually filled (on average).
-    /// The closer it gets to 1, the less consistent the distribution is.
-    /// Corresponds to `1 / (1 + epsilon)` from this paper:
-    /// https://research.google/blog/consistent-hashing-with-bounded-loads/
-    pub saturation: f64,
 
     pub network: String,
 
@@ -151,7 +202,7 @@ pub struct Config {
     pub scheduler_state_bucket: String,
 
     #[serde(skip_serializing)]
-    pub cloudflare_storage_secret: CloudflareSecret,
+    pub cloudflare_storage_secret: Secret,
 
     #[serde(default = "default_min_worker_version")]
     pub min_supported_worker_version: Version,
@@ -278,25 +329,44 @@ fn default_concurrent_downloads() -> usize {
     20
 }
 
-/// Newtype to give `SecretString` a `Clone` impl, so `Config` can derive `Clone`.
+/// Secret-bearing CLI/config value: `Debug` prints redacted, so it cannot leak into logs.
+/// Newtype over `SecretString` for the `Clone`, serde, and clap integrations it lacks.
 #[derive(Debug, Deserialize)]
 #[serde(transparent)]
-pub struct CloudflareSecret(SecretString);
+pub struct Secret(SecretString);
 
-impl Clone for CloudflareSecret {
+impl Clone for Secret {
     fn clone(&self) -> Self {
         Self(SecretString::from(self.0.expose_secret().to_owned()))
     }
 }
 
-impl CloudflareSecret {
+impl Secret {
     pub fn expose_secret(&self) -> &str {
         self.0.expose_secret()
     }
 }
 
-impl From<String> for CloudflareSecret {
+impl From<String> for Secret {
     fn from(s: String) -> Self {
         Self(SecretString::from(s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the deployed config-file schema: the scheduling knobs are flattened top-level keys,
+    /// and `worker_storage_bytes` maps onto `SchedulingConfig::worker_capacity`.
+    #[test]
+    fn example_config_parses_with_flat_scheduling_keys() {
+        let config: Config =
+            serde_yaml::from_str(include_str!("../examples/scheduler_config.yaml"))
+                .expect("parse the example config");
+        assert_eq!(config.scheduling.worker_capacity, 483_183_820_800);
+        assert_eq!(config.scheduling.min_replication, 2);
+        assert_eq!(config.scheduling.saturation, 0.99);
+        assert!(config.scheduling.ignore_reliability);
     }
 }

--- a/src/clickhouse.rs
+++ b/src/clickhouse.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, str::FromStr, sync::Arc, time::Duration};
 use anyhow::{Context, Result};
 use clickhouse::{Client, Row};
 use itertools::Itertools;
+use libp2p_identity::PeerId;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -64,6 +65,45 @@ fn worker_status(row: &PingRow, version: Option<&Version>, t: &StatusThresholds)
     status
 }
 
+/// [`PingRow`] plus the worker-echoed assignment id.
+#[cfg(feature = "mvcc-chunks")]
+#[derive(Row, Debug, Deserialize)]
+struct MvccPingRow {
+    worker_id: String,
+    version: String,
+    stored_bytes: u64,
+    timestamp: u64,
+    current_epoch: Option<u32>,
+    last_applied_assignment_id: Option<String>,
+}
+
+#[cfg(feature = "mvcc-chunks")]
+impl MvccPingRow {
+    /// Split off the shared ping fields so this path classifies through the same
+    /// [`worker_status`] rule as [`ClickhouseClient::get_active_workers`].
+    fn split(self) -> (PingRow, Option<String>) {
+        (
+            PingRow {
+                worker_id: self.worker_id,
+                version: self.version,
+                stored_bytes: self.stored_bytes,
+                timestamp: self.timestamp,
+                current_epoch: self.current_epoch,
+            },
+            self.last_applied_assignment_id,
+        )
+    }
+}
+
+/// A worker from the latest ping snapshot; `last_applied_assignment_id` is the id the worker
+/// echoed as applied, verbatim (interpreting it is the scheduler's concern).
+#[cfg(feature = "mvcc-chunks")]
+#[derive(Debug)]
+pub struct WorkerPing {
+    pub worker: Worker,
+    pub last_applied_assignment_id: Option<String>,
+}
+
 pub struct ClickhouseClient {
     client: Client,
 }
@@ -89,7 +129,8 @@ impl ClickhouseClient {
             .with_password(
                 args.clickhouse_password
                     .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("ClickHouse password is required"))?,
+                    .ok_or_else(|| anyhow::anyhow!("ClickHouse password is required"))?
+                    .expose_secret(),
             );
         let this = Self { client };
         this.create_tables().await?;
@@ -106,12 +147,6 @@ impl ClickhouseClient {
     ) -> Result<Vec<Worker>> {
         let _timer = crate::metrics::Timer::new("get_active_workers");
 
-        let inactive_threshold = (std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("Failed to get system time")
-            - inactive_timeout)
-            .as_millis() as u64;
-
         let query = format!(
             r"
             SELECT DISTINCT ON (worker_id) worker_id, version, stored_bytes, timestamp, current_epoch
@@ -126,19 +161,14 @@ impl ClickhouseClient {
         // Buffered, not classified inline: the epoch baseline needs every row first.
         let mut rows = Vec::new();
         while let Some(row) = cursor.next().await? {
-            let peer_id = match row.worker_id.parse() {
-                Ok(peer_id) => peer_id,
-                Err(e) => {
-                    tracing::warn!("Failed to parse worker ID \"{}\": {}", row.worker_id, e);
-                    crate::metrics::failure("invalid_peer_id");
-                    continue;
-                }
+            let Some(peer_id) = parse_peer_id(&row.worker_id) else {
+                continue;
             };
             rows.push((peer_id, row));
         }
 
         let thresholds = StatusThresholds {
-            inactive_threshold,
+            inactive_threshold: inactive_threshold(inactive_timeout),
             stale_threshold,
             min_version,
             max_epoch: rows.iter().filter_map(|(_, row)| row.current_epoch).max(),
@@ -171,6 +201,69 @@ impl ClickhouseClient {
         }
 
         crate::metrics::report_workers(&results);
+        Ok(results)
+    }
+
+    /// [`Self::get_active_workers`] plus each worker's echoed `last_applied_assignment_id` —
+    /// the confirmation-gate input. The column exists when the pings collector (see
+    /// subsquid/network-components) is also built with `mvcc-chunks`.
+    #[cfg(feature = "mvcc-chunks")]
+    #[instrument(skip_all)]
+    pub async fn active_worker_pings(&self, config: &Config) -> Result<Vec<WorkerPing>> {
+        let _timer = crate::metrics::Timer::new("active_worker_pings");
+
+        let query = format!(
+            r"
+            SELECT DISTINCT ON (worker_id)
+                worker_id, version, stored_bytes, timestamp, current_epoch,
+                last_applied_assignment_id
+            FROM {PINGS_TABLE}
+            WHERE timestamp >= (SELECT MAX(timestamp) FROM {PINGS_TABLE}) - INTERVAL 1 DAY
+            ORDER BY worker_id, timestamp DESC
+            "
+        );
+
+        let mut cursor = self.client.query(&query).fetch::<MvccPingRow>()?;
+
+        // Buffered, not classified inline: the epoch baseline needs every row first.
+        let mut rows = Vec::new();
+        while let Some(row) = cursor.next().await? {
+            let (ping, last_applied_assignment_id) = row.split();
+            let Some(peer_id) = parse_peer_id(&ping.worker_id) else {
+                continue;
+            };
+            rows.push((peer_id, ping, last_applied_assignment_id));
+        }
+
+        let thresholds = StatusThresholds {
+            inactive_threshold: inactive_threshold(config.worker_inactive_timeout),
+            stale_threshold: config.worker_stale_bytes,
+            min_version: &config.min_supported_worker_version,
+            max_epoch: rows
+                .iter()
+                .filter_map(|(_, ping, _)| ping.current_epoch)
+                .max(),
+            max_epoch_lag: config.max_worker_epoch_lag,
+        };
+
+        let results: Vec<WorkerPing> = rows
+            .into_iter()
+            .map(|(peer_id, ping, last_applied_assignment_id)| {
+                let version = Version::from_str(&ping.version).ok();
+                let status = worker_status(&ping, version.as_ref(), &thresholds);
+                WorkerPing {
+                    worker: Worker {
+                        id: peer_id,
+                        status,
+                        version,
+                    },
+                    last_applied_assignment_id,
+                }
+            })
+            .collect();
+
+        let workers: Vec<Worker> = results.iter().map(|ping| ping.worker.clone()).collect();
+        crate::metrics::report_workers(&workers);
         Ok(results)
     }
 
@@ -250,6 +343,27 @@ impl ClickhouseClient {
     }
 }
 
+/// Ping timestamps older than this (ms since epoch) mean the worker is offline.
+fn inactive_threshold(inactive_timeout: Duration) -> u64 {
+    (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("Failed to get system time")
+        - inactive_timeout)
+        .as_millis() as u64
+}
+
+/// The peer id a ping names, or `None` if it doesn't parse (warned and counted).
+fn parse_peer_id(worker_id: &str) -> Option<PeerId> {
+    match worker_id.parse() {
+        Ok(peer_id) => Some(peer_id),
+        Err(e) => {
+            tracing::warn!("Failed to parse worker ID \"{worker_id}\": {e}");
+            crate::metrics::failure("invalid_peer_id");
+            None
+        }
+    }
+}
+
 #[derive(Row, Debug, Serialize, Deserialize)]
 struct ChunkRow {
     dataset: String,
@@ -323,7 +437,7 @@ mod test {
             clickhouse_url: Some("http://localhost:8123/".to_string()),
             clickhouse_database: Some("logs_db".to_string()),
             clickhouse_user: Some("user".to_string()),
-            clickhouse_password: Some("password".to_string()),
+            clickhouse_password: Some("password".to_string().into()),
         })
         .await
         .expect("Cannot connect to clickhouse");

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -252,12 +252,7 @@ impl WithScheduledChunks {
             scheduling::schedule(
                 &scheduled_chunks,
                 &self.workers,
-                scheduling::SchedulingConfig {
-                    worker_capacity: self.config.worker_storage_bytes,
-                    saturation: self.config.saturation,
-                    min_replication: self.config.min_replication,
-                    ignore_reliability: self.config.ignore_reliability,
-                },
+                self.config.scheduling.clone(),
             )
             .context("Can't schedule chunks")?
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,10 @@ async fn main() -> anyhow::Result<()> {
     match args.mode {
         cli::RunMode::Prod => run_prod_mode(&args, config).await?,
         cli::RunMode::Cli => run_cli_mode(&args, config).await?,
+        #[cfg(feature = "mvcc-chunks")]
+        cli::RunMode::Service => {
+            network_scheduler::multistep_controller::service::run(&args, config).await?
+        }
     }
 
     tracing::info!("Done");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -41,6 +41,12 @@ lazy_static::lazy_static! {
 
     pub static ref FAILURE: Family<Labels, Gauge> = Default::default();
     pub static ref ASSIGNMENT_TIMESTAMP: Gauge = Default::default();
+
+    /// Service mode: per-task heartbeat and leadership, the signals a one-shot run has no use for.
+    /// A task's timestamp stops advancing the moment its work stops completing, whatever the cause,
+    /// so `now - task_last_success` is the one number that makes a wedge visible.
+    pub static ref TASK_LAST_SUCCESS: Family<Labels, Gauge> = Default::default();
+    pub static ref LEADERSHIP_EPOCH: Gauge = Default::default();
 }
 
 // Without the `mvcc-chunks` crate there is no `PhaseTimer`, so `exec_times` is a root-local family
@@ -285,6 +291,17 @@ pub fn register_metrics(network: String) -> Registry {
         "Timestamp of the last assignment",
         Unit::Seconds,
         ASSIGNMENT_TIMESTAMP.clone(),
+    );
+    registry.register_with_unit(
+        "task_last_success",
+        "Unix time of a service task's last completed unit of work",
+        Unit::Seconds,
+        TASK_LAST_SUCCESS.clone(),
+    );
+    registry.register(
+        "leadership_epoch",
+        "Leadership epoch this instance claimed at startup",
+        LEADERSHIP_EPOCH.clone(),
     );
 
     registry

--- a/src/multistep_controller/mod.rs
+++ b/src/multistep_controller/mod.rs
@@ -1,8 +1,14 @@
-//! Multistep (MVCC) scheduling entry point (requires the `mvcc-chunks` feature): runs one
-//! scheduling cycle against Postgres instead of the ordinary `Controller` pipeline.
+//! Multistep (MVCC) scheduling entry points (requires the `mvcc-chunks` feature): the one-shot
+//! [`run`] runs one scheduling cycle against Postgres instead of the ordinary `Controller`
+//! pipeline; [`service`] wraps the same steps in a long-running service of three periodic tasks.
 //!
-//! Only [`SchedulerStorage::run_scheduling_cycle`] runs — no confirmation or visibility cycle yet
-//! (see `docs/README.md`). The resulting assignment is only computed and logged, not published.
+//! The one-shot path runs only [`SchedulerStorage::run_scheduling_cycle`]; the service also
+//! advances the confirmation watermark from worker-echoed ping ids and runs the visibility cycle
+//! (see `tasks`). Assignments are computed and logged, not published (`docs/README.md`).
+
+mod ops;
+pub mod service;
+mod tasks;
 
 use std::{
     collections::{BTreeMap, HashSet},
@@ -30,13 +36,17 @@ pub async fn run(
 ) -> anyhow::Result<()> {
     let database_url = args
         .database_url
-        .as_deref()
+        .as_ref()
         .context("--database-url is required with --multistep-scheduler")?;
 
     tracing::info!("Multistep: scheduling for {} workers", workers.len());
 
-    let mut storage = PostgresStorage::connect(database_url).context("connect to Postgres")?;
-    storage.migrate().context("run Postgres migrations")?;
+    // Its own leader; nothing else connects, so the epoch goes nowhere.
+    let (mut storage, _epoch) = PostgresStorage::connect(
+        database_url.expose_secret(),
+        args.leadership_claim_timeout.into(),
+        args.batch_size,
+    )?;
 
     let watermarks = bootstrap_datasets(&mut storage, config)?;
 
@@ -59,22 +69,19 @@ pub async fn run(
 
     let now = now_ticks();
     storage
-        .update_worker_set(&workers, now, args.multistep_worker_gc.as_secs())
+        .update_worker_set(&workers, now)
         .context("update worker set")?;
+    storage
+        .gc_inactive_workers(now, args.multistep_worker_gc.as_secs())
+        .context("gc inactive workers")?;
 
     let algorithm = MultistepAlgorithm::new(config.datasets.clone());
-    let multistep_config = crate::multistep_scheduler::SchedulingConfig {
-        worker_capacity: config.worker_storage_bytes,
-        saturation: config.saturation,
-        min_replication: config.min_replication,
-        ignore_reliability: config.ignore_reliability,
-    };
     let assignment = {
         let _timer = metrics::Timer::new("multistep:schedule");
         storage
             .run_scheduling_cycle(
                 &algorithm,
-                &multistep_config,
+                &config.scheduling,
                 now,
                 args.multistep_drain_window.as_secs(),
             )
@@ -86,14 +93,13 @@ pub async fn run(
         .context("generate schema bundle")?;
 
     tracing::info!(
-        "Multistep scheduling cycle done: assignment {}, {} chunks placed, replication_by_weight={:?}, \
-         bundle {} ({} write / {} read schemas)",
-        assignment.id,
-        assignment.chunk_workers.len(),
-        assignment.replication_by_weight,
-        bundle.id(),
-        bundle.schemas().len(),
-        bundle.read_schemas().len(),
+        assignment_id = %assignment.id,
+        chunks_placed = assignment.chunk_workers.len(),
+        replication_by_weight = ?assignment.replication_by_weight,
+        schema_bundle_id = %bundle.id(),
+        write_schemas = bundle.schemas().len(),
+        read_schemas = bundle.read_schemas().len(),
+        "Multistep scheduling cycle done"
     );
 
     Ok(())

--- a/src/multistep_controller/ops.rs
+++ b/src/multistep_controller/ops.rs
@@ -1,0 +1,274 @@
+//! The service's operational surface: `/metrics`, `/health`, `/ready`.
+//!
+//! Liveness is the heartbeat rule. Each task stamps [`Heartbeat::beat`] when a unit of work
+//! completes — not when a tick merely runs — so a task that keeps looping while every attempt
+//! fails, or one wedged inside an uncancellable call, both stop advancing their stamp. One number
+//! per task then covers every stall cause without instrumenting each dependency, and `/health`
+//! turns it into the only recovery the service has for a wedge: a restart.
+
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    time::Duration,
+};
+
+use anyhow::Context;
+use axum::{
+    Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use prometheus_client::registry::Registry;
+use tokio_util::sync::CancellationToken;
+
+use super::now_ticks;
+
+/// How far past its own period a task may go before it counts as stalled. Generous because the
+/// action is a process restart: a cycle running 3x its interval is wedged, one running 1.5x is a
+/// big database. A placeholder like the intervals themselves — the exported timestamps are what
+/// alerting should be tuned on.
+const STALL_PERIODS: u32 = 3;
+
+/// One task's last completed unit of work.
+pub struct Heartbeat {
+    task: &'static str,
+    period: Duration,
+    /// Unix seconds; 0 until the first success.
+    last_success: AtomicU64,
+}
+
+impl Heartbeat {
+    pub fn new(task: &'static str, period: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            task,
+            period,
+            last_success: AtomicU64::new(0),
+        })
+    }
+
+    /// Record a completed unit of work.
+    pub fn beat(&self) {
+        let now = now_ticks();
+        self.last_success.store(now, Ordering::Relaxed);
+        crate::metrics::TASK_LAST_SUCCESS
+            .get_or_create(&vec![("task", self.task.to_string())])
+            .set(now as i64);
+    }
+
+    /// `None` while the task has not completed anything yet — startup, not a stall.
+    fn stalled_for(&self, now: u64) -> Option<Duration> {
+        let last = self.last_success.load(Ordering::Relaxed);
+        let budget = self.period * STALL_PERIODS;
+        let age = Duration::from_secs(now.saturating_sub(last));
+        (last != 0 && age > budget).then_some(age)
+    }
+}
+
+/// What the endpoints read. `ready` flips once startup finished; it deliberately says nothing about
+/// leadership, so a future standby replica can report ready while waiting to take over.
+pub struct Ops {
+    registry: Registry,
+    heartbeats: Vec<Arc<Heartbeat>>,
+    ready: AtomicBool,
+}
+
+impl Ops {
+    pub fn new(registry: Registry, heartbeats: Vec<Arc<Heartbeat>>) -> Arc<Self> {
+        Arc::new(Self {
+            registry,
+            heartbeats,
+            ready: AtomicBool::new(false),
+        })
+    }
+
+    pub fn mark_ready(&self) {
+        self.ready.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Serve until `token` is cancelled. Started before the startup passes, so a slow cold start is
+/// visibly not-ready rather than unreachable.
+pub async fn serve(
+    addr: SocketAddr,
+    ops: Arc<Ops>,
+    token: CancellationToken,
+) -> anyhow::Result<()> {
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("bind {addr}"))?;
+    tracing::info!(%addr, "Ops surface listening");
+    let router = Router::new()
+        .route("/metrics", get(metrics))
+        .route("/health", get(health))
+        .route("/ready", get(ready))
+        .with_state(ops);
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move { token.cancelled().await })
+        .await
+        .context("serve the ops surface")
+}
+
+async fn metrics(State(ops): State<Arc<Ops>>) -> Response {
+    match crate::metrics::encode_metrics(&ops.registry) {
+        Ok(body) => (
+            StatusCode::OK,
+            [("content-type", "text/plain; version=0.0.4")],
+            body,
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!(error = format!("{e:#}"), "Failed to encode metrics");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// 503 once any task has stopped completing work for [`STALL_PERIODS`] of its period: the
+/// orchestrator restarts us, which is the only way out of a wedged uncancellable call.
+async fn health(State(ops): State<Arc<Ops>>) -> Response {
+    let now = now_ticks();
+    let stalled: Vec<_> = ops
+        .heartbeats
+        .iter()
+        .filter_map(|hb| hb.stalled_for(now).map(|age| (hb.task, age.as_secs())))
+        .collect();
+    if stalled.is_empty() {
+        return StatusCode::OK.into_response();
+    }
+    tracing::warn!(?stalled, "Task stalled past its budget");
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        format!("stalled: {stalled:?}"),
+    )
+        .into_response()
+}
+
+async fn ready(State(ops): State<Arc<Ops>>) -> StatusCode {
+    if ops.ready.load(Ordering::Relaxed) {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PERIOD: Duration = Duration::from_secs(60);
+
+    #[test]
+    fn a_task_that_never_finished_anything_is_not_stalled() {
+        // Startup: `/health` must not kill an instance still running its first pass.
+        let hb = Heartbeat::new("test", PERIOD);
+        assert_eq!(hb.stalled_for(1_000_000), None);
+    }
+
+    #[test]
+    fn stall_is_reported_only_past_the_budget() {
+        let hb = Heartbeat::new("test", PERIOD);
+        hb.last_success.store(1_000, Ordering::Relaxed);
+        let budget = PERIOD.as_secs() * u64::from(STALL_PERIODS);
+        assert_eq!(hb.stalled_for(1_000 + budget), None, "at the budget");
+        assert_eq!(
+            hb.stalled_for(1_000 + budget + 1).map(|d| d.as_secs()),
+            Some(budget + 1),
+        );
+    }
+
+    #[test]
+    fn a_beat_clears_a_stall() {
+        let hb = Heartbeat::new("test", PERIOD);
+        hb.last_success.store(1_000, Ordering::Relaxed);
+        assert!(hb.stalled_for(1_000_000).is_some());
+        hb.beat();
+        assert_eq!(hb.stalled_for(now_ticks()), None);
+    }
+
+    /// The surface end to end: it serves before readiness is marked, `/ready` flips, `/metrics`
+    /// renders the registry, and `/health` follows the heartbeat rather than the process.
+    #[test]
+    fn the_served_surface_reports_readiness_metrics_and_stalls() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        rt.block_on(async {
+            let hb = Heartbeat::new("scheduling", PERIOD);
+            let ops = Ops::new(
+                crate::metrics::register_metrics("test".to_string()),
+                vec![hb.clone()],
+            );
+            let token = CancellationToken::new();
+            // Port 0: the OS picks a free one, so concurrent tests never collide.
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind");
+            let addr = listener.local_addr().expect("local addr");
+            drop(listener);
+            let server = tokio::spawn(serve(addr, ops.clone(), token.clone()));
+
+            // A raw GET keeps an HTTP client out of the dependency tree for one test.
+            let get = async |path: &str| {
+                use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+                loop {
+                    // The server may not have bound yet.
+                    let Ok(mut sock) = tokio::net::TcpStream::connect(addr).await else {
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        continue;
+                    };
+                    sock.write_all(
+                        format!("GET {path} HTTP/1.1\r\nHost: ops\r\nConnection: close\r\n\r\n")
+                            .as_bytes(),
+                    )
+                    .await
+                    .expect("send request");
+                    let mut raw = String::new();
+                    sock.read_to_string(&mut raw).await.expect("read response");
+                    let (head, body) = raw.split_once("\r\n\r\n").expect("headers end");
+                    let status: u16 = head
+                        .split_whitespace()
+                        .nth(1)
+                        .and_then(|s| s.parse().ok())
+                        .expect("status line");
+                    return (status, body.to_string());
+                }
+            };
+
+            assert_eq!(
+                get("/ready").await.0,
+                503,
+                "not ready until startup finishes"
+            );
+            ops.mark_ready();
+            assert_eq!(get("/ready").await.0, 200);
+
+            assert_eq!(get("/health").await.0, 200, "no beat yet is not a stall");
+            hb.last_success.store(
+                now_ticks() - PERIOD.as_secs() * u64::from(STALL_PERIODS) - 1,
+                Ordering::Relaxed,
+            );
+            assert_eq!(get("/health").await.0, 503, "a stalled task fails liveness");
+            hb.beat();
+            assert_eq!(get("/health").await.0, 200);
+
+            let (status, body) = get("/metrics").await;
+            assert_eq!(status, 200);
+            assert!(
+                body.contains("scheduler_task_last_success_seconds")
+                    && body.contains("task=\"scheduling\""),
+                "the heartbeat must be exported: {body}"
+            );
+
+            token.cancel();
+            server
+                .await
+                .expect("server task")
+                .expect("graceful shutdown");
+        });
+    }
+}

--- a/src/multistep_controller/service.rs
+++ b/src/multistep_controller/service.rs
@@ -1,0 +1,567 @@
+//! Long-running multistep scheduler service (`RunMode::Service`): three periodic tasks —
+//! scheduling, worker-status, chunk-discovery — each running on its own OS thread and owning its
+//! own Postgres connection (see `tasks/`). The scheduling task is the leader (advisory lock,
+//! migrations, epoch claim) and runs worker GC and the visibility cycle after every scheduling
+//! cycle. The tasks interleave freely — no cross-task lock: each table has a single writing
+//! connection (the ownership map in `scheduler_storage::postgres`), so chunk registration, the
+//! confirmation pass, and the status-only worker-set update all proceed while a long scheduling
+//! cycle runs.
+//!
+//! The worker-status task drives the confirmation gate: quorum over the assignment ids workers
+//! echo in their pings advances the confirmation watermark. Assignments are still only computed
+//! and logged — publishing is not wired yet (see `docs/README.md`).
+
+use std::sync::{Arc, OnceLock};
+
+use anyhow::Context;
+use tokio::{
+    runtime::{Handle, RuntimeFlavor},
+    sync::{oneshot, watch},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    cli,
+    clickhouse::ClickhouseClient,
+    dataset_data_storage::S3Storage,
+    scheduler_storage::{AssignmentId, algorithm::MultistepAlgorithm},
+};
+
+use super::ops::{self, Heartbeat, Ops};
+use super::tasks::{ChunkDiscoveryTask, SchedulingTask, WorkerStatusTask};
+
+/// Runs the service until SIGTERM (clean exit) or a task-thread failure (error exit — the
+/// orchestrator restarts us); ctrl-c exits immediately instead (see [`handle_signals`]).
+///
+/// # Errors
+///
+/// Startup failures (ClickHouse, Postgres connect/migrate — including `AlreadyRunning`), or a
+/// task thread that died mid-flight (fatal storage error or panic).
+pub async fn run(args: &cli::Args, config: cli::Config) -> anyhow::Result<()> {
+    let database_url = args
+        .database_url
+        .clone()
+        .context("--database-url is required in service mode")?;
+    // Loop threads drive their async work (ClickHouse, S3, timers) on this runtime via
+    // `Handle::block_on`; a current-thread runtime has no worker to serve them while `run`
+    // itself is parked.
+    anyhow::ensure!(
+        !matches!(
+            Handle::current().runtime_flavor(),
+            RuntimeFlavor::CurrentThread
+        ),
+        "service mode requires the multi-thread tokio runtime"
+    );
+
+    // Signals are handled before the startup passes, so even a slow cold-start S3 listing shuts
+    // down cleanly.
+    let token = CancellationToken::new();
+    let cause: Arc<OnceLock<Shutdown>> = Arc::new(OnceLock::new());
+    tokio::spawn(handle_signals(token.clone(), cause.clone()));
+
+    // Serving before the startup passes: a slow cold start then reads as not-ready rather than
+    // unreachable, and a startup that wedges is visible instead of silent.
+    let heartbeats = Heartbeats::new(args);
+    let ops = Ops::new(
+        crate::metrics::register_metrics(config.network.clone()),
+        heartbeats.all(),
+    );
+    tokio::spawn(ops::serve(args.ops_addr, ops.clone(), token.clone()));
+
+    let threads = tokio::select! {
+        // Polled in order: a failing task thread cancels the token as it exits, and its startup
+        // error must win over that cancellation.
+        biased;
+        threads = start_tasks(args, config, database_url, &heartbeats, &token, &cause) => match threads {
+            Ok(threads) => threads,
+            Err(e) => {
+                // Unpark any task already waiting (e.g. the scheduling task at its release).
+                // Already-spawned threads are deliberately left unjoined: they exit on the
+                // cancelled token, and a replacement leader's epoch claim refuses whatever they
+                // still try to write in the meantime.
+                token.cancel();
+                return Err(e);
+            }
+        },
+        () = token.cancelled() => {
+            // Deliberately drops the startup future, detaching any threads it spawned (one
+            // may sit in a sync connect, which nothing can interrupt); process exit reaps
+            // them and Postgres cleans up their connections server-side. Their join handles go
+            // with it, so `cause` — not a join — is what separates a requested stop from a task
+            // that died while a later one was still starting. Getting that wrong would exit 0 on
+            // a fatal failure, and `Restart=on-failure` would leave the scheduler down.
+            return startup_cancelled(cause.get());
+        }
+    };
+
+    ops.mark_ready();
+
+    // Every task-thread exit — signal-triggered, fatal, or panic — cancels the token.
+    token.cancelled().await;
+
+    // Thread exit order is unconstrained: a replacement leader's claim fences every connection of
+    // this instance at once, whichever of ours are still open (see `scheduler_storage::postgres`).
+    let joined = tokio::task::spawn_blocking(move || threads.map(|t| (t.name, t.handle.join())))
+        .await
+        .context("join task threads")?;
+    let mut fatal: Option<anyhow::Error> = None;
+    for (name, joined) in joined {
+        let result = joined.unwrap_or_else(|panic| {
+            let msg = panic
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "non-string panic payload".to_string());
+            Err(anyhow::anyhow!("{name} task panicked: {msg}"))
+        });
+        if let Err(e) = result {
+            // The first error is returned (`main` prints its chain); later ones are logged here.
+            if fatal.is_none() {
+                fatal = Some(e);
+            } else {
+                tracing::error!(error = format!("{e:#}"), "Another task failed");
+            }
+        }
+    }
+    match fatal {
+        Some(e) => Err(e),
+        None => {
+            tracing::info!("Service stopped");
+            Ok(())
+        }
+    }
+}
+
+/// Connect ClickHouse and bring up the three task threads: the scheduling task first — it is the
+/// leader, and its epoch is what the other two connect with — parked until released; then the
+/// worker and chunk-discovery tasks, whose startup passes run before they report ready; then the
+/// release, so the first scheduling cycle sees workers and chunks. Returns the threads in join
+/// order.
+async fn start_tasks(
+    args: &cli::Args,
+    config: cli::Config,
+    database_url: cli::Secret,
+    heartbeats: &Heartbeats,
+    token: &CancellationToken,
+    cause: &Arc<OnceLock<Shutdown>>,
+) -> anyhow::Result<[TaskThread; 3]> {
+    let clickhouse = ClickhouseClient::new(&args.clickhouse)
+        .await
+        .context("connect to ClickHouse")?;
+    let config = Arc::new(config);
+    let s3_storage = S3Storage::new(&args.s3.config().await);
+    let handle = Handle::current();
+    let (latest_tx, latest_rx) = watch::channel(0 as AssignmentId);
+    let (start_tx, start_rx) = oneshot::channel();
+
+    let sched = SchedulingTask {
+        database_url: database_url.clone(),
+        claim_lock_timeout: args.leadership_claim_timeout.into(),
+        batch_size: args.batch_size,
+        algorithm: MultistepAlgorithm::new(config.datasets.clone()),
+        config: config.scheduling.clone(),
+        period: args.schedule_interval,
+        drain_window_ticks: args.multistep_drain_window.as_secs(),
+        worker_gc_ticks: args.multistep_worker_gc.as_secs(),
+        latest_published: latest_tx,
+        probe_interval: args.connection_probe_interval,
+        ping_timeout: args.connection_ping_timeout,
+        heartbeat: heartbeats.scheduling.clone(),
+        start: start_rx,
+        handle: handle.clone(),
+        token: token.clone(),
+    };
+    let (sched, epoch) =
+        spawn_task("scheduling", token, cause, move |ready| sched.run(ready)).await?;
+
+    let worker = WorkerStatusTask {
+        database_url: database_url.clone(),
+        epoch,
+        batch_size: args.batch_size,
+        clickhouse,
+        config: config.clone(),
+        period: args.worker_update_interval,
+        quorum_pct: args.confirmation_quorum_pct,
+        latest_published: latest_rx,
+        probe_interval: args.connection_probe_interval,
+        ping_timeout: args.connection_ping_timeout,
+        heartbeat: heartbeats.worker_status.clone(),
+        handle: handle.clone(),
+        token: token.clone(),
+    };
+    let (worker, ()) = spawn_task("worker-status", token, cause, move |ready| {
+        worker.run(ready)
+    })
+    .await?;
+
+    let discovery = ChunkDiscoveryTask {
+        database_url,
+        epoch,
+        batch_size: args.batch_size,
+        s3_storage,
+        config,
+        period: args.chunk_discovery_interval,
+        probe_interval: args.connection_probe_interval,
+        ping_timeout: args.connection_ping_timeout,
+        heartbeat: heartbeats.chunk_discovery.clone(),
+        handle,
+        token: token.clone(),
+    };
+    let (discovery, ()) = spawn_task("chunk-discovery", token, cause, move |ready| {
+        discovery.run(ready)
+    })
+    .await?;
+
+    // Both startup passes are in — release the first scheduling cycle.
+    let _ = start_tx.send(());
+    Ok([worker, discovery, sched])
+}
+
+/// One heartbeat per task, built up front so the ops surface can report staleness from the moment
+/// it starts serving — before the tasks that own them exist.
+struct Heartbeats {
+    scheduling: Arc<Heartbeat>,
+    worker_status: Arc<Heartbeat>,
+    chunk_discovery: Arc<Heartbeat>,
+}
+
+impl Heartbeats {
+    fn new(args: &cli::Args) -> Self {
+        Self {
+            scheduling: Heartbeat::new("scheduling", args.schedule_interval),
+            worker_status: Heartbeat::new("worker-status", args.worker_update_interval),
+            chunk_discovery: Heartbeat::new("chunk-discovery", args.chunk_discovery_interval),
+        }
+    }
+
+    fn all(&self) -> Vec<Arc<Heartbeat>> {
+        vec![
+            self.scheduling.clone(),
+            self.worker_status.clone(),
+            self.chunk_discovery.clone(),
+        ]
+    }
+}
+
+#[derive(Debug)]
+struct TaskThread {
+    name: &'static str,
+    handle: std::thread::JoinHandle<anyhow::Result<()>>,
+}
+
+/// What a cancellation observed during startup means for the exit status. A task that died is a
+/// failure even though the cancellation looks identical to a requested stop: reporting it as clean
+/// would exit 0, and `Restart=on-failure` would leave the scheduler down.
+fn startup_cancelled(cause: Option<&Shutdown>) -> anyhow::Result<()> {
+    match cause {
+        Some(Shutdown::TaskExit(name)) => Err(anyhow::anyhow!("{name} task exited during startup")),
+        None | Some(Shutdown::Signal) => {
+            tracing::info!("Shutdown requested during startup");
+            Ok(())
+        }
+    }
+}
+
+/// Why the service is winding down. Recorded once — the first cause wins, so a task exit that
+/// races SIGTERM still reports the failure, since the exit code is what the orchestrator acts on.
+#[derive(Debug)]
+enum Shutdown {
+    /// SIGTERM: a clean, requested stop.
+    Signal,
+    /// A task thread left: fatal error, panic, or an unexpected clean return.
+    TaskExit(&'static str),
+}
+
+/// Cancels the token when a task thread leaves, recording the task as the cause. A `Drop` impl
+/// rather than a step at the end of the thread body, so a panicking task is attributed too.
+struct ExitGuard {
+    name: &'static str,
+    cause: Arc<OnceLock<Shutdown>>,
+    token: CancellationToken,
+}
+
+impl Drop for ExitGuard {
+    fn drop(&mut self) {
+        let _ = self.cause.set(Shutdown::TaskExit(self.name));
+        self.token.cancel();
+    }
+}
+
+/// Spawn task thread `name` and wait for it to report its startup outcome (connect + startup
+/// pass) plus its ready payload `T` — the scheduling task's leadership epoch, `()` for the rest.
+/// `body` reports startup failures through `ready` — send the `Err`, then return `Ok(())`; its own
+/// result covers only post-startup operation. Any later exit — clean, fatal, or panic — cancels
+/// `token` and records itself in `cause`; the thread's result is collected by [`run`] after
+/// joining, except on the startup-cancellation path, where the handle goes with the dropped future
+/// and `cause` is all that survives.
+async fn spawn_task<T: Send + 'static>(
+    name: &'static str,
+    token: &CancellationToken,
+    cause: &Arc<OnceLock<Shutdown>>,
+    body: impl FnOnce(oneshot::Sender<anyhow::Result<T>>) -> anyhow::Result<()> + Send + 'static,
+) -> anyhow::Result<(TaskThread, T)> {
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let guard = ExitGuard {
+        name,
+        cause: cause.clone(),
+        token: token.clone(),
+    };
+    let handle = std::thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            let _cancel_on_exit = guard;
+            let result = body(ready_tx);
+            if let Err(e) = &result {
+                // Logged here rather than left to `run`: on the startup-cancellation path `run`
+                // never sees this result, and the chain would go with the dropped join handle.
+                tracing::error!(
+                    error = format!("{e:#}"),
+                    "{name} task failed, shutting down"
+                );
+            }
+            result
+        })
+        .with_context(|| format!("spawn {name} thread"))?;
+    // On the error paths the thread has already terminated, so the blocking `join` returns at
+    // once.
+    match ready_rx.await {
+        Ok(Ok(ready)) => Ok((TaskThread { name, handle }, ready)),
+        Ok(Err(e)) => {
+            let _ = handle.join();
+            Err(e)
+        }
+        Err(_) => {
+            let _ = handle.join();
+            Err(anyhow::anyhow!("{name} task thread died during startup"))
+        }
+    }
+}
+
+/// SIGTERM begins the graceful shutdown (cancel the token, drain, join); a repeat is a no-op —
+/// supervisor escalation is SIGKILL, which needs no cooperation. SIGINT (ctrl-c) instead exits
+/// on the spot, whatever the state: the interactive escape hatch must not wait out a possibly
+/// minutes-long, uncancellable drain, and Postgres cleans up dropped connections server-side.
+/// Never returns, so both meanings stay live during a failure-initiated wind-down.
+async fn handle_signals(token: CancellationToken, cause: Arc<OnceLock<Shutdown>>) {
+    let mut signals = ShutdownSignals::install();
+    loop {
+        match signals.recv().await {
+            ShutdownSignal::Interrupt => {
+                tracing::info!("Received ctrl-c, exiting immediately");
+                std::process::exit(1);
+            }
+            ShutdownSignal::Terminate => {
+                tracing::info!("Received SIGTERM, shutting down");
+                request_shutdown(&token, &cause);
+            }
+        }
+    }
+}
+
+/// Begin a requested shutdown. The cause is claimed *before* the cancellation, so the task exits
+/// this unparks cannot overwrite it and turn a clean stop into a reported failure.
+fn request_shutdown(token: &CancellationToken, cause: &OnceLock<Shutdown>) {
+    let _ = cause.set(Shutdown::Signal);
+    token.cancel();
+}
+
+enum ShutdownSignal {
+    /// SIGINT/ctrl-c: exit immediately.
+    Interrupt,
+    /// SIGTERM: graceful shutdown.
+    Terminate,
+}
+
+/// Ctrl-c plus SIGTERM, receivable repeatedly.
+struct ShutdownSignals {
+    sigterm: Option<tokio::signal::unix::Signal>,
+}
+
+impl ShutdownSignals {
+    fn install() -> Self {
+        let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .map_err(|e| tracing::error!(error = %e, "Failed to install SIGTERM handler"))
+            .ok();
+        Self { sigterm }
+    }
+
+    async fn recv(&mut self) -> ShutdownSignal {
+        let terminate = async {
+            match self.sigterm.as_mut() {
+                Some(sigterm) => {
+                    sigterm.recv().await;
+                }
+                None => std::future::pending().await,
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => ShutdownSignal::Interrupt,
+            () = terminate => ShutdownSignal::Terminate,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn test_rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime")
+    }
+
+    fn fresh_cause() -> Arc<OnceLock<Shutdown>> {
+        Arc::new(OnceLock::new())
+    }
+
+    #[test]
+    fn startup_failure_is_reported_through_ready() {
+        test_rt().block_on(async {
+            let token = CancellationToken::new();
+            let result = spawn_task::<()>("test-task", &token, &fresh_cause(), |ready| {
+                let _ = ready.send(Err(anyhow::anyhow!("no database")));
+                Ok(())
+            })
+            .await;
+            let err = result.expect_err("startup error must propagate");
+            assert_eq!(err.to_string(), "no database");
+        });
+    }
+
+    #[test]
+    fn thread_death_before_ready_is_a_startup_error() {
+        test_rt().block_on(async {
+            let token = CancellationToken::new();
+            let result =
+                spawn_task::<()>("test-task", &token, &fresh_cause(), |_ready| Ok(())).await;
+            let err = result.expect_err("a dropped ready channel is a startup failure");
+            assert!(err.to_string().contains("died during startup"));
+        });
+    }
+
+    /// A task exiting after startup — here with a fatal error — cancels the token, winding down
+    /// the sibling tasks, and its result is recovered by joining.
+    #[test]
+    fn task_exit_cancels_the_token() {
+        test_rt().block_on(async {
+            let token = CancellationToken::new();
+            let (thread, ()) = spawn_task("test-task", &token, &fresh_cause(), |ready| {
+                let _ = ready.send(Ok(()));
+                anyhow::bail!("boom")
+            })
+            .await
+            .expect("startup succeeds");
+            tokio::time::timeout(Duration::from_secs(10), token.cancelled())
+                .await
+                .expect("task exit must cancel the token");
+            let err = thread
+                .handle
+                .join()
+                .expect("no panic")
+                .expect_err("fatal task result");
+            assert_eq!(err.to_string(), "boom");
+        });
+    }
+
+    /// The verdict `run`'s startup cancel arm reaches. A task exit and a SIGTERM cancel the same
+    /// token, so only the recorded cause separates exit 1 from exit 0.
+    #[test]
+    fn a_startup_cancellation_reports_a_task_exit_but_not_a_signal() {
+        startup_cancelled(None).expect("no recorded cause reads as a requested stop");
+        startup_cancelled(Some(&Shutdown::Signal)).expect("SIGTERM is a clean exit");
+        let err = startup_cancelled(Some(&Shutdown::TaskExit("worker-status")))
+            .expect_err("a task that died must not exit 0");
+        assert_eq!(err.to_string(), "worker-status task exited during startup");
+    }
+
+    /// The startup race that must not read as an operator shutdown: a task dies after reporting
+    /// ready while `start_tasks` is still awaiting a later one, so `run`'s cancel arm wins and the
+    /// join handle is dropped with the startup future. `cause` is then the only thing standing
+    /// between a fatal failure and an exit code of 0.
+    #[test]
+    fn a_post_ready_task_exit_is_attributed_to_the_task() {
+        test_rt().block_on(async {
+            let token = CancellationToken::new();
+            let cause = fresh_cause();
+            let (_thread, ()) = spawn_task("test-task", &token, &cause, |ready| {
+                let _ = ready.send(Ok(()));
+                anyhow::bail!("boom")
+            })
+            .await
+            .expect("startup succeeds");
+            tokio::time::timeout(Duration::from_secs(10), token.cancelled())
+                .await
+                .expect("task exit must cancel the token");
+            assert!(
+                matches!(cause.get(), Some(Shutdown::TaskExit("test-task"))),
+                "got {:?}",
+                cause.get()
+            );
+        });
+    }
+
+    /// The reason attribution lives in a `Drop` impl: a panicking task never reaches the end of
+    /// its body, and it must still be told apart from a requested shutdown.
+    #[test]
+    fn a_panicking_task_is_attributed_too() {
+        test_rt().block_on(async {
+            let token = CancellationToken::new();
+            let cause = fresh_cause();
+            let (thread, ()) = spawn_task("test-task", &token, &cause, |ready| {
+                let _ = ready.send(Ok(()));
+                panic!("kaboom")
+            })
+            .await
+            .expect("startup succeeds");
+            tokio::time::timeout(Duration::from_secs(10), token.cancelled())
+                .await
+                .expect("a panic must cancel the token");
+            assert!(
+                matches!(cause.get(), Some(Shutdown::TaskExit("test-task"))),
+                "got {:?}",
+                cause.get()
+            );
+            assert!(thread.handle.join().is_err(), "the panic is recoverable");
+        });
+    }
+
+    /// SIGTERM claims the cause before cancelling, so the task exits it unparks cannot turn a
+    /// requested stop into a reported failure — the first cause wins.
+    #[test]
+    fn a_signal_outranks_the_task_exits_it_causes() {
+        test_rt().block_on(async {
+            let token = CancellationToken::new();
+            let cause = fresh_cause();
+            let (thread, ()) = spawn_task("test-task", &token, &cause, {
+                let token = token.clone();
+                move |ready| {
+                    let _ = ready.send(Ok(()));
+                    // Leaves only once cancelled, as a task parked in its tick wait does.
+                    while !token.is_cancelled() {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Ok(())
+                }
+            })
+            .await
+            .expect("startup succeeds");
+
+            // The same call SIGTERM makes, so the claim-before-cancel ordering is what is pinned.
+            request_shutdown(&token, &cause);
+
+            thread
+                .handle
+                .join()
+                .expect("no panic")
+                .expect("a cancelled task exits cleanly");
+            assert!(
+                matches!(cause.get(), Some(Shutdown::Signal)),
+                "got {:?}",
+                cause.get()
+            );
+        });
+    }
+}

--- a/src/multistep_controller/tasks/chunk_discovery.rs
+++ b/src/multistep_controller/tasks/chunk_discovery.rs
@@ -1,0 +1,129 @@
+//! The chunk-discovery task: watermarks → S3 listing → insert + register.
+
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use tokio::{runtime::Handle, sync::oneshot};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    cli,
+    dataset_data_storage::S3Storage,
+    scheduler_storage::postgres::{Epoch, PostgresStorage, SessionMemory},
+    types::{Chunk, DatasetWatermark},
+};
+
+use super::super::ops::Heartbeat;
+use super::super::{bootstrap_datasets, register_chunks};
+use super::{retry_or_die, wait_for_next_tick};
+
+pub struct ChunkDiscoveryTask {
+    pub database_url: cli::Secret,
+    /// The scheduling task's epoch: our writes stop the moment a newer leader claims one.
+    pub epoch: Epoch,
+    pub batch_size: usize,
+    pub s3_storage: S3Storage,
+    pub config: Arc<cli::Config>,
+    pub period: Duration,
+    pub probe_interval: Duration,
+    pub ping_timeout: Duration,
+    pub heartbeat: Arc<Heartbeat>,
+    pub handle: Handle,
+    pub token: CancellationToken,
+}
+
+impl ChunkDiscoveryTask {
+    pub fn run(self, ready: oneshot::Sender<anyhow::Result<()>>) -> anyhow::Result<()> {
+        // The startup pass runs before reporting ready: the first scheduling cycle waits on it.
+        let started = self.startup().and_then(|mut storage| {
+            self.tick(&mut storage)?;
+            Ok(storage)
+        });
+        let mut storage = match started {
+            Ok(storage) => storage,
+            Err(e) => {
+                let _ = ready.send(Err(e));
+                return Ok(());
+            }
+        };
+        let _ = ready.send(Ok(()));
+        while wait_for_next_tick(
+            &self.handle,
+            &self.token,
+            self.period,
+            self.probe_interval,
+            || Ok(storage.ping(self.ping_timeout)?),
+        )?
+        .is_continue()
+        {
+            self.tick(&mut storage)?;
+        }
+        Ok(())
+    }
+
+    fn startup(&self) -> anyhow::Result<PostgresStorage> {
+        // Batched inserts don't need raised session memory.
+        let mut storage = PostgresStorage::connect_follower(
+            self.database_url.expose_secret(),
+            SessionMemory::ServerDefault,
+            self.epoch,
+            self.batch_size,
+        )?;
+        bootstrap_datasets(&mut storage, &self.config)?;
+        Ok(storage)
+    }
+
+    fn tick(&self, storage: &mut PostgresStorage) -> anyhow::Result<()> {
+        let watermarks = match storage.datasets_with_last_chunk() {
+            Ok(watermarks) => watermarks,
+            Err(e) => {
+                return retry_or_die(storage, self.ping_timeout, e, "read dataset watermarks");
+            }
+        };
+        let Some(discovered) = self.handle.block_on(list_newer_chunks(
+            &self.s3_storage,
+            watermarks,
+            &self.config,
+            &self.token,
+        )) else {
+            return Ok(());
+        };
+        let new_chunks = discovered.values().map(Vec::len).sum::<usize>();
+        let datasets = discovered.len();
+        match register_chunks(storage, discovered) {
+            Ok(()) => {
+                tracing::info!(new_chunks, datasets, "Chunk discovery pass done");
+                self.heartbeat.beat();
+            }
+            Err(e) => retry_or_die(storage, self.ping_timeout, e, "register discovered chunks")?,
+        }
+        Ok(())
+    }
+}
+
+/// `None` on shutdown or a (logged) S3 error. The listing can be unbounded
+/// (`dataset_load_timeout` defaults to none), so it is raced against shutdown.
+async fn list_newer_chunks(
+    s3_storage: &S3Storage,
+    watermarks: Vec<DatasetWatermark>,
+    config: &cli::Config,
+    token: &CancellationToken,
+) -> Option<BTreeMap<Arc<String>, Vec<Chunk>>> {
+    let loaded = tokio::select! {
+        () = token.cancelled() => return None,
+        loaded = s3_storage.load_newer_chunks(
+            watermarks,
+            config.concurrent_dataset_downloads,
+            config.dataset_load_timeout,
+        ) => loaded,
+    };
+    match loaded {
+        Ok(discovered) => Some(discovered),
+        Err(e) => {
+            tracing::error!(
+                error = format!("{e:#}"),
+                "Failed to load chunks from S3, retrying next tick"
+            );
+            None
+        }
+    }
+}

--- a/src/multistep_controller/tasks/mod.rs
+++ b/src/multistep_controller/tasks/mod.rs
@@ -1,0 +1,396 @@
+//! The service's three periodic tasks — scheduling, worker-status, chunk-discovery — one module
+//! and one OS thread each. A task owns its `PostgresStorage` outright: created on the task's
+//! thread and called directly, since the sync `block_on` facade must stay off the async runtime.
+//! ClickHouse/S3 futures and cancellable waits are driven on the main runtime through
+//! `Handle::block_on`, so the shared clients never leave the runtime they were built on.
+//!
+//! Failure policy: a failed operation is logged and retried next tick, unless [`retry_or_die`]
+//! finds it fatal — leadership lost to a newer epoch, or the Postgres connection gone — in which
+//! case the task exits (which shuts the service down for an orchestrator restart) instead of
+//! retrying against a database that will refuse it anyway.
+
+mod chunk_discovery;
+mod scheduling;
+mod worker_status;
+
+pub(super) use chunk_discovery::ChunkDiscoveryTask;
+pub(super) use scheduling::SchedulingTask;
+pub(super) use worker_status::WorkerStatusTask;
+
+use std::ops::ControlFlow;
+use std::time::{Duration, Instant};
+
+use tokio::runtime::Handle;
+use tokio_util::sync::CancellationToken;
+
+use crate::scheduler_storage::StorageError;
+use crate::scheduler_storage::postgres::PostgresStorage;
+
+/// A storage operation failed: fatal if a newer leader has taken the epoch (the connection is
+/// healthy, but every write of ours is refused from now on) or if the Postgres connection is gone —
+/// either way the service must exit and restart rather than retry — otherwise logged and retried
+/// next tick.
+pub(super) fn retry_or_die(
+    storage: &mut PostgresStorage,
+    ping_timeout: Duration,
+    error: impl Into<anyhow::Error>,
+    what: &str,
+) -> anyhow::Result<()> {
+    let error = error.into();
+    // Before the liveness probe: being fenced out says nothing about the connection.
+    if matches!(
+        error.downcast_ref::<StorageError>(),
+        Some(StorageError::FencedOut)
+    ) {
+        return Err(error.context(format!("{what}: fenced out by a newer leader")));
+    }
+    if let Err(ping) = storage.ping(ping_timeout) {
+        return Err(error.context(format!("{what}: Postgres connection lost ({ping})")));
+    }
+    tracing::error!(
+        error = format!("{error:#}"),
+        "{what} failed, retrying next tick"
+    );
+    Ok(())
+}
+
+/// Park the task's thread until the next tick (`Continue`) or shutdown (`Break`). The period
+/// restarts after each tick, so an overrunning cycle gets a full breather, not an immediate
+/// re-run.
+///
+/// `probe` runs every `probe_every` of the wait (0 disables it). Without it a connection that dies
+/// while the task sleeps goes unnoticed until the next tick's first statement fails — twenty
+/// minutes for the scheduling task — and the periodic traffic also keeps the connection out of
+/// reach of idle timeouts. A failing probe is fatal, like any other lost connection.
+fn wait_for_next_tick(
+    handle: &Handle,
+    token: &CancellationToken,
+    period: Duration,
+    probe_every: Duration,
+    mut probe: impl FnMut() -> anyhow::Result<()>,
+) -> anyhow::Result<ControlFlow<()>> {
+    let started = Instant::now();
+    loop {
+        let remaining = period.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Ok(ControlFlow::Continue(()));
+        }
+        // The last leg is whatever is left; earlier ones are a probe interval each. Probing after
+        // the last would be pointless — the tick that follows is itself the liveness check.
+        let final_leg = probe_every.is_zero() || remaining <= probe_every;
+        let leg = if final_leg { remaining } else { probe_every };
+        let shutting_down = handle.block_on(async {
+            tokio::select! {
+                () = token.cancelled() => true,
+                () = tokio::time::sleep(leg) => false,
+            }
+        });
+        if shutting_down {
+            return Ok(ControlFlow::Break(()));
+        }
+        if !final_leg {
+            probe()?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+    use crate::scheduler_storage::SchedulerStorage;
+    use crate::scheduler_storage::postgres::{
+        DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT, SessionMemory,
+    };
+    use crate::scheduler_storage::test_harness::pg_harness::fresh_db_url;
+    use crate::scheduler_storage::test_harness::utils::{
+        StaticSchedulingAlgorithm, chunk, new_dataset, worker,
+    };
+    use crate::types::{DatasetSchema, Worker};
+
+    static TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn retry_or_die_is_fatal_only_when_the_connection_is_gone() {
+        use sqlx::Connection as _;
+
+        let (url, _db) = fresh_db_url("tasks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+        let (mut storage, _) =
+            PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("connect");
+        retry_or_die(
+            &mut storage,
+            PING_TIMEOUT,
+            anyhow::anyhow!("op failed"),
+            "test op",
+        )
+        .expect("a live connection retries");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        rt.block_on(async {
+            let mut admin = sqlx::postgres::PgConnection::connect(&url)
+                .await
+                .expect("admin connection");
+            sqlx::query(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+                 WHERE datname = current_database() AND pid <> pg_backend_pid()",
+            )
+            .execute(&mut admin)
+            .await
+            .expect("terminate the task's backend");
+        });
+
+        let err = storage
+            .datasets_with_last_chunk()
+            .expect_err("query on a dead connection must fail");
+        retry_or_die(&mut storage, PING_TIMEOUT, err, "test op")
+            .expect_err("a dead connection is fatal");
+    }
+
+    /// Losing leadership is fatal on a perfectly healthy connection: retrying in place would keep
+    /// hitting a database that now refuses us, so the task must exit and let the orchestrator
+    /// restart it as a fresh candidate.
+    #[test]
+    fn retry_or_die_is_fatal_when_fenced_out_despite_a_live_connection() {
+        let (url, _db) = fresh_db_url("tasks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+        let (leader, epoch) =
+            PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("connect leader");
+        let mut follower = PostgresStorage::connect_follower(
+            &url,
+            SessionMemory::ServerDefault,
+            epoch,
+            DEFAULT_BATCH_SIZE,
+        )
+        .expect("connect follower");
+        drop(leader);
+        let _replacement =
+            PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("replacement leader claims a new epoch");
+
+        let err = follower
+            .update_worker_set(&[worker(1, None)], 100)
+            .expect_err("the stale epoch is refused");
+        let fatal = retry_or_die(&mut follower, PING_TIMEOUT, err, "update worker set")
+            .expect_err("fenced out is fatal");
+        assert!(format!("{fatal:#}").contains("fenced out by a newer leader"));
+
+        // The shape the chunk-discovery task passes in: `FencedOut` under a `.context` layer, which
+        // the downcast must still see.
+        let err = follower
+            .update_worker_set(&[worker(1, None)], 100)
+            .expect_err("the stale epoch is refused");
+        retry_or_die(
+            &mut follower,
+            PING_TIMEOUT,
+            anyhow::Error::new(err).context("register discovered chunks"),
+            "update worker set",
+        )
+        .expect_err("a wrapped FencedOut is just as fatal");
+
+        follower
+            .ping(PING_TIMEOUT)
+            .expect("the connection was never the problem");
+    }
+
+    /// Smoke test for the service's three-connection layout: scheduling cycles (with worker GC,
+    /// as in the scheduling task's tick), chunk ingest, and status-only worker-set updates run
+    /// concurrently on one database — the lock-free ownership-map layout, where each table has a
+    /// single writing connection — and the state stays consistent (every chunk admitted exactly
+    /// once, a final cycle succeeds).
+    #[test]
+    fn cycle_ingest_and_worker_updates_run_concurrently() {
+        const ROUNDS: u32 = 5;
+        let (url, _db) = fresh_db_url("tasks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+        let (mut sched, epoch) =
+            PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("connect leader");
+        let mut ingest = PostgresStorage::connect_follower(
+            &url,
+            SessionMemory::ServerDefault,
+            epoch,
+            DEFAULT_BATCH_SIZE,
+        )
+        .expect("connect ingest");
+        let mut workers = PostgresStorage::connect_follower(
+            &url,
+            SessionMemory::Raised,
+            epoch,
+            DEFAULT_BATCH_SIZE,
+        )
+        .expect("connect worker");
+
+        ingest
+            .insert_new_datasets(vec![new_dataset("actors", DatasetSchema::default())])
+            .expect("create dataset");
+
+        let admitted = std::thread::scope(|scope| {
+            let sched_side = scope.spawn(|| {
+                let algorithm = StaticSchedulingAlgorithm {
+                    mapping: Vec::new(),
+                };
+                for i in 0..ROUNDS {
+                    sched
+                        .run_scheduling_cycle(&algorithm, &(), 100 + u64::from(i), 60)
+                        .expect("scheduling cycle");
+                    sched
+                        .gc_inactive_workers(100 + u64::from(i), 1000)
+                        .expect("gc inactive workers");
+                }
+            });
+            let ingest_side = scope.spawn(|| {
+                let mut admitted = 0usize;
+                for i in 0..ROUNDS {
+                    ingest
+                        .insert_new_chunks(vec![chunk("actors", i, 10)])
+                        .expect("insert chunk");
+                    admitted += ingest.register_new_chunks().expect("register chunks").len();
+                }
+                admitted
+            });
+            let worker_side = scope.spawn(|| {
+                for round in 0..ROUNDS {
+                    let active: Vec<Worker> = (1..=3).map(|s| worker(s, None)).collect();
+                    workers
+                        .update_worker_set(&active, 1000 + u64::from(round))
+                        .expect("update worker set");
+                }
+            });
+            sched_side.join().expect("sched thread");
+            worker_side.join().expect("worker thread");
+            ingest_side.join().expect("ingest thread")
+        });
+        // The non-overlapping chunks were each admitted exactly once, and a cycle over the final
+        // state still succeeds.
+        assert_eq!(admitted, ROUNDS as usize);
+        let algorithm = StaticSchedulingAlgorithm {
+            mapping: Vec::new(),
+        };
+        sched
+            .run_scheduling_cycle(&algorithm, &(), 200, 60)
+            .expect("final cycle");
+    }
+
+    #[test]
+    fn wait_for_next_tick_returns_on_deadline_and_on_cancel() {
+        // Multi-thread runtime: its workers drive the sleep while this thread is parked in
+        // `Handle::block_on`, as in production.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("build test runtime");
+        let token = CancellationToken::new();
+        assert!(
+            wait_for_next_tick(
+                rt.handle(),
+                &token,
+                Duration::from_millis(1),
+                PROBE_EVERY,
+                ok_probe
+            )
+            .expect("no probe can fail")
+            .is_continue(),
+            "deadline elapses without shutdown"
+        );
+        token.cancel();
+        assert!(
+            wait_for_next_tick(
+                rt.handle(),
+                &token,
+                Duration::from_secs(3600),
+                PROBE_EVERY,
+                ok_probe
+            )
+            .expect("no probe can fail")
+            .is_break(),
+            "cancellation interrupts the wait"
+        );
+    }
+
+    fn ok_probe() -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Short enough to keep the wait tests in milliseconds.
+    const PROBE_EVERY: Duration = Duration::from_millis(20);
+
+    /// Generous: these tests care about the verdict, not the bound.
+    const PING_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// A wait shorter than the probe interval must not probe at all — the tick that follows is
+    /// itself the liveness check, and a probe per tick would double every task's round trips.
+    #[test]
+    fn a_short_wait_does_not_probe() {
+        let rt = multi_thread_rt();
+        let probes = AtomicU64::new(0);
+        let waited = wait_for_next_tick(
+            rt.handle(),
+            &CancellationToken::new(),
+            Duration::from_millis(1),
+            PROBE_EVERY,
+            || {
+                probes.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .expect("no probe can fail");
+        assert!(waited.is_continue());
+        assert_eq!(probes.load(Ordering::Relaxed), 0);
+    }
+
+    /// A connection that dies while the task sleeps is fatal there and then, rather than at the
+    /// next tick's first statement — which for the scheduling task is a period away.
+    #[test]
+    fn a_failing_probe_ends_the_wait_fatally() {
+        let rt = multi_thread_rt();
+        let started = Instant::now();
+        let err = wait_for_next_tick(
+            rt.handle(),
+            &CancellationToken::new(),
+            // Far longer than the test may run: only the probe can end this wait.
+            Duration::from_secs(3600),
+            PROBE_EVERY,
+            || anyhow::bail!("connection gone"),
+        )
+        .expect_err("a failed probe is fatal");
+        assert_eq!(err.to_string(), "connection gone");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the probe must end the wait, not the period"
+        );
+    }
+
+    /// `0` turns probing off — an operational escape hatch, and the value that would otherwise
+    /// spin the wait on zero-length naps.
+    #[test]
+    fn a_zero_interval_disables_probing() {
+        let rt = multi_thread_rt();
+        let probes = AtomicU64::new(0);
+        let waited = wait_for_next_tick(
+            rt.handle(),
+            &CancellationToken::new(),
+            Duration::from_millis(30),
+            Duration::ZERO,
+            || {
+                probes.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .expect("no probe can fail");
+        assert!(waited.is_continue());
+        assert_eq!(probes.load(Ordering::Relaxed), 0);
+    }
+
+    fn multi_thread_rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("build test runtime")
+    }
+}

--- a/src/multistep_controller/tasks/scheduling.rs
+++ b/src/multistep_controller/tasks/scheduling.rs
@@ -1,0 +1,171 @@
+//! The scheduling task: the leader connection (advisory lock, migrations, leadership claim — it
+//! reports the [`Epoch`] its sibling tasks connect with through its readiness channel). Each tick
+//! runs one scheduling cycle producing the worker assignment, then regenerates the schema bundle
+//! (every tick, shortage or not), then worker GC (after the cycle, so phase A's state-based stale
+//! cleanup precedes worker-row deletion), then
+//! the visibility cycle, whose promotion and stale-drain act on the current confirmation
+//! watermark. This connection owns every UPDATE/DELETE of existing `sched_*` rows (see the
+//! ownership map in `scheduler_storage::postgres`), which is why worker GC lives here and not
+//! with the worker-status task. Everything is only computed and logged; publishing is not wired
+//! yet (docs/README.md).
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::{
+    runtime::Handle,
+    sync::{oneshot, watch},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    cli, metrics,
+    scheduler_storage::{
+        AssignmentId, SchedulerStorage,
+        algorithm::MultistepAlgorithm,
+        postgres::{Epoch, PostgresStorage},
+    },
+};
+
+use super::super::now_ticks;
+use super::super::ops::Heartbeat;
+use super::{retry_or_die, wait_for_next_tick};
+
+pub struct SchedulingTask {
+    pub database_url: cli::Secret,
+    pub claim_lock_timeout: Duration,
+    pub batch_size: usize,
+    pub algorithm: MultistepAlgorithm<cli::DatasetsConfig>,
+    pub config: crate::multistep_scheduler::SchedulingConfig,
+    pub period: Duration,
+    pub drain_window_ticks: u64,
+    pub worker_gc_ticks: u64,
+    pub latest_published: watch::Sender<AssignmentId>,
+    pub probe_interval: Duration,
+    pub ping_timeout: Duration,
+    pub heartbeat: Arc<Heartbeat>,
+    /// Fired when the worker and chunk-discovery startup passes have seeded workers and chunks;
+    /// the first cycle waits for it. Dropped unfired when startup fails.
+    pub start: oneshot::Receiver<()>,
+    pub handle: Handle,
+    pub token: CancellationToken,
+}
+
+impl SchedulingTask {
+    pub fn run(self, ready: oneshot::Sender<anyhow::Result<Epoch>>) -> anyhow::Result<()> {
+        let Self {
+            database_url,
+            claim_lock_timeout,
+            batch_size,
+            algorithm,
+            config,
+            period,
+            drain_window_ticks,
+            worker_gc_ticks,
+            latest_published,
+            probe_interval,
+            ping_timeout,
+            heartbeat,
+            start,
+            handle,
+            token,
+        } = self;
+        // No call-site context on connect: the storage layer already names the operation.
+        let (mut storage, epoch) = match PostgresStorage::connect(
+            database_url.expose_secret(),
+            claim_lock_timeout,
+            batch_size,
+        ) {
+            Ok(leader) => leader,
+            Err(e) => {
+                let _ = ready.send(Err(e.into()));
+                return Ok(());
+            }
+        };
+        crate::metrics::LEADERSHIP_EPOCH.set(epoch.get());
+        let _ = ready.send(Ok(epoch));
+        let proceed = handle.block_on(async {
+            tokio::select! {
+                biased;
+                () = token.cancelled() => false,
+                started = start => started.is_ok(),
+            }
+        });
+        if !proceed {
+            return Ok(());
+        }
+        loop {
+            // Beat only once the whole tick landed: a task looping on retryable failures has to
+            // look stalled, not healthy.
+            let mut done = true;
+            let cycle = {
+                let _timer = metrics::Timer::new("multistep:schedule");
+                storage.run_scheduling_cycle(&algorithm, &config, now_ticks(), drain_window_ticks)
+            };
+            match cycle {
+                Ok(assignment) => {
+                    // STUB: publishing serializes/uploads the assignment here once the upload
+                    // path exists (see docs/README.md).
+                    tracing::info!(
+                        assignment_id = %assignment.id,
+                        chunks_placed = assignment.chunk_workers.len(),
+                        replication_by_weight = ?assignment.replication_by_weight,
+                        "Multistep scheduling cycle done"
+                    );
+                    // Bounds the confirmation gate's trust in worker-echoed ids.
+                    latest_published.send_replace(assignment.id);
+                }
+                Err(e) => {
+                    retry_or_die(&mut storage, ping_timeout, e, "scheduling cycle")?;
+                    done = false;
+                }
+            }
+            // Unconditional, including after a Shortage: the write section stays frozen with the
+            // last successful assignment, but a read-schema promoted since then has to reach the
+            // very next bundle rather than wait for placement to recover.
+            // STUB: publishing the bundle goes here (docs/README.md).
+            match storage.generate_schema_bundle() {
+                Ok(bundle) => tracing::info!(
+                    schema_bundle_id = %bundle.id(),
+                    write_schemas = bundle.schemas().len(),
+                    read_schemas = bundle.read_schemas().len(),
+                    "Schema bundle generated"
+                ),
+                Err(e) => {
+                    retry_or_die(&mut storage, ping_timeout, e, "generate schema bundle")?;
+                    done = false;
+                }
+            }
+            // After the cycle: its phase-A cleanup has already settled the departed workers'
+            // mapping state, so deleting long-inactive worker rows here never races it.
+            if let Err(e) = storage.gc_inactive_workers(now_ticks(), worker_gc_ticks) {
+                retry_or_die(&mut storage, ping_timeout, e, "gc inactive workers")?;
+                done = false;
+            }
+            // Portal projection: promotion and stale-drain act on the confirmation watermark the
+            // worker-status task advances between our ticks. Runs regardless of the cycle
+            // outcome — a rolled-back cycle doesn't preclude promoting already-confirmed chunks.
+            // STUB: publishing the promoted portal assignment goes here (docs/README.md).
+            match storage.run_visibility_cycle(now_ticks()) {
+                Ok(portal) => tracing::info!(
+                    portal_assignment_id = portal.id,
+                    portal_chunks = portal.chunks.len(),
+                    "Visibility cycle done"
+                ),
+                Err(e) => {
+                    retry_or_die(&mut storage, ping_timeout, e, "visibility cycle")?;
+                    done = false;
+                }
+            }
+            if done {
+                heartbeat.beat();
+            }
+            if wait_for_next_tick(&handle, &token, period, probe_interval, || {
+                Ok(storage.ping(ping_timeout)?)
+            })?
+            .is_break()
+            {
+                return Ok(());
+            }
+        }
+    }
+}

--- a/src/multistep_controller/tasks/worker_status.rs
+++ b/src/multistep_controller/tasks/worker_status.rs
@@ -1,0 +1,364 @@
+//! The worker-status task: refreshes the worker set from ClickHouse and drives the confirmation
+//! gate on the same ping snapshot — quorum over the assignment ids workers echo in their pings
+//! (`last_applied_assignment_id`) advances the confirmation watermark. The quorum denominator is
+//! the snapshot's online workers.
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Context;
+use tokio::{
+    runtime::Handle,
+    sync::{oneshot, watch},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    cli,
+    clickhouse::{ClickhouseClient, WorkerPing},
+    scheduler_storage::{
+        AssignmentId, SchedulerStorage,
+        postgres::{Epoch, PostgresStorage, SessionMemory},
+    },
+    types::WorkerStatus,
+};
+
+use super::super::now_ticks;
+use super::super::ops::Heartbeat;
+use super::{retry_or_die, wait_for_next_tick};
+
+pub struct WorkerStatusTask {
+    pub database_url: cli::Secret,
+    /// The scheduling task's epoch: our writes stop the moment a newer leader claims one.
+    pub epoch: Epoch,
+    pub batch_size: usize,
+    pub clickhouse: ClickhouseClient,
+    pub config: Arc<cli::Config>,
+    pub period: Duration,
+    pub quorum_pct: u8,
+    pub latest_published: watch::Receiver<AssignmentId>,
+    pub probe_interval: Duration,
+    pub ping_timeout: Duration,
+    pub heartbeat: Arc<Heartbeat>,
+    pub handle: Handle,
+    pub token: CancellationToken,
+}
+
+impl WorkerStatusTask {
+    pub fn run(self, ready: oneshot::Sender<anyhow::Result<()>>) -> anyhow::Result<()> {
+        // The startup pass runs before reporting ready: the first scheduling cycle waits on it.
+        let started = self.startup().and_then(|(mut storage, mut gate)| {
+            self.tick(&mut storage, &mut gate)?;
+            Ok((storage, gate))
+        });
+        let (mut storage, mut gate) = match started {
+            Ok(started) => started,
+            Err(e) => {
+                let _ = ready.send(Err(e));
+                return Ok(());
+            }
+        };
+        let _ = ready.send(Ok(()));
+        while wait_for_next_tick(
+            &self.handle,
+            &self.token,
+            self.period,
+            self.probe_interval,
+            || Ok(storage.ping(self.ping_timeout)?),
+        )?
+        .is_continue()
+        {
+            self.tick(&mut storage, &mut gate)?;
+        }
+        Ok(())
+    }
+
+    fn startup(&self) -> anyhow::Result<(PostgresStorage, ConfirmationGate)> {
+        // Worker upserts and the watermark confirm are small statements — no raised session
+        // memory needed.
+        let mut storage = PostgresStorage::connect_follower(
+            self.database_url.expose_secret(),
+            SessionMemory::ServerDefault,
+            self.epoch,
+            self.batch_size,
+        )?;
+        let confirmed = storage
+            .worker_confirmation_watermark()
+            .context("seed confirmation gate")?;
+        Ok((
+            storage,
+            ConfirmationGate::new(self.quorum_pct, self.latest_published.clone(), confirmed),
+        ))
+    }
+
+    /// One confirmation-gate pass plus a worker-set refresh over the same ping snapshot.
+    fn tick(
+        &self,
+        storage: &mut PostgresStorage,
+        gate: &mut ConfirmationGate,
+    ) -> anyhow::Result<()> {
+        let Some(pings) = self.handle.block_on(load_worker_pings(
+            &self.clickhouse,
+            &self.config,
+            &self.token,
+        )) else {
+            return Ok(());
+        };
+        let applied: Vec<_> = pings
+            .iter()
+            .filter(|ping| ping.worker.status == WorkerStatus::Online)
+            .map(|ping| parse_applied_id(ping.last_applied_assignment_id.as_deref()))
+            .collect();
+        let workers: Vec<_> = pings.into_iter().map(|ping| ping.worker).collect();
+        // Both operations write only tables this connection owns (the confirmation tables and
+        // `sched_workers` status columns), so neither waits on a concurrent scheduling cycle.
+        gate.advance(storage, self.ping_timeout, &applied)?;
+        match storage.update_worker_set(&workers, now_ticks()) {
+            Ok(()) => {
+                tracing::info!(workers = workers.len(), "Worker set updated");
+                self.heartbeat.beat();
+            }
+            Err(e) => retry_or_die(storage, self.ping_timeout, e, "update worker set")?,
+        }
+        Ok(())
+    }
+}
+
+/// `None` on shutdown or a (logged) ClickHouse error. The query has no client-side timeout, so it
+/// is raced against shutdown; storage operations never are — once started they run to completion.
+async fn load_worker_pings(
+    clickhouse: &ClickhouseClient,
+    config: &cli::Config,
+    token: &CancellationToken,
+) -> Option<Vec<WorkerPing>> {
+    let result = tokio::select! {
+        () = token.cancelled() => return None,
+        result = clickhouse.active_worker_pings(config) => result,
+    };
+    match result {
+        Ok(pings) => Some(pings),
+        Err(e) => {
+            tracing::error!(
+                error = format!("{e:#}"),
+                "Failed to load active workers, retrying next tick"
+            );
+            None
+        }
+    }
+}
+
+/// Confirmation state for one service run.
+struct ConfirmationGate {
+    quorum_pct: u8,
+    /// Newest assignment id this run's scheduling task produced; 0 until its first cycle.
+    latest_published: watch::Receiver<AssignmentId>,
+    confirmed: AssignmentId,
+}
+
+impl ConfirmationGate {
+    /// Seed `confirmed` with the storage's watermark, so a restart doesn't re-confirm.
+    fn new(
+        quorum_pct: u8,
+        latest_published: watch::Receiver<AssignmentId>,
+        confirmed: AssignmentId,
+    ) -> Self {
+        Self {
+            quorum_pct,
+            latest_published,
+            confirmed,
+        }
+    }
+
+    /// One gate pass over a ping snapshot: a new watermark with quorum is confirmed. The
+    /// scheduling task picks the advanced watermark up in its next visibility cycle.
+    fn advance(
+        &mut self,
+        storage: &mut PostgresStorage,
+        ping_timeout: Duration,
+        applied: &[Option<AssignmentId>],
+    ) -> anyhow::Result<()> {
+        let latest = *self.latest_published.borrow();
+        let Some(watermark) = quorum_watermark(self.quorum_pct, latest, applied) else {
+            return Ok(());
+        };
+        if watermark <= self.confirmed {
+            return Ok(());
+        }
+        match storage.confirm_worker_assignment(watermark, now_ticks()) {
+            Ok(()) => {
+                self.confirmed = watermark;
+                tracing::info!(watermark, "Confirmation watermark advanced");
+            }
+            Err(e) => {
+                retry_or_die(
+                    storage,
+                    ping_timeout,
+                    e,
+                    &format!("confirm watermark {watermark}"),
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Highest assignment id that at least `quorum_pct`% of online workers have applied, or `None`
+/// when no id has quorum.
+///
+/// `applied`: one entry per online worker, `None` when it echoed nothing usable. Ids above
+/// `latest_published` are not ours and count as not-confirmed. `quorum_pct == 0` skips the vote
+/// and returns `latest_published` (`None` while it is still 0).
+fn quorum_watermark(
+    quorum_pct: u8,
+    latest_published: AssignmentId,
+    applied: &[Option<AssignmentId>],
+) -> Option<AssignmentId> {
+    if quorum_pct == 0 {
+        return (latest_published > 0).then_some(latest_published);
+    }
+    if applied.is_empty() {
+        return None;
+    }
+    let quorum = usize::max(1, (applied.len() * quorum_pct as usize).div_ceil(100));
+    let mut ids: Vec<AssignmentId> = applied
+        .iter()
+        .flatten()
+        .copied()
+        .filter(|&id| id > 0 && id <= latest_published)
+        .collect();
+    if ids.len() < quorum {
+        return None;
+    }
+    ids.sort_unstable_by(|a, b| b.cmp(a));
+    // The quorum-th largest id is the highest one at least `quorum` workers have reached.
+    Some(ids[quorum - 1])
+}
+
+/// Worker-echoed assignment id in this scheduler's id space: the numeric storage id it was
+/// published under. Non-numeric echoes (e.g. the legacy `20241008T141245_…` format) are not ours.
+fn parse_applied_id(echoed: Option<&str>) -> Option<AssignmentId> {
+    echoed?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    /// Generous: these tests care about the gate's verdict, not the bound.
+    const PING_TIMEOUT: Duration = Duration::from_secs(5);
+
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+    use crate::scheduler_storage::postgres::{DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT};
+    use crate::scheduler_storage::test_harness::pg_harness::fresh_db_url;
+    use crate::scheduler_storage::test_harness::utils::StaticSchedulingAlgorithm;
+
+    static TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    /// The stateful gate against real storage: quorum persists the watermark, an unchanged
+    /// quorum is a no-op, and a gate re-seeded from storage (a service restart) does not
+    /// re-confirm.
+    #[test]
+    fn gate_confirms_persists_and_reseeds() {
+        let (url, _db) = fresh_db_url("worker_status", TEST_ID.fetch_add(1, Ordering::Relaxed));
+        let (mut storage, _) =
+            PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("connect leader");
+        let algorithm = StaticSchedulingAlgorithm {
+            mapping: Vec::new(),
+        };
+        let assignment = storage
+            .run_scheduling_cycle(&algorithm, &(), 100, 60)
+            .expect("mint an assignment");
+
+        let (latest_tx, latest_rx) = watch::channel(0);
+        latest_tx.send_replace(assignment.id);
+        let applied = vec![Some(assignment.id); 3];
+
+        let mut gate = ConfirmationGate::new(90, latest_rx.clone(), 0);
+        gate.advance(&mut storage, PING_TIMEOUT, &applied)
+            .expect("advance");
+        assert_eq!(
+            storage.worker_confirmation_watermark().expect("watermark"),
+            assignment.id,
+            "quorum must persist the watermark"
+        );
+
+        gate.advance(&mut storage, PING_TIMEOUT, &applied)
+            .expect("repeat advance is a no-op");
+        assert_eq!(gate.confirmed, assignment.id);
+
+        let seeded = storage.worker_confirmation_watermark().expect("watermark");
+        let mut reseeded = ConfirmationGate::new(90, latest_rx, seeded);
+        reseeded
+            .advance(&mut storage, PING_TIMEOUT, &applied)
+            .expect("advance on a re-seeded gate");
+        assert_eq!(
+            reseeded.confirmed, assignment.id,
+            "a restart must not re-confirm"
+        );
+    }
+
+    #[test]
+    fn zero_quorum_jumps_to_latest_published() {
+        assert_eq!(quorum_watermark(0, 7, &[]), Some(7));
+        assert_eq!(quorum_watermark(0, 0, &[]), None);
+    }
+
+    #[test]
+    fn no_online_workers_holds_the_watermark() {
+        assert_eq!(quorum_watermark(90, 7, &[]), None);
+    }
+
+    #[test]
+    fn nothing_echoed_holds_the_watermark() {
+        assert_eq!(quorum_watermark(90, 7, &[None, None, None]), None);
+    }
+
+    #[test]
+    fn full_agreement_confirms_the_echoed_id() {
+        let applied = [Some(5), Some(5), Some(5)];
+        assert_eq!(quorum_watermark(90, 7, &applied), Some(5));
+    }
+
+    #[test]
+    fn watermark_is_the_quorum_th_largest_id() {
+        // 10 workers at 90% -> the 9th largest applied id carries the quorum.
+        let applied: Vec<_> = (1..=10).map(Some).collect();
+        assert_eq!(quorum_watermark(90, 10, &applied), Some(2));
+        // At 50%, the 5th largest.
+        assert_eq!(quorum_watermark(50, 10, &applied), Some(6));
+    }
+
+    #[test]
+    fn laggards_within_tolerance_do_not_stall() {
+        // 9 of 10 on id 5, one silent: 90% quorum is met without the straggler.
+        let mut applied = vec![Some(5); 9];
+        applied.push(None);
+        assert_eq!(quorum_watermark(90, 7, &applied), Some(5));
+        // Two silent of 10 exceed the 10% tolerance.
+        let mut applied = vec![Some(5); 8];
+        applied.extend([None, None]);
+        assert_eq!(quorum_watermark(90, 7, &applied), None);
+    }
+
+    #[test]
+    fn ids_beyond_latest_published_are_not_trusted() {
+        let applied = [Some(9), Some(9), Some(9)];
+        assert_eq!(quorum_watermark(90, 7, &applied), None);
+        // Mixed: only the in-range echo counts, and alone it is below a 100% quorum of 3.
+        let applied = [Some(9), Some(9), Some(5)];
+        assert_eq!(quorum_watermark(100, 7, &applied), None);
+    }
+
+    #[test]
+    fn single_worker_fleet_confirms_alone() {
+        assert_eq!(quorum_watermark(90, 7, &[Some(3)]), Some(3));
+    }
+
+    #[test]
+    fn parse_rejects_legacy_and_garbage_ids() {
+        assert_eq!(parse_applied_id(Some("42")), Some(42));
+        assert_eq!(parse_applied_id(Some("20241008T141245_242da92f7d6c")), None);
+        assert_eq!(parse_applied_id(Some("")), None);
+        assert_eq!(parse_applied_id(None), None);
+    }
+}

--- a/src/multistep_scheduler/mod.rs
+++ b/src/multistep_scheduler/mod.rs
@@ -34,13 +34,7 @@ use crate::{
 /// Chunk indices assigned to each worker.
 type WorkerChunks = BTreeMap<PeerId, Vec<ChunkIndex>>;
 
-#[derive(Debug, Clone)]
-pub struct SchedulingConfig {
-    pub worker_capacity: u64,
-    pub saturation: f64,
-    pub min_replication: ReplicationFactor,
-    pub ignore_reliability: bool,
-}
+pub use crate::types::SchedulingConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScheduledChunk<'a> {

--- a/src/multistep_scheduler/sim/regression.rs
+++ b/src/multistep_scheduler/sim/regression.rs
@@ -519,7 +519,7 @@ fn worker_gc_orphans_post_departure_stale_rows_case() -> (SimConfig, Vec<Action>
         // Heavy adds reshuffle pairs off the departed worker; still registered, it passes
         // the mint filter and collects stale rows.
         Action::AddChunks(vec![nc(2, 12), nc(3, 12)]),
-        // This sync GCs the departed worker under its stale rows.
+        // The next cycle's GC deletes the departed worker under its stale rows.
         Action::WorkerJoined(4),
     ];
     (config, actions)
@@ -585,10 +585,10 @@ fn departure_reshuffle_overcommits_a_survivor() {
     );
 }
 
-/// Regression: a departed worker's lingering row must not stall the drain probe. GC waits for a
-/// membership sync and the drain triggers none, so the row survives the whole probe; while
-/// departed workers were still scheduled onto, the ideal oscillated around it and the probe
-/// exhausted its 200-cycle budget. Shrunk by the churn walk.
+/// Regression: a departed worker's lingering row must not stall the drain probe. The row survives
+/// the probe's early cycles (GC waits out `gc_ticks`); while departed workers were still scheduled
+/// onto, the ideal oscillated around it and the probe exhausted its 200-cycle budget. Shrunk by
+/// the churn walk.
 ///
 /// Parked for the same reason as [`departure_reshuffle_overcommits_a_survivor`]: the oscillation
 /// was the reorder bug, fixed in a separate PR and masked here by the departed-worker filter.
@@ -657,7 +657,7 @@ fn stale_minted_for_a_gc_deleted_worker() {
             ))]),
             Action::WorkerLeft(0),
             // Draining advances the clock past the retention; the departed worker keeps its
-            // ideal pairs (nothing filters it) until the join's sync GC-deletes the row.
+            // ideal pairs (nothing filters it) until a cycle's GC deletes the row.
             Action::CheckConverged(ConvergenceCheck::FloorLocallyFeasible),
             Action::WorkerJoined(8),
             // The reshuffle drops the deleted worker's pair from the ideal — and the mint
@@ -1354,7 +1354,7 @@ fn vacuous_confirmation_must_not_expire_the_last_drain() {
     replay(&config, actions);
 }
 
-/// Postgres twin: the re-promotion is a `update_worker_set` SQL phase — exercise it on the real
+/// Postgres twin: the re-promotion is a scheduling-cycle SQL phase — exercise it on the real
 /// backend, keeping the two storages at parity on the fix.
 #[test]
 fn vacuous_confirmation_must_not_expire_the_last_drain_pg() {

--- a/src/multistep_scheduler/sim/sut.rs
+++ b/src/multistep_scheduler/sim/sut.rs
@@ -112,7 +112,7 @@ pub(super) struct SimConfig {
     /// active workers have applied; 100 = all workers confirm; 0 = watermark skips to latest
     /// published assignment (no fetch required).
     pub(super) confirm_threshold_pct: u32,
-    /// Ticks a departed worker's row survives before a membership sync deletes it.
+    /// Ticks a departed worker's row survives before a cycle's GC deletes it.
     pub(super) gc_ticks: Tick,
 }
 
@@ -359,6 +359,10 @@ pub(super) struct SimUnderTest<D: SimStorage> {
     /// watermark passes it, the oracles hold the worker to nothing (see
     /// [`routing_has_caught_up_with_departure`](Self::routing_has_caught_up_with_departure)).
     placed_until_departure: BTreeMap<WorkerPk, AssignmentId>,
+    /// Workers that departed since the last cycle: their stale mappings legally survive until
+    /// that cycle's phase-A cleanup ([`Self::assert_no_orphaned_stale_mappings`]'s only
+    /// tolerance). Cleared by [`Self::run_cycle`]; a rejoin removes the worker again.
+    departed_awaiting_cycle: BTreeSet<WorkerPk>,
     /// X% confirmation quorum.
     confirm_threshold_pct: u32,
     /// Converged latch: set by a terminal convergence check or one under a recorded shortage;
@@ -830,31 +834,25 @@ impl<D: SimStorage> SimUnderTest<D> {
         true
     }
 
-    /// Hand the active fleet to the storage registry — departure marking and departed-worker
-    /// deletion run inside.
+    /// Hand the active fleet to the storage registry — status only: departure marking and revival
+    /// run inside, a departed worker's cleanup and deletion wait for the next cycle.
     fn sync_worker_set(&mut self) {
-        let mut registered_before: BTreeSet<WorkerPk> = BTreeSet::new();
         let mut inactive_before: BTreeSet<WorkerPk> = BTreeSet::new();
         for view in self.storage.get_workers(|_| true) {
-            registered_before.insert(view.worker_id);
             if view.inactive_since.is_some() {
                 inactive_before.insert(view.worker_id);
             }
         }
         let active: Vec<Worker> = self.active_workers().into_iter().cloned().collect();
         self.storage
-            .update_worker_set(&active, self.now, self.gc_ticks)
+            .update_worker_set(&active, self.now)
             .expect("worker set update succeeds");
         let latest_assignment = self
             .latest_worker_assignment
             .as_ref()
             .map_or(0, |assignment| assignment.id);
-        let mut survivors = 0usize;
         let mut any_departed = false;
         for view in self.storage.get_workers(|_| true) {
-            if registered_before.contains(&view.worker_id) {
-                survivors += 1;
-            }
             if view.inactive_since.is_some() {
                 any_departed = true;
                 // Edge-triggered: only on the active -> inactive transition, so the bound stays the
@@ -862,26 +860,25 @@ impl<D: SimStorage> SimUnderTest<D> {
                 if !inactive_before.contains(&view.worker_id) {
                     self.placed_until_departure
                         .insert(view.worker_id, latest_assignment);
+                    // Its stale rows legally survive until the next cycle's phase-A cleanup.
+                    self.departed_awaiting_cycle.insert(view.worker_id);
                 }
             } else if inactive_before.contains(&view.worker_id) {
                 // Rejoined (inactive -> active, same pk): the worker is placeable again, so its stale
                 // departure bound no longer applies — clear it, or coverage would keep treating this
                 // active holder as an unscrubbed departed route.
                 self.placed_until_departure.remove(&view.worker_id);
+                self.departed_awaiting_cycle.remove(&view.worker_id);
             }
         }
-        statistics::classify(
-            survivors < registered_before.len(),
-            "churn: worker deleted this sync",
-        );
         statistics::classify(any_departed, "churn: departed worker still registered");
         let active_pks = self.active_worker_pks();
         self.workers_state.sync_active_workers(&active_pks);
     }
 
-    /// Every stale mapping must reference an *active* worker. A departed one serves nothing, so
-    /// departure purges its mappings and the mint skips it; a deleted one takes its mappings with
-    /// it. Either way a mapping naming a non-active worker can never drain.
+    /// Every stale mapping must reference an *active* worker, except in the window between a
+    /// departure and the next cycle, which is what clears it (`departed_awaiting_cycle`). Past
+    /// that window a mapping naming a departed or deleted worker can never drain.
     fn assert_no_orphaned_stale_mappings(&self) {
         let mappings = self.storage.get_stale_mappings(|_| true);
         if mappings.is_empty() {
@@ -895,12 +892,15 @@ impl<D: SimStorage> SimUnderTest<D> {
             .collect();
         let orphaned: Vec<_> = mappings
             .into_iter()
-            .filter(|mapping| !active.contains(&mapping.worker_id))
+            .filter(|mapping| {
+                !active.contains(&mapping.worker_id)
+                    && !self.departed_awaiting_cycle.contains(&mapping.worker_id)
+            })
             .map(|mapping| (mapping.chunk_pk, mapping.worker_id))
             .collect();
         assert!(
             orphaned.is_empty(),
-            "stale mappings held by departed or deleted workers: {orphaned:?}",
+            "stale mappings held by cycled-over departed or deleted workers: {orphaned:?}",
         );
     }
 
@@ -1141,15 +1141,18 @@ impl<D: SimStorage> SimUnderTest<D> {
         id
     }
 
-    /// One storage cycle: schedule, advance the clock, run visibility, assert per-step safety.
-    /// Does not confirm — confirmation comes from worker fetches. On a shortage nothing is
-    /// committed; the shortage is recorded.
+    /// One storage cycle: schedule, GC inactive workers, advance the clock, run visibility,
+    /// assert per-step safety. Does not confirm — confirmation comes from worker fetches. On a
+    /// shortage nothing is committed; the shortage is recorded.
     ///
     /// The clock and portal visibility advance even on a shortage: skipping them would freeze
     /// draining forever.
     fn run_cycle(&mut self) {
         self.with_step_safety(|sim| {
             let scheduled = sim.run_scheduler();
+            // The cycle's phase-A cleanup ran (it commits even on a shortage): pending
+            // departures are settled, so their stale rows may no longer linger.
+            sim.departed_awaiting_cycle.clear();
             // Sync against the freshly published worker set so a departed-then-rejoined worker
             // starts from empty holdings.
             let active_workers = sim.active_worker_pks();
@@ -1162,6 +1165,15 @@ impl<D: SimStorage> SimUnderTest<D> {
                 sim.refresh_confirmation(&active_workers);
             }
             sim.now += CLOCK_STEP;
+            // GC after the cycle, so its cleanup settles a departure before the row goes.
+            let registered_before = sim.storage.get_workers(|_| true).len();
+            sim.storage
+                .gc_inactive_workers(sim.now, sim.gc_ticks)
+                .expect("worker gc succeeds");
+            statistics::classify(
+                sim.storage.get_workers(|_| true).len() < registered_before,
+                "churn: worker deleted by cycle GC",
+            );
             let portal_assignment = sim
                 .storage
                 .run_visibility_cycle(sim.now)
@@ -1868,6 +1880,7 @@ impl<D: SimStorage> SimUnderTest<D> {
             latest_portal_watermark: 0,
             latest_portal_publication: None,
             placed_until_departure: BTreeMap::new(),
+            departed_awaiting_cycle: BTreeSet::new(),
             confirm_threshold_pct: config.confirm_threshold_pct,
             converge_checked: false,
             real_steps: 0,

--- a/src/multistep_scheduler/sim/utils.rs
+++ b/src/multistep_scheduler/sim/utils.rs
@@ -211,7 +211,7 @@ pub(super) const DEPARTURE_DETECTION_TICKS: Tick = 4 * M_TICKS;
 /// Retention longer than any run — departed workers are never deleted.
 pub(super) const NEVER_GC_TICKS: Tick = 1_000_000_000;
 
-/// Per-case departed-worker retention: deletion eligible at the next membership sync, racing the
+/// Per-case departed-worker retention: deletion eligible at the next cycle's GC, racing the
 /// drain window, production-shaped `retention > M`, or never.
 pub(super) fn gc_ticks() -> BoxedStrategy<Tick> {
     prop_oneof![

--- a/src/scheduler_storage/in_memory/mod.rs
+++ b/src/scheduler_storage/in_memory/mod.rs
@@ -526,6 +526,66 @@ impl InMemoryStorage {
             .retain(|(_, worker_id), _| !evicted.contains(worker_id));
     }
 
+    /// Drop stale mappings held by inactive (or evicted) workers. State-based, like the Postgres
+    /// phase-A delete: departures detected by any earlier `update_worker_set` are settled here.
+    fn delete_inactive_stale_mappings(&mut self) {
+        let workers = &self.sched_workers;
+        self.sched_stale_mappings.retain(|(_, worker_id), _| {
+            workers
+                .get(worker_id)
+                .is_some_and(|entry| entry.inactive_since.is_none())
+        });
+    }
+
+    /// Give a drain back its committed-holder status when every worker it was handing off to has
+    /// departed. Confirmation is a quorum of *active* workers, so a recipient's departure lets
+    /// the handoff count as "confirmed" without any download (a vacuous confirmation — Invariant
+    /// 2, docs/mvcc-storage.md); the drain's expiry clock would then delete the fleet's last real
+    /// copy. Promotion takes the copy off the expiry clock and under the retention floor. Excess
+    /// copies become ordinary drains in later cycles; departed ideal rows fall out with the next
+    /// cycle's diff.
+    ///
+    /// Runs after [`Self::delete_inactive_stale_mappings`] (every leftover stale row belongs to an
+    /// active worker) and before the drain expiry — rescue before reaper.
+    fn promote_orphaned_drains(&mut self) {
+        // handoff_void: ideal rows with holders, none of them active.
+        let handoff_void: HashSet<ChunkPk> = self
+            .sched_ideal_chunk_workers
+            .iter()
+            .filter(|(_, holders)| {
+                !holders.is_empty()
+                    && holders.iter().all(|w| {
+                        self.sched_workers
+                            .get(w)
+                            .is_none_or(|entry| entry.inactive_since.is_some())
+                    })
+            })
+            .map(|(pk, _)| *pk)
+            .collect();
+        let promoted: Vec<(ChunkPk, WorkerPk)> = self
+            .sched_stale_mappings
+            .keys()
+            .filter(|(pk, worker_id)| {
+                handoff_void.contains(pk)
+                    && self
+                        .sched_workers
+                        .get(worker_id)
+                        .is_some_and(|entry| entry.inactive_since.is_none())
+            })
+            .copied()
+            .collect();
+        for (pk, worker_id) in promoted {
+            self.sched_stale_mappings.remove(&(pk, worker_id));
+            let holders = self
+                .sched_ideal_chunk_workers
+                .get_mut(&pk)
+                .expect("promoted chunk came from the ideal");
+            if !holders.contains(&worker_id) {
+                holders.push(worker_id);
+            }
+        }
+    }
+
     /// True if `dropped_at_portal` names a portal assignment created at or before `cutoff` — i.e.
     /// its M-tick grace has elapsed. `None` (never dropped) is not elapsed.
     fn portal_drop_elapsed(
@@ -903,22 +963,19 @@ impl SchedulerStorage for InMemoryStorage {
         &mut self,
         active_workers: &[Worker],
         now: Tick,
-        gc_ticks: u64,
     ) -> Result<(), StorageError> {
         let mut remaining: HashMap<PeerId, &Worker> =
             active_workers.iter().map(|w| (w.id, w)).collect();
 
-        // Workers that go inactive this call, collected to drop their stale mappings below.
-        let mut departed: Vec<WorkerPk> = Vec::new();
-
+        // Status columns only, like the Postgres backend: a departure's mapping-table
+        // consequences are settled by the next scheduling cycle, keyed on `inactive_since`.
         // Matched peers are drained from `remaining`; leftovers are new.
-        for (id, entry) in self.sched_workers.iter_mut() {
+        for entry in self.sched_workers.values_mut() {
             if let Some(worker) = remaining.remove(&entry.peer_id) {
                 entry.inactive_since = None;
                 entry.version = worker.version.clone();
             } else if entry.inactive_since.is_none() {
                 entry.inactive_since = Some(now);
-                departed.push(*id);
             }
         }
 
@@ -934,62 +991,17 @@ impl SchedulerStorage for InMemoryStorage {
             );
         }
 
-        if !departed.is_empty() {
-            let departed_set: HashSet<WorkerPk> = departed.iter().copied().collect();
-            self.sched_stale_mappings
-                .retain(|(_, worker_id), _| !departed_set.contains(worker_id));
-
-            // Give a drain back its committed-holder status when every worker it was handing
-            // off to has departed. Confirmation is a quorum of *active* workers, so a
-            // recipient's departure lets the handoff count as "confirmed" without any download
-            // (a vacuous confirmation — Invariant 2, docs/mvcc-storage.md); the drain's expiry
-            // clock would then delete the fleet's last real copy. Promotion takes the copy off
-            // the expiry clock and under the retention floor. Excess copies become ordinary
-            // drains in later cycles; departed ideal rows fall out with the next cycle's diff.
-            let handoff_void: HashSet<ChunkPk> = self
-                .sched_ideal_chunk_workers
-                .iter()
-                .filter(|(_, holders)| {
-                    !holders.is_empty()
-                        && holders.iter().all(|w| {
-                            self.sched_workers
-                                .get(w)
-                                .is_none_or(|entry| entry.inactive_since.is_some())
-                        })
-                })
-                .map(|(pk, _)| *pk)
-                .collect();
-            let promoted: Vec<(ChunkPk, WorkerPk)> = self
-                .sched_stale_mappings
-                .keys()
-                .filter(|(pk, worker_id)| {
-                    handoff_void.contains(pk)
-                        && self
-                            .sched_workers
-                            .get(worker_id)
-                            .is_some_and(|entry| entry.inactive_since.is_none())
-                })
-                .copied()
-                .collect();
-            for (pk, worker_id) in promoted {
-                self.sched_stale_mappings.remove(&(pk, worker_id));
-                let holders = self
-                    .sched_ideal_chunk_workers
-                    .get_mut(&pk)
-                    .expect("promoted chunk came from the ideal");
-                if !holders.contains(&worker_id) {
-                    holders.push(worker_id);
-                }
-            }
-        }
-
-        self.evict_stale_workers(now.saturating_sub(gc_ticks));
-
         Ok(())
     }
 
-    /// Run one scheduling cycle: tombstone expired chunks, expire stale mappings, run `algorithm`,
-    /// then diff + commit the result. Returns the published worker assignment.
+    fn gc_inactive_workers(&mut self, now: Tick, gc_ticks: u64) -> Result<(), StorageError> {
+        self.evict_stale_workers(now.saturating_sub(gc_ticks));
+        Ok(())
+    }
+
+    /// Run one scheduling cycle: clean up departed workers' state, tombstone expired chunks,
+    /// expire stale mappings, run `algorithm`, then diff + commit the result. Returns the
+    /// published worker assignment.
     fn run_scheduling_cycle<Algo>(
         &mut self,
         algorithm: &Algo,
@@ -1000,7 +1012,10 @@ impl SchedulerStorage for InMemoryStorage {
     where
         Algo: SchedulingAlgorithm + Send + Sync,
     {
-        // Clock-driven GC runs first; it persists even through the shortage below.
+        // Departed-worker cleanup, then clock-driven GC; the promotion must run before the expiry
+        // (rescue before reaper). All of it persists even through the shortage below.
+        self.delete_inactive_stale_mappings();
+        self.promote_orphaned_drains();
         self.tombstone_expired_chunks(now, m_ticks);
         self.expire_drained_stale_mappings(now, m_ticks);
 

--- a/src/scheduler_storage/in_memory/tests/correction_tests/machinery.rs
+++ b/src/scheduler_storage/in_memory/tests/correction_tests/machinery.rs
@@ -110,7 +110,7 @@ fn register_correction_duplicate_completed() -> anyhow::Result<()> {
     let a_pk = storage.pk_of(&a);
 
     let w = worker(1, None);
-    storage.update_worker_set(&[w], 0, 1000)?;
+    storage.update_worker_set(&[w], 0)?;
     let wid = workers(&storage)[0].worker_id;
 
     let wa1 = run_cycle(&mut storage, &a_pk, vec![wid], CYCLE_INTERVAL);
@@ -219,7 +219,7 @@ fn correction_chain_link_held_until_producer_fires() -> anyhow::Result<()> {
     let pk_a = storage.pk_of(&chunk_a);
 
     let single_worker = worker(1, None);
-    storage.update_worker_set(&[single_worker], 0, 1000)?;
+    storage.update_worker_set(&[single_worker], 0)?;
     let worker_id = workers(&storage)[0].worker_id;
 
     // Make A visible at the portal so the chain has something to swap out of.
@@ -277,7 +277,7 @@ fn correction_independent_same_dataset_fires_without_waiting() -> anyhow::Result
     let c_pk = storage.pk_of(&c);
 
     let w = worker(1, None);
-    storage.update_worker_set(&[w], 0, 1000)?;
+    storage.update_worker_set(&[w], 0)?;
     let wid = workers(&storage)[0].worker_id;
 
     let wa1 = run_cycle_multi(
@@ -333,7 +333,7 @@ fn correction_audit_row_retained() -> anyhow::Result<()> {
     let a_pk = storage.pk_of(&a);
 
     let w = worker(1, None);
-    storage.update_worker_set(&[w], 0, 1000)?;
+    storage.update_worker_set(&[w], 0)?;
     let wid = workers(&storage)[0].worker_id;
 
     let wa1 = run_cycle(&mut storage, &a_pk, vec![wid], CYCLE_INTERVAL);
@@ -380,7 +380,7 @@ fn correction_old_chunk_removed_from_worker_after_m_ticks() -> anyhow::Result<()
     let a_pk = storage.pk_of(&a);
 
     let w = worker(1, None);
-    storage.update_worker_set(&[w], 0, 1000)?;
+    storage.update_worker_set(&[w], 0)?;
     let wid = workers(&storage)[0].worker_id;
 
     let wa1 = run_cycle(&mut storage, &a_pk, vec![wid], CYCLE_INTERVAL);
@@ -442,7 +442,7 @@ proptest! {
         let worker_list: Vec<Worker> = (0..n_workers).map(|i| worker(i + 1, None)).collect();
         let mut storage = storage_with(vec![orig_chunk.clone()]);
         let orig_pk = storage.pk_of(&orig_chunk);
-        storage.update_worker_set(&worker_list, 0, 1000).unwrap();
+        storage.update_worker_set(&worker_list, 0).unwrap();
         let all_wids: Vec<WorkerPk> = workers(&storage).iter().map(|v| v.worker_id).collect();
         let wid = all_wids[0];
 

--- a/src/scheduler_storage/in_memory/tests/correction_tests/multistep.rs
+++ b/src/scheduler_storage/in_memory/tests/correction_tests/multistep.rs
@@ -111,7 +111,7 @@ fn correction_held_until_new_chunk_confirmed<S: TestStorage>() -> anyhow::Result
     let mut storage = make_storage::<S>(vec![chunk_a.clone()]);
     let pk_a = storage.pk_of(&chunk_a);
 
-    storage.update_worker_set(&[worker(1, None)], 0, 1000)?;
+    storage.update_worker_set(&[worker(1, None)], 0)?;
 
     let assignment_a = run_real_cycle(&mut storage, CYCLE_INTERVAL);
     storage.confirm_worker_assignment(assignment_a.id, CYCLE_INTERVAL)?;
@@ -140,7 +140,7 @@ fn correction_new_chunk_not_promoted_until_correction_fires<S: TestStorage>() ->
     let mut storage = make_storage::<S>(vec![chunk_a.clone()]);
     let pk_a = storage.pk_of(&chunk_a);
 
-    storage.update_worker_set(&[worker(1, None)], 0, 1000)?;
+    storage.update_worker_set(&[worker(1, None)], 0)?;
 
     let pk_b = storage.register_correction(pk_a, chunk_with_blocks(dataset, 2, 100, 2..=3), 150)?;
 
@@ -158,7 +158,7 @@ fn correction_chain_collapses_in_one_cycle<S: TestStorage>() -> anyhow::Result<(
     let mut storage = make_storage::<S>(vec![chunk_a.clone()]);
     let pk_a = storage.pk_of(&chunk_a);
 
-    storage.update_worker_set(&[worker(1, None)], 0, 1000)?;
+    storage.update_worker_set(&[worker(1, None)], 0)?;
 
     let assignment_a = run_real_cycle(&mut storage, CYCLE_INTERVAL);
     storage.confirm_worker_assignment(assignment_a.id, CYCLE_INTERVAL)?;
@@ -188,7 +188,7 @@ fn correction_independent_corrections_fire_together<S: TestStorage>() -> anyhow:
     let pk_a = storage.pk_of(&chunk_a);
     let pk_c = storage.pk_of(&chunk_c);
 
-    storage.update_worker_set(&[worker(1, None)], 0, 1000)?;
+    storage.update_worker_set(&[worker(1, None)], 0)?;
 
     let assignment_ac = run_real_cycle(&mut storage, CYCLE_INTERVAL);
     storage.confirm_worker_assignment(assignment_ac.id, CYCLE_INTERVAL)?;
@@ -223,7 +223,7 @@ fn overlapping_duplicate_rejected_at_registration<S: TestStorage>() -> anyhow::R
     let mut storage = make_storage::<S>(vec![lower.clone(), higher.clone()]);
     let lower_pk = storage.pk_of(&lower);
 
-    storage.update_worker_set(&[worker(1, None)], 0, 1000)?;
+    storage.update_worker_set(&[worker(1, None)], 0)?;
     let assignment = run_real_cycle(&mut storage, CYCLE_INTERVAL);
     storage.confirm_worker_assignment(assignment.id, CYCLE_INTERVAL)?;
 
@@ -245,7 +245,7 @@ fn rejected_duplicate_does_not_self_heal<S: TestStorage>() -> anyhow::Result<()>
     let mut storage = make_storage::<S>(vec![lower.clone(), higher.clone()]);
     let lower_pk = storage.pk_of(&lower);
 
-    storage.update_worker_set(&[worker(1, None)], 0, 1000)?;
+    storage.update_worker_set(&[worker(1, None)], 0)?;
     let assignment = run_real_cycle(&mut storage, CYCLE_INTERVAL);
     storage.confirm_worker_assignment(assignment.id, CYCLE_INTERVAL)?;
     let portal = storage.run_visibility_cycle(CYCLE_INTERVAL + DELTA)?;
@@ -269,7 +269,7 @@ fn correction_replacement_changing_range_is_rejected<S: TestStorage>() -> anyhow
     let original_pk = storage.pk_of(&original);
     let neighbor_pk = storage.pk_of(&neighbor);
 
-    storage.update_worker_set(&[worker(1, None)], 0, 1000)?;
+    storage.update_worker_set(&[worker(1, None)], 0)?;
     let assignment = run_real_cycle(&mut storage, CYCLE_INTERVAL);
     storage.confirm_worker_assignment(assignment.id, CYCLE_INTERVAL)?;
     let portal = storage.run_visibility_cycle(CYCLE_INTERVAL + DELTA)?;
@@ -360,7 +360,7 @@ proptest! {
         let c0 = chunk(dataset, 1, 100);
         let mut storage = make_storage::<InMemoryStorage>(vec![c0.clone()]);
         let c0_pk = storage.pk_of(&c0);
-        storage.update_worker_set(&[worker(1, None)], 0, 1000).unwrap();
+        storage.update_worker_set(&[worker(1, None)], 0).unwrap();
 
         let seed_assignment = run_real_cycle(&mut storage, CYCLE_INTERVAL);
         storage.confirm_worker_assignment(seed_assignment.id, CYCLE_INTERVAL).unwrap();

--- a/src/scheduler_storage/in_memory/tests/mod.rs
+++ b/src/scheduler_storage/in_memory/tests/mod.rs
@@ -115,7 +115,7 @@ fn update_worker_set_inserts_new_peer_with_version() {
     let mut storage = InMemoryStorage::default();
     let worker = worker(1, Some("2.8.0"));
     storage
-        .update_worker_set(std::slice::from_ref(&worker), 100, 60)
+        .update_worker_set(std::slice::from_ref(&worker), 100)
         .unwrap();
 
     let registry = workers(&storage);
@@ -130,11 +130,9 @@ fn update_worker_set_inserts_new_peer_with_version() {
 #[test]
 fn update_worker_set_marks_absent_peer_stale() {
     let mut storage = InMemoryStorage::default();
-    storage
-        .update_worker_set(&[worker(1, None)], 100, 60)
-        .unwrap();
+    storage.update_worker_set(&[worker(1, None)], 100).unwrap();
 
-    storage.update_worker_set(&[], 200, 60).unwrap();
+    storage.update_worker_set(&[], 200).unwrap();
     assert_eq!(
         workers(&storage).len(),
         1,
@@ -147,12 +145,12 @@ fn update_worker_set_marks_absent_peer_stale() {
 fn update_worker_set_revives_stale_and_refreshes_version() {
     let mut storage = InMemoryStorage::default();
     storage
-        .update_worker_set(&[worker(1, Some("2.7.0"))], 100, 60)
+        .update_worker_set(&[worker(1, Some("2.7.0"))], 100)
         .unwrap();
-    storage.update_worker_set(&[], 200, 60).unwrap(); // now stale
+    storage.update_worker_set(&[], 200).unwrap(); // now stale
 
     storage
-        .update_worker_set(&[worker(1, Some("2.8.0"))], 300, 60)
+        .update_worker_set(&[worker(1, Some("2.8.0"))], 300)
         .unwrap();
     let registry = workers(&storage);
     let view = &registry[0];
@@ -164,10 +162,10 @@ fn update_worker_set_revives_stale_and_refreshes_version() {
 fn update_worker_set_refreshes_version_for_continuously_active() {
     let mut storage = InMemoryStorage::default();
     storage
-        .update_worker_set(&[worker(1, Some("2.7.0"))], 100, 60)
+        .update_worker_set(&[worker(1, Some("2.7.0"))], 100)
         .unwrap();
     storage
-        .update_worker_set(&[worker(1, Some("2.8.0"))], 200, 60)
+        .update_worker_set(&[worker(1, Some("2.8.0"))], 200)
         .unwrap();
     let registry = workers(&storage);
     let view = &registry[0];
@@ -178,13 +176,11 @@ fn update_worker_set_refreshes_version_for_continuously_active() {
 #[test]
 fn update_worker_set_already_stale_is_idempotent() {
     let mut storage = InMemoryStorage::default();
-    storage
-        .update_worker_set(&[worker(1, None)], 100, 1000)
-        .unwrap();
-    storage.update_worker_set(&[], 200, 1000).unwrap();
+    storage.update_worker_set(&[worker(1, None)], 100).unwrap();
+    storage.update_worker_set(&[], 200).unwrap();
     let stale_at = workers(&storage)[0].inactive_since;
 
-    storage.update_worker_set(&[], 300, 1000).unwrap();
+    storage.update_worker_set(&[], 300).unwrap();
     assert_eq!(
         workers(&storage)[0].inactive_since,
         stale_at,
@@ -193,19 +189,17 @@ fn update_worker_set_already_stale_is_idempotent() {
 }
 
 #[test]
-fn update_worker_set_gc_boundary() {
+fn gc_inactive_workers_boundary() {
     let mut storage = InMemoryStorage::default();
-    storage
-        .update_worker_set(&[worker(1, None)], 100, 60)
-        .unwrap();
-    storage.update_worker_set(&[], 200, 60).unwrap(); // worker stale at 200
+    storage.update_worker_set(&[worker(1, None)], 100).unwrap();
+    storage.update_worker_set(&[], 200).unwrap(); // worker stale at 200
 
     // At now=260, cutoff = 260 - 60 = 200. 200 < 200 is false → kept.
-    storage.update_worker_set(&[], 260, 60).unwrap();
+    storage.gc_inactive_workers(260, 60).unwrap();
     assert_eq!(workers(&storage).len(), 1, "worker at the boundary is kept");
 
     // At now=300, cutoff = 300 - 60 = 240. 200 < 240 → evicted.
-    storage.update_worker_set(&[], 300, 60).unwrap();
+    storage.gc_inactive_workers(300, 60).unwrap();
     assert!(
         workers(&storage).is_empty(),
         "worker past the boundary is evicted"
@@ -213,11 +207,9 @@ fn update_worker_set_gc_boundary() {
 }
 
 #[test]
-fn update_worker_set_cleans_stale_mappings_for_departed() {
+fn scheduling_cycle_cleans_stale_mappings_for_departed() {
     let mut storage = InMemoryStorage::default();
-    storage
-        .update_worker_set(&[worker(1, None)], 100, 60)
-        .unwrap();
+    storage.update_worker_set(&[worker(1, None)], 100).unwrap();
     let worker_id = workers(&storage)[0].worker_id;
     storage.sched_stale_mappings.insert(
         (ChunkPk(1), worker_id),
@@ -226,7 +218,18 @@ fn update_worker_set_cleans_stale_mappings_for_departed() {
         },
     );
 
-    storage.update_worker_set(&[], 200, 60).unwrap(); // worker departs
+    storage.update_worker_set(&[], 200).unwrap(); // worker departs
+    assert!(
+        !storage.get_stale_mappings(|_| true).is_empty(),
+        "departure alone leaves the stale mapping; the cycle cleans it up"
+    );
+
+    let algorithm = StaticSchedulingAlgorithm {
+        mapping: Vec::new(),
+    };
+    storage
+        .run_scheduling_cycle(&algorithm, &(), 300, 60)
+        .expect("scheduling succeeds");
     assert!(storage.get_stale_mappings(|_| true).is_empty());
 }
 
@@ -588,7 +591,7 @@ fn run_scheduling_cycle_applies_mapping_from_algorithm() {
     // worker_ids are assigned in HashMap iteration order — record them rather
     // than assume a peer→id mapping.
     storage
-        .update_worker_set(&[worker(1, None), worker(2, None)], 0, 1000)
+        .update_worker_set(&[worker(1, None), worker(2, None)], 0)
         .unwrap();
     let worker_ids: Vec<WorkerPk> = workers(&storage)
         .iter()
@@ -642,9 +645,7 @@ fn worker_assignment_diffs_recorded_after_cycle_then_cleared_on_confirm() {
     let pk_1 = storage.pk_of(&chunk_1);
     storage.register_new_chunks().unwrap();
 
-    storage
-        .update_worker_set(&[worker(1, None)], 0, 1000)
-        .unwrap();
+    storage.update_worker_set(&[worker(1, None)], 0).unwrap();
     let worker_id = workers(&storage)[0].worker_id;
 
     let mapping: IdealMapping = vec![(pk_1, vec![worker_id])];

--- a/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
+++ b/src/scheduler_storage/in_memory/tests/mvcc_protocol.rs
@@ -306,9 +306,7 @@ fn setup(num_workers: usize, num_chunks: usize) -> Setup {
     let workers_to_register: Vec<Worker> = (0..num_workers)
         .map(|i| worker((i + 1) as u8, None))
         .collect();
-    storage
-        .update_worker_set(&workers_to_register, 0, 1000)
-        .unwrap();
+    storage.update_worker_set(&workers_to_register, 0).unwrap();
     let worker_ids: Vec<WorkerPk> = workers(&storage)
         .iter()
         .map(|view| view.worker_id)
@@ -369,9 +367,7 @@ fn schema_bundle_holds_only_in_play_schemas() {
         .insert_new_chunks(vec![a.clone(), b.clone()])
         .unwrap();
     let a_pk = storage.pk_of(&a);
-    storage
-        .update_worker_set(&[worker(1, None)], 0, 1000)
-        .unwrap();
+    storage.update_worker_set(&[worker(1, None)], 0).unwrap();
     let w1 = workers(&storage)[0].worker_id;
 
     // Place only "a"; "b" stays unplaced (in no worker or portal assignment).
@@ -406,9 +402,7 @@ fn bundle_read_section_tracks_the_current_read_schema() {
     let a = chunk("a", 1, 100);
     storage.insert_new_chunks(vec![a.clone()]).unwrap();
     let a_pk = storage.pk_of(&a);
-    storage
-        .update_worker_set(&[worker(1, None)], 0, 1000)
-        .unwrap();
+    storage.update_worker_set(&[worker(1, None)], 0).unwrap();
     let w1 = workers(&storage)[0].worker_id;
     run_cycle(&mut storage, &a_pk, vec![w1], CYCLE_INTERVAL);
 
@@ -566,9 +560,7 @@ fn schema_bundle_covers_holderless_portal_visible_chunk() {
         .unwrap();
 
     // Depart the sole holder: its copy vanishes (not drained), no stale row survives.
-    storage
-        .update_worker_set(&[], 2 * CYCLE_INTERVAL, 1000)
-        .unwrap();
+    storage.update_worker_set(&[], 2 * CYCLE_INTERVAL).unwrap();
 
     // Next cycle places nothing (no active workers) -> chunk is holderless (ideal={}, stale={}),
     // still portal_visible. The bundle must still carry its schema.

--- a/src/scheduler_storage/mod.rs
+++ b/src/scheduler_storage/mod.rs
@@ -150,15 +150,23 @@ pub trait SchedulerStorage {
     /// Create scheduling metadata for new chunks, and make them eligible for workers
     fn register_new_chunks(&mut self) -> Result<Vec<ChunkPk>, StorageError>;
 
-    /// Update the current view on the active workers
+    /// Update the current view on the active workers — status columns only. A departed worker's
+    /// mappings are cleaned up by [`run_scheduling_cycle`](Self::run_scheduling_cycle) and its row
+    /// deleted by [`gc_inactive_workers`](Self::gc_inactive_workers), so this never writes a table
+    /// the cycle writes and the two can run concurrently.
     fn update_worker_set(
         &mut self,
         active_workers: &[Worker],
         now: Tick,
-        gc_ticks: u64,
     ) -> Result<(), StorageError>;
 
-    /// Run one full scheduling cycle: tombstone expired chunks, expire stale
+    /// Delete workers inactive for longer than `gc_ticks` (their stale mappings go with them).
+    /// Runs after [`run_scheduling_cycle`](Self::run_scheduling_cycle), on the same connection, so
+    /// the cycle's cleanup settles a departure before the row disappears under it.
+    fn gc_inactive_workers(&mut self, now: Tick, gc_ticks: u64) -> Result<(), StorageError>;
+
+    /// Run one full scheduling cycle: clean up departed workers (drop the stale mappings of
+    /// inactive workers, promote orphaned drains), tombstone expired chunks, expire stale
     /// mappings, run `algorithm` in-process, diff + commit results.
     ///
     /// Returns the published `WorkerAssignment` (ideal ∪ stale); call
@@ -234,7 +242,8 @@ pub trait SchedulerStorage {
     ) -> Result<ReadSchemaId, StorageError>;
 
     /// Register a new chunk replacement for an old chunk. New chunk must have the same block range
-    /// as the old chunk. A production path now — reorgs drive it.
+    /// as the old chunk. Reorgs drive it, but in production through metadata-service, which writes
+    /// the same rows; this entry point has no service caller yet.
     fn register_correction(
         &mut self,
         old_pk: ChunkPk,

--- a/src/scheduler_storage/postgres/mod.rs
+++ b/src/scheduler_storage/postgres/mod.rs
@@ -1,8 +1,29 @@
 //! PostgreSQL-backed implementation of [`SchedulerStorage`].
 //!
-//! Single [`PgConnection`], no pool — the scheduler runs cycles sequentially.
-//! The connection holds an advisory lock for the struct's lifetime, so only one
-//! scheduler instance runs at a time; dropping the struct releases it.
+//! Single [`PgConnection`], no pool — each instance serves one loop, which runs
+//! its calls sequentially. [`PostgresStorage::connect`] is the leader: it holds a session advisory
+//! lock for the struct's lifetime (admission control, so a second instance fails fast), migrates,
+//! then claims the next leadership [`Epoch`]. [`PostgresStorage::connect_follower`] needs that
+//! epoch and covers the instance's secondary loops. Every mutating path re-reads the epoch inside
+//! its own transaction and fails with [`StorageError::FencedOut`] once a newer leader claimed one,
+//! so a demoted instance cannot commit no matter what its connections are still doing.
+//!
+//! # Ownership map
+//!
+//! The instance's connections interleave without any cross-connection lock because each table has
+//! exactly one writing connection:
+//!
+//! * **worker connection** — `sched_workers` status columns only, plus the confirmation tables it
+//!   solely owns (its diff replay consumes ids strictly below those a running cycle mints).
+//! * **ingest writers** — the chunk-discovery connection and metadata-service: append-only,
+//!   new-key rows. They never UPDATE/DELETE a row the cycle writes.
+//! * **scheduling connection** — every UPDATE/DELETE of existing `sched_*` rows: the scheduling
+//!   cycle (departed-worker cleanup included), the visibility cycle, worker GC, and — once wired —
+//!   the corrections consumer.
+//!
+//! No two connections write the same row, so the cycle tables need no advisory lock and the only
+//! 40001 reachable is the fence's own row lock, which maps to `FencedOut`. The cycle's transactions
+//! run at REPEATABLE READ only to give their reads one snapshot.
 //!
 //! `Tick` values are logical integer timestamps stored in `BIGINT` columns;
 //! `m_ticks`/`gc_ticks` are raw tick counts used in integer arithmetic.
@@ -23,6 +44,7 @@ mod workers;
 mod tests;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
 
 use anyhow::Context;
 use sqlx::Connection;
@@ -39,10 +61,38 @@ use crate::types::{Dataset, DatasetSchema, DatasetWatermark, Worker};
 use nonoverlap::Candidate;
 use rows::tick_to_i64;
 
-/// Rows per batched write. Caps the jsonb payload and keeps a single statement under Postgres'
-/// per-value / message-size limits. The cycle's writes also need whole chunks to stay within one
-/// batch, or `array_agg` would split a chunk's holder set across statements.
-const DEFAULT_BATCH_SIZE: usize = 10_000;
+/// Rows per batched write, the default the CLI's `--batch-size` takes. Caps the jsonb payload and
+/// keeps a single statement under Postgres' per-value / message-size limits; the cycle's writes also
+/// need whole chunks to stay within one batch, or `array_agg` would split a chunk's holder set
+/// across statements.
+pub const DEFAULT_BATCH_SIZE: usize = 10_000;
+
+/// Cap on a leadership claim's wait for an in-flight fenced transaction (a scheduling cycle holds
+/// one for minutes) — the default the CLI's `--leadership-claim-timeout` takes, and what the tests
+/// connect with. Expiry surfaces as `AlreadyRunning`, i.e. "retry as a candidate".
+pub const DEFAULT_CLAIM_LOCK_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Session memory GUCs (`work_mem`/`maintenance_work_mem`) for one connection.
+#[derive(Clone, Copy, Debug)]
+pub enum SessionMemory {
+    /// 512MB, for the scheduling cycle's routing reads and the visibility queries.
+    Raised,
+    /// Server default, for connections running only small statements (chunk ingest).
+    ServerDefault,
+}
+
+/// Leadership fencing token. Only the claim in [`PostgresStorage::connect`] mints one, so a
+/// follower connection cannot be constructed without a leader's epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Epoch(i64);
+
+impl Epoch {
+    /// The raw counter, for reporting it. Not a constructor: an epoch still only comes from a
+    /// successful claim.
+    pub fn get(self) -> i64 {
+        self.0
+    }
+}
 
 /// Synchronous facade over a Postgres connection: owns a current-thread tokio
 /// runtime and drives all sqlx queries via `block_on`.
@@ -55,6 +105,7 @@ pub struct PostgresStorage {
     rt: tokio::runtime::Runtime,
     conn: std::cell::RefCell<PgConnection>,
     batch_size: usize,
+    fence: Epoch,
     /// Declared last so it drops after `conn`: the harness can only drop a database once this
     /// storage's connection to it is gone.
     #[cfg(any(test, feature = "pg-testkit"))]
@@ -62,48 +113,60 @@ pub struct PostgresStorage {
 }
 
 impl PostgresStorage {
-    /// Connect and acquire the scheduler advisory lock. Errors if another
-    /// scheduler already holds the lock.
-    pub fn connect(database_url: &str) -> Result<Self, StorageError> {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("build current-thread runtime")?;
-        let (conn, locked) = rt.block_on(async {
-            let mut conn = PgConnection::connect(database_url)
-                .await
-                .context("failed to connect to Postgres")?;
-            // Session-scoped GUCs, held for this connection's lifetime: raise sort/hash
-            // memory for the cycle's heavy routing and visibility queries.
-            for stmt in [
-                "SET work_mem = '512MB'",
-                "SET maintenance_work_mem = '512MB'",
-            ] {
-                sqlx::query(stmt)
-                    .execute(&mut conn)
-                    .await
-                    .with_context(|| format!("failed to run {stmt}"))?;
+    /// Connect as the leader: take the scheduler advisory lock, run the migrations, then claim the
+    /// next leadership epoch — the fence every write of this instance carries. Errors with
+    /// [`StorageError::AlreadyRunning`] if another scheduler holds the lock. `claim_lock_timeout`
+    /// caps how long the claim waits behind an in-flight fenced transaction before giving up as a
+    /// candidate; `batch_size` is the rows-per-batch cap this instance's batched writes use.
+    pub fn connect(
+        database_url: &str,
+        claim_lock_timeout: Duration,
+        batch_size: usize,
+    ) -> Result<(Self, Epoch), StorageError> {
+        let (rt, mut conn) = open(database_url, SessionMemory::Raised)?;
+        let epoch = rt.block_on(async {
+            if !try_acquire_scheduler_lock(&mut conn).await? {
+                return Err(StorageError::AlreadyRunning);
             }
-            // Advisory locks are cluster-wide, not per-database; scope the key to the
-            // current database, or per-test databases on one cluster collide on the lock.
-            let locked: bool = sqlx::query_scalar(
-                "SELECT pg_try_advisory_lock(hashtext('network-scheduler:' || current_database()))",
-            )
-            .fetch_one(&mut conn)
-            .await
-            .context("failed to acquire advisory lock")?;
-            Ok::<_, anyhow::Error>((conn, locked))
+            // Before the claim, since the claim needs the leadership row: a real schema change
+            // therefore runs while a demoted instance may still be writing, and serializes against
+            // it on the table locks its DDL takes.
+            scheduler_metadata::pg::MIGRATOR
+                .run(&mut conn)
+                .await
+                .context("migration failed")?;
+            claim_leadership(&mut conn, claim_lock_timeout).await
         })?;
-        if !locked {
-            return Err(StorageError::AlreadyRunning);
-        }
-        Ok(Self {
+        Ok((Self::fenced_by(rt, conn, epoch, batch_size), epoch))
+    }
+
+    /// An extra connection of the *same* instance (the service's secondary loops), fenced by the
+    /// leader's `epoch`: no advisory lock, no migrations. Its writes fail with
+    /// [`StorageError::FencedOut`] once a newer leader claims the epoch.
+    pub fn connect_follower(
+        database_url: &str,
+        memory: SessionMemory,
+        epoch: Epoch,
+        batch_size: usize,
+    ) -> Result<Self, StorageError> {
+        let (rt, conn) = open(database_url, memory)?;
+        Ok(Self::fenced_by(rt, conn, epoch, batch_size))
+    }
+
+    fn fenced_by(
+        rt: tokio::runtime::Runtime,
+        conn: PgConnection,
+        fence: Epoch,
+        batch_size: usize,
+    ) -> Self {
+        Self {
             rt,
             conn: std::cell::RefCell::new(conn),
-            batch_size: DEFAULT_BATCH_SIZE,
+            batch_size,
+            fence,
             #[cfg(any(test, feature = "pg-testkit"))]
             case_db: None,
-        })
+        }
     }
 
     /// Tie a harness database to this storage, so the case's database goes when the storage does.
@@ -111,17 +174,6 @@ impl PostgresStorage {
     pub(crate) fn owning(mut self, db: pg_testkit::CaseDb) -> Self {
         self.case_db = Some(db);
         self
-    }
-
-    /// Run pending sqlx migrations. Call once on startup before the scheduling loop.
-    pub fn migrate(&mut self) -> Result<(), StorageError> {
-        self.with_conn(async move |conn| {
-            scheduler_metadata::pg::MIGRATOR
-                .run(&mut *conn)
-                .await
-                .context("migration failed")?;
-            Ok::<_, StorageError>(())
-        })
     }
 
     /// Existing datasets, each with the S3-discovery watermark for its last chunk (its id and end
@@ -165,6 +217,37 @@ impl PostgresStorage {
         })
     }
 
+    /// Current confirmation watermark, 0 when nothing is confirmed — seeds the service's gate
+    /// across restarts.
+    pub fn worker_confirmation_watermark(&mut self) -> Result<AssignmentId, StorageError> {
+        self.with_conn(async move |conn| {
+            let watermark = sqlx::query_scalar(
+                "SELECT COALESCE(MAX(assignment_id), 0) FROM sched_worker_confirmations",
+            )
+            .fetch_one(&mut *conn)
+            .await
+            .context("fetch confirmation watermark")?;
+            Ok(watermark)
+        })
+    }
+
+    /// Liveness probe: round-trips the connection. An error means the connection (and with it the
+    /// advisory lock) is gone — this storage is unusable and the process must not keep retrying.
+    ///
+    /// `timeout` is required rather than defaulted: the failure this exists to catch includes a socket
+    /// that accepts writes and never answers: an unbounded probe would hang exactly where the
+    /// operation it is vouching for already hung. A timed-out probe leaves a request in flight, so
+    /// its verdict has to be final — which it is, since every caller treats a failure as fatal.
+    pub fn ping(&mut self, timeout: Duration) -> Result<(), StorageError> {
+        self.with_conn(async move |conn| {
+            tokio::time::timeout(timeout, conn.ping())
+                .await
+                .map_err(|_| anyhow::anyhow!("timed out after {timeout:?}"))?
+                .context("ping Postgres connection")?;
+            Ok(())
+        })
+    }
+
     /// Run an async query closure on the owned runtime with exclusive
     /// connection access. The `AsyncFnOnce` bound lets the future borrow the
     /// `&mut PgConnection` argument, which `FnOnce(_) -> Fut` cannot express.
@@ -193,14 +276,19 @@ impl PostgresStorage {
             return Ok(Vec::new());
         }
         let batch_size = self.batch_size;
+        let fence = self.fence;
         self.with_conn(async move |conn| {
-            scheduler_metadata::pg::correction::register_corrections(
-                conn,
+            // The shared helper opens its own transaction, which nests as a savepoint here.
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
+            let pks = scheduler_metadata::pg::correction::register_corrections(
+                &mut tx,
                 &corrections,
                 now,
                 batch_size,
             )
-            .await
+            .await?;
+            tx.commit().await.context("register_corrections: commit")?;
+            Ok(pks)
         })
     }
 
@@ -208,15 +296,159 @@ impl PostgresStorage {
     /// `register_new_chunks` admits the clones. Returns the number of clones.
     #[cfg(any(test, feature = "pg-testkit"))]
     pub fn copy_dataset_chunks(&mut self, src: &str, dst: &str) -> Result<u64, StorageError> {
-        self.with_conn(async move |conn| testkit::copy_dataset_chunks(conn, src, dst).await)
+        let fence = self.fence;
+        self.with_conn(async move |conn| {
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
+            let cloned = testkit::copy_dataset_chunks(&mut tx, src, dst).await?;
+            tx.commit().await.context("copy_dataset_chunks: commit")?;
+            Ok(cloned)
+        })
     }
+}
+
+/// A connection and the runtime driving it, with this connection's session GUCs applied.
+fn open(
+    database_url: &str,
+    memory: SessionMemory,
+) -> Result<(tokio::runtime::Runtime, PgConnection), StorageError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build current-thread runtime")?;
+    let conn = rt.block_on(async {
+        let mut conn = PgConnection::connect(database_url)
+            .await
+            .context("failed to connect to Postgres")?;
+        if matches!(memory, SessionMemory::Raised) {
+            // Session-scoped GUCs, held for this connection's lifetime.
+            for stmt in [
+                "SET work_mem = '512MB'",
+                "SET maintenance_work_mem = '512MB'",
+            ] {
+                sqlx::query(stmt)
+                    .execute(&mut conn)
+                    .await
+                    .with_context(|| format!("failed to run {stmt}"))?;
+            }
+        }
+        Ok::<_, anyhow::Error>(conn)
+    })?;
+    Ok((rt, conn))
+}
+
+/// Take the singleton scheduler session lock, held for the connection's lifetime. `false` means
+/// another instance holds it — cheap admission control, so a second instance fails fast instead of
+/// stealing leadership from a healthy one. Advisory locks are cluster-wide, not per-database; the
+/// key is scoped to the current database, or per-test databases on one cluster would collide on it.
+async fn try_acquire_scheduler_lock(conn: &mut PgConnection) -> anyhow::Result<bool> {
+    sqlx::query_scalar(
+        "SELECT pg_try_advisory_lock(hashtext('network-scheduler:' || current_database()))",
+    )
+    .fetch_one(&mut *conn)
+    .await
+    .context("failed to acquire advisory lock")
+}
+
+/// Claim leadership by bumping the epoch. Blocks behind any in-flight fenced transaction's
+/// `FOR SHARE`, so the previous leader's last write either commits before this claim or is refused
+/// after it — bounded by `lock_timeout`, because a hung startup hides worse than a retryable
+/// `AlreadyRunning`.
+async fn claim_leadership(
+    conn: &mut PgConnection,
+    lock_timeout: Duration,
+) -> Result<Epoch, StorageError> {
+    let mut tx = conn.begin().await.context("begin leadership claim")?;
+    // `SET LOCAL`: the cap belongs to this claim, not to every later statement on the connection.
+    // A bare integer is milliseconds to Postgres' `lock_timeout`.
+    let lock_timeout_ms = lock_timeout.as_millis();
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SET LOCAL lock_timeout = '{lock_timeout_ms}'"
+    )))
+    .execute(&mut *tx)
+    .await
+    .context("cap the leadership claim's wait")?;
+    let claim = sqlx::query_scalar(
+        "UPDATE sched_leadership SET epoch = epoch + 1, leader_pid = pg_backend_pid() \
+         WHERE only_row RETURNING epoch",
+    )
+    .fetch_one(&mut *tx)
+    .await;
+    let epoch: i64 = match claim {
+        Ok(epoch) => epoch,
+        // Someone else's write is still in flight; the caller retries as a fresh candidate.
+        Err(e) if scheduler_metadata::pg::rows::is_lock_timeout(&e) => {
+            return Err(StorageError::AlreadyRunning);
+        }
+        Err(e) => {
+            return Err(anyhow::Error::new(e)
+                .context("claim leadership epoch")
+                .into());
+        }
+    };
+    tx.commit().await.context("commit leadership claim")?;
+    Ok(Epoch(epoch))
+}
+
+/// Begin a transaction and check the fence, in one place because both matter to every write.
+///
+/// The `FOR SHARE` holds the leadership row for the transaction's lifetime, so a concurrent claim
+/// parks until we finish: no fenced write can commit after a new leader believes it is exclusive.
+/// It is also the transaction's first read, so it fixes the REPEATABLE READ snapshot — for which
+/// the isolation level must already be set (`SET TRANSACTION` only accepts a virgin transaction).
+async fn begin_fenced(
+    conn: &mut PgConnection,
+    fence: Epoch,
+    isolation: Isolation,
+) -> Result<sqlx::Transaction<'_, sqlx::Postgres>, StorageError> {
+    let mut tx = conn.begin().await.context("begin transaction")?;
+    if matches!(isolation, Isolation::RepeatableRead) {
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+            .execute(&mut *tx)
+            .await
+            .context("set transaction isolation level")?;
+    }
+    let read = sqlx::query_scalar("SELECT epoch FROM sched_leadership WHERE only_row FOR SHARE")
+        .fetch_one(&mut *tx)
+        .await;
+    let current: i64 = match read {
+        Ok(epoch) => epoch,
+        // Under REPEATABLE READ, parking on a claim that then commits raises 40001 — the same event
+        // as a plain mismatch. The row lock is already released with the aborted transaction.
+        Err(e) if scheduler_metadata::pg::rows::is_serialization_failure(&e) => {
+            return Err(StorageError::FencedOut);
+        }
+        Err(e) => {
+            return Err(anyhow::Error::new(e)
+                .context("read leadership epoch")
+                .into());
+        }
+    };
+    if Epoch(current) != fence {
+        // Roll back explicitly: dropping a transaction only queues the `ROLLBACK` until the
+        // connection is next used, and a fenced-out caller never uses it again — the `FOR SHARE`
+        // would go on parking the new leader's claim.
+        tx.rollback().await.context("release the fence")?;
+        return Err(StorageError::FencedOut);
+    }
+    Ok(tx)
+}
+
+/// Isolation level for a fenced transaction.
+#[derive(Clone, Copy, Debug)]
+enum Isolation {
+    /// No `SET`: the session default (READ COMMITTED), which re-snapshots per statement.
+    ServerDefault,
+    /// One snapshot for the whole transaction, so the cycle's placement read, its stale-mint worker
+    /// filter, and its cleanup predicates see the same worker set.
+    RepeatableRead,
 }
 
 impl SchedulerStorage for PostgresStorage {
     fn insert_new_datasets(&mut self, datasets: Vec<NewDataset>) -> Result<(), StorageError> {
+        let fence = self.fence;
         self.with_conn(async move |conn| -> Result<(), StorageError> {
             let mut timer = PhaseTimer::new("insert_new_datasets");
-            let mut tx = conn.begin().await.context("insert_new_datasets: begin")?;
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
             for NewDataset {
                 name,
                 location,
@@ -247,8 +479,9 @@ impl SchedulerStorage for PostgresStorage {
         dataset: &str,
         dataset_schema: DatasetSchema,
     ) -> Result<(), StorageError> {
+        let fence = self.fence;
         self.with_conn(async move |conn| -> Result<(), StorageError> {
-            let mut tx = conn.begin().await.context("set_dataset_schema: begin")?;
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
             let dataset_id: Option<DatasetPk> =
                 sqlx::query_scalar("SELECT id FROM datasets WHERE name = $1")
                     .bind(dataset)
@@ -321,16 +554,25 @@ impl SchedulerStorage for PostgresStorage {
 
     fn insert_new_chunks(&mut self, chunks: Vec<NewChunk>) -> Result<(), StorageError> {
         let batch_size = self.batch_size;
+        let fence = self.fence;
         self.with_conn(async move |conn| {
-            scheduler_metadata::pg::registration::insert_chunks(conn, &chunks, batch_size).await
+            // The shared helper opens its own transaction, which nests as a savepoint here.
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
+            scheduler_metadata::pg::registration::insert_chunks(&mut tx, &chunks, batch_size)
+                .await?;
+            tx.commit().await.context("insert_new_chunks: commit")?;
+            Ok(())
         })
     }
 
     fn register_new_chunks(&mut self) -> Result<Vec<ChunkPk>, StorageError> {
+        let fence = self.fence;
         self.with_conn(async move |conn| {
             let _timer = Timer::new("register_new_chunks");
+            // One transaction, so admission is atomic as well as fenced.
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
 
-            let candidate_rows = admission::fetch_candidates(conn).await?;
+            let candidate_rows = admission::fetch_candidates(&mut tx).await?;
             let admission::Classified {
                 exempt,
                 candidates,
@@ -339,7 +581,7 @@ impl SchedulerStorage for PostgresStorage {
 
             // Reject candidates overlapping a live chunk in their dataset (indexed SQL probe), then
             // settle overlaps within the batch (two new chunks covering the same range).
-            let conflicting = nonoverlap::overlapping_live(&mut *conn, &candidates).await?;
+            let conflicting = nonoverlap::overlapping_live(&mut tx, &candidates).await?;
             let (clear, mut rejected): (Vec<Candidate>, Vec<Candidate>) = candidates
                 .into_iter()
                 .partition(|c| !conflicting.contains(&c.pk));
@@ -350,13 +592,14 @@ impl SchedulerStorage for PostgresStorage {
 
             let mut admitted = exempt;
             admitted.extend(&accepted);
-            admission::persist_admitted(conn, &admitted).await?;
+            admission::persist_admitted(&mut tx, &admitted).await?;
             let rejected_pks: Vec<ChunkPk> = rejected
                 .iter()
                 .chain(&range_rejected)
                 .map(|c| c.pk)
                 .collect();
-            admission::persist_rejected(conn, &rejected_pks).await?;
+            admission::persist_rejected(&mut tx, &rejected_pks).await?;
+            tx.commit().await.context("register_new_chunks: commit")?;
 
             Ok::<_, StorageError>(admitted)
         })
@@ -366,8 +609,8 @@ impl SchedulerStorage for PostgresStorage {
         &mut self,
         active_workers: &[Worker],
         now: Tick,
-        gc_ticks: u64,
     ) -> Result<(), StorageError> {
+        let fence = self.fence;
         self.with_conn(async move |conn| {
             let _timer = Timer::new("update_worker_set");
             let peer_ids: Vec<String> = active_workers.iter().map(|w| w.id.to_string()).collect();
@@ -376,14 +619,24 @@ impl SchedulerStorage for PostgresStorage {
                 .map(|w| w.version.as_ref().map(|v| v.to_string()))
                 .collect();
 
-            let mut tx = conn.begin().await.context("update_worker_set: begin")?;
+            // Status columns only (see the module's ownership map); a departure's mapping-table
+            // consequences are settled by the scheduling cycle, keyed on `inactive_since`.
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
             workers::upsert_active(&mut tx, &peer_ids, &versions).await?;
-            let departed = workers::mark_departed(&mut tx, &peer_ids, now).await?;
-            workers::delete_stale_mappings(&mut tx, &departed).await?;
-            workers::promote_orphaned_drains(&mut tx, &departed).await?;
-            workers::gc_inactive(&mut tx, now, gc_ticks).await?;
+            workers::mark_departed(&mut tx, &peer_ids, now).await?;
             tx.commit().await.context("update_worker_set: commit")?;
 
+            Ok::<_, StorageError>(())
+        })
+    }
+
+    fn gc_inactive_workers(&mut self, now: Tick, gc_ticks: u64) -> Result<(), StorageError> {
+        let fence = self.fence;
+        self.with_conn(async move |conn| {
+            // Server default, not RR: the DELETE must re-snapshot (see `workers::gc_inactive_workers`).
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
+            workers::gc_inactive_workers(&mut tx, now, gc_ticks).await?;
+            tx.commit().await.context("gc_inactive_workers: commit")?;
             Ok::<_, StorageError>(())
         })
     }
@@ -401,14 +654,15 @@ impl SchedulerStorage for PostgresStorage {
         use scheduling_cycle as phase;
 
         let batch_size = self.batch_size;
+        let fence = self.fence;
         self.with_conn(async move |conn| {
             let _timer = Timer::new("run_scheduling_cycle");
-            // Phase A — clock-driven GC, committed up front so it survives a Phase B
-            // shortage rollback; otherwise stale never drains under a sustained shortage.
-            let mut gc_tx = conn
-                .begin()
-                .await
-                .context("run_scheduling_cycle: begin gc")?;
+            // Phase A — departed-worker cleanup, then clock-driven GC, committed up front so it
+            // survives a Phase B shortage rollback; otherwise stale never drains under a
+            // sustained shortage. The promotion must run before the expiry — rescue before reaper.
+            let mut gc_tx = begin_fenced(conn, fence, Isolation::RepeatableRead).await?;
+            workers::delete_inactive_stale_mappings(&mut gc_tx).await?;
+            workers::promote_orphaned_drains(&mut gc_tx).await?;
             phase::tombstone_expired_chunks(&mut gc_tx, now, m_ticks).await?;
             phase::expire_drained_stale_mappings(&mut gc_tx, now, m_ticks).await?;
             gc_tx
@@ -417,7 +671,7 @@ impl SchedulerStorage for PostgresStorage {
                 .context("run_scheduling_cycle: commit gc")?;
 
             // Phase B — placement reconcile; rolls back on shortage, leaving Phase A committed.
-            let mut tx = conn.begin().await.context("run_scheduling_cycle: begin")?;
+            let mut tx = begin_fenced(conn, fence, Isolation::RepeatableRead).await?;
 
             // One streamed round-trip decoding the algorithm's inputs and the published chunk
             // columns together, so the post-commit assignment build needn't re-read them.
@@ -490,17 +744,20 @@ impl SchedulerStorage for PostgresStorage {
                 };
             phase::persist_assignment_schemas(&mut tx, &published_schema_ids).await?;
 
+            // Read before commit: the tx sees its own writes, so the published assignment is
+            // exactly what this commit makes live; a post-commit read takes a fresh snapshot.
+            let stale_holders = phase::fetch_stale_holders(&mut tx).await?;
+
             tx.commit().await.context("run_scheduling_cycle: commit")?;
 
             let wa = phase::build_worker_assignment(
-                conn,
                 new_wa_id,
                 workers_map,
                 replication_by_weight,
                 ideal_mappings,
                 published_chunks,
-            )
-            .await?;
+                stale_holders,
+            );
             Ok::<_, StorageError>(wa)
         })
     }
@@ -512,12 +769,10 @@ impl SchedulerStorage for PostgresStorage {
     ) -> Result<(), StorageError> {
         use visibility as phase;
 
+        let fence = self.fence;
         self.with_conn(async move |conn| {
             let _timer = Timer::new("confirm_worker_assignment");
-            let mut tx = conn
-                .begin()
-                .await
-                .context("confirm_worker_assignment: begin")?;
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
 
             let prev = phase::confirmation_watermark(&mut tx).await?;
 
@@ -542,9 +797,10 @@ impl SchedulerStorage for PostgresStorage {
     fn run_visibility_cycle(&mut self, now: Tick) -> Result<PortalAssignment, StorageError> {
         use visibility as phase;
 
+        let fence = self.fence;
         self.with_conn(async move |conn| {
             let _timer = Timer::new("run_visibility_cycle");
-            let mut tx = conn.begin().await.context("run_visibility_cycle: begin")?;
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
 
             // Watermark read first so the portal assignment records it (activates drains).
             let confirmed_up_to = phase::confirmation_watermark(&mut tx).await?;
@@ -586,16 +842,19 @@ impl SchedulerStorage for PostgresStorage {
     }
 
     fn mark_for_removal(&mut self, chunk_pk: ChunkPk, now: Tick) -> Result<(), StorageError> {
+        let fence = self.fence;
         self.with_conn(async move |conn| {
             let mut timer = PhaseTimer::new("mark_for_removal");
+            let mut tx = begin_fenced(conn, fence, Isolation::ServerDefault).await?;
             let res = sqlx::query(
                 "UPDATE sched_chunk_metadata SET marked_for_removal = $2 WHERE chunk_pk = $1",
             )
             .bind(chunk_pk)
             .bind(tick_to_i64(now))
-            .execute(&mut *conn)
+            .execute(&mut *tx)
             .await
             .context("mark_for_removal")?;
+            tx.commit().await.context("mark_for_removal: commit")?;
             timer.stmt(res.rows_affected());
             Ok::<_, StorageError>(())
         })

--- a/src/scheduler_storage/postgres/scheduling_cycle.rs
+++ b/src/scheduler_storage/postgres/scheduling_cycle.rs
@@ -1,5 +1,5 @@
 //! Phase helpers for [`PostgresStorage::run_scheduling_cycle`], run inside the
-//! cycle's transaction, plus the post-commit [`build_worker_assignment`] read.
+//! cycle's transaction, plus the post-commit in-memory [`build_worker_assignment`].
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
@@ -9,7 +9,6 @@ use futures::TryStreamExt;
 use itertools::Itertools as _;
 use rustc_hash::{FxHashMap, FxHashSet};
 use semver::Version;
-use sqlx::postgres::PgConnection;
 use sqlx::{Postgres, Transaction};
 
 use crate::metrics::{PhaseTimer, Timer};
@@ -299,7 +298,10 @@ pub(super) async fn apply_deltas_and_swap(
 ///   4. Cancel self-resolved removals: a pair the new ideal takes back was never really leaving,
 ///      so its drain (and the clock on it) must not outlive the decision.
 ///   5. Start the lifecycle of newcomers: a chunk's first appearance in an ideal is the anchor
-///      that later gates its portal promotion and schema-bundle membership (ADR 0002).
+///      that later gates its portal promotion and schema-bundle membership (ADR 0002). Chunks
+///      already marked for removal are skipped: promotion is closed to them anyway — their rows
+///      belong to the removal tail (`drop_marked_chunks`, run by the visibility cycle on this
+///      same connection).
 ///   6. Make the new ideal live: swap the staged twin in, leaving the old table empty and ready
 ///      to stage the next cycle.
 const SQL_DELTAS_AND_SWAP: &str = r#"
@@ -339,7 +341,8 @@ UPDATE sched_chunk_metadata m
 SET applied_at_worker_assignment_id = $WA
 FROM sched_future_ideal_chunk_workers f
 WHERE m.chunk_pk = f.chunk_pk
-  AND m.applied_at_worker_assignment_id IS NULL;
+  AND m.applied_at_worker_assignment_id IS NULL
+  AND m.marked_for_removal IS NULL;
 
 TRUNCATE sched_ideal_chunk_workers;
 ALTER TABLE sched_ideal_chunk_workers RENAME TO sched_ideal_chunk_workers__swap;
@@ -458,27 +461,34 @@ pub(super) fn decode_workers(worker_rows: &[WorkerRow]) -> Result<DecodedWorkers
     })
 }
 
+/// Post-delta stale holders: pre-existing rows plus this cycle's mint, minus resolved flip-flops
+/// and phase-A drops — i.e. exactly what the cycle's commit publishes. Read inside the cycle
+/// transaction, which sees its own writes.
+pub(super) async fn fetch_stale_holders(
+    tx: &mut Transaction<'_, Postgres>,
+) -> Result<Vec<(ChunkPk, Vec<WorkerPk>)>> {
+    let mut timer = PhaseTimer::new("run_scheduling_cycle:fetch_stale_holders");
+    let stale: Vec<(ChunkPk, Vec<WorkerPk>)> = sqlx::query_as(
+        "SELECT chunk_pk, array_agg(worker_id) FROM sched_stale_mappings GROUP BY chunk_pk",
+    )
+    .fetch_all(&mut **tx)
+    .await
+    .context("run_scheduling_cycle: fetch stale holders")?;
+    timer.stmt(stale.len() as u64);
+    Ok(stale)
+}
+
 /// Post-commit assembly of the published WorkerAssignment: ideal ∪ stale, excluding tombstoned
 /// chunks.
-pub(super) async fn build_worker_assignment(
-    conn: &mut PgConnection,
+pub(super) fn build_worker_assignment(
     id: AssignmentId,
     workers: BTreeMap<WorkerPk, AssignmentWorker>,
     replication_by_weight: BTreeMap<u16, u16>,
     ideal_mappings: Vec<(ChunkPk, Vec<WorkerPk>)>,
     mut active_chunks: FxHashMap<ChunkPk, WorkerAssignmentChunk>,
-) -> Result<WorkerAssignment> {
-    let mut timer = PhaseTimer::new("run_scheduling_cycle:build_worker_assignment");
-    // Post-delta stale holders: pre-existing rows plus this cycle's mint, minus resolved
-    // flip-flops and phase-A drops — i.e. exactly what the committed table now holds.
-    let stale: Vec<(ChunkPk, Vec<WorkerPk>)> = sqlx::query_as(
-        "SELECT chunk_pk, array_agg(worker_id) FROM sched_stale_mappings GROUP BY chunk_pk",
-    )
-    .fetch_all(&mut *conn)
-    .await
-    .context("build_worker_assignment: fetch stale holders")?;
-    timer.stmt(stale.len() as u64);
-
+    stale: Vec<(ChunkPk, Vec<WorkerPk>)>,
+) -> WorkerAssignment {
+    let _timer = Timer::new("run_scheduling_cycle:build_worker_assignment");
     let mut chunk_workers: BTreeMap<ChunkPk, Vec<WorkerPk>> = ideal_mappings.into_iter().collect();
     for (pk, extra) in stale {
         // Keep holder sets canonical (sorted, distinct), as the SQL merge did.
@@ -500,11 +510,11 @@ pub(super) async fn build_worker_assignment(
         None => false,
     });
 
-    Ok(WorkerAssignment {
+    WorkerAssignment {
         id,
         chunk_workers,
         chunks: chunks_out,
         workers,
         replication_by_weight,
-    })
+    }
 }

--- a/src/scheduler_storage/postgres/tests/correction_tests.rs
+++ b/src/scheduler_storage/postgres/tests/correction_tests.rs
@@ -312,7 +312,7 @@ fn register_corrections_batch_registers_all_and_swaps() {
     let pk_b = insert_and_register_chunk(&mut storage, "ds", 2, 100);
 
     storage
-        .update_worker_set(&[worker(1, None)], 0, 1000)
+        .update_worker_set(&[worker(1, None)], 0)
         .expect("upsert worker");
     let worker_ids: Vec<WorkerPk> = storage
         .get_workers(|_| true)
@@ -401,7 +401,7 @@ fn correction_chain_link_held_until_producer_fires() {
     let pk_a = insert_and_register_chunk(&mut storage, "ds", 1, 100);
 
     storage
-        .update_worker_set(&[worker(1, None)], 0, 1000)
+        .update_worker_set(&[worker(1, None)], 0)
         .expect("upsert worker");
     let worker_ids: Vec<WorkerPk> = storage
         .get_workers(|_| true)
@@ -457,7 +457,7 @@ proptest! {
 
         let workers: Vec<Worker> = (1..=n_workers).map(|s| worker(s, None)).collect();
         storage
-            .update_worker_set(&workers, 0, 10000)
+            .update_worker_set(&workers, 0)
             .expect("upsert workers");
         let worker_ids: Vec<WorkerPk> = storage
             .get_workers(|_| true)

--- a/src/scheduler_storage/postgres/tests/drain_tests.rs
+++ b/src/scheduler_storage/postgres/tests/drain_tests.rs
@@ -43,7 +43,7 @@ impl DrainFixture {
         insert_and_register_chunk(&mut storage, "ds", 2, 100);
         insert_and_register_chunk(&mut storage, "ds", 3, 100);
         let workers: Vec<Worker> = (1..=5).map(|s| worker(s, None)).collect();
-        storage.update_worker_set(&workers, 0, 1000).unwrap();
+        storage.update_worker_set(&workers, 0).unwrap();
         Self { storage, target }
     }
 

--- a/src/scheduler_storage/postgres/tests/ingest_tests.rs
+++ b/src/scheduler_storage/postgres/tests/ingest_tests.rs
@@ -17,7 +17,9 @@ use scheduler_metadata::{
 };
 
 use crate::scheduler_storage::SchedulerStorage;
-use crate::scheduler_storage::postgres::PostgresStorage;
+use crate::scheduler_storage::postgres::{
+    DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT, PostgresStorage,
+};
 use crate::scheduler_storage::test_harness::pg_harness::{CaseDb, fresh_db_url};
 
 // --- inputs -----------------------------------------------------------------------------------
@@ -98,7 +100,9 @@ impl IngestHarness {
     /// Run one scheduler registration sweep (admits/rejects the pending chunks). Sync context: it
     /// owns its own runtime, so calling it inside `block` would nest-panic.
     fn admit(&self) {
-        let mut store = PostgresStorage::connect(&self.url).expect("connect scheduler");
+        let (mut store, _) =
+            PostgresStorage::connect(&self.url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("connect scheduler");
         store.register_new_chunks().expect("register_new_chunks");
     }
 
@@ -106,7 +110,9 @@ impl IngestHarness {
     /// overlapping *pending* chunk for the admission sweep to reject (the API path rejects it
     /// synchronously). Sync context, like [`Self::admit`].
     fn discovery_insert(&self, ds: &str, id: &str, first: u64, last: u64, s: SchemaId) {
-        let mut store = PostgresStorage::connect(&self.url).expect("connect scheduler");
+        let (mut store, _) =
+            PostgresStorage::connect(&self.url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("connect scheduler");
         store
             .insert_new_chunks(vec![crate::scheduler_storage::NewChunk {
                 dataset: std::sync::Arc::new(ds.to_owned()),

--- a/src/scheduler_storage/postgres/tests/locks.rs
+++ b/src/scheduler_storage/postgres/tests/locks.rs
@@ -1,0 +1,327 @@
+//! Cross-connection leadership behaviour: the advisory-lock admission check, the epoch fence every
+//! write carries, and the worker-GC row-lock race with a concurrent reactivation.
+
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use sqlx::Connection as _;
+
+use super::TEST_ID;
+use crate::scheduler_storage::postgres::{
+    DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT, PostgresStorage, SessionMemory,
+};
+use crate::scheduler_storage::test_harness::pg_harness::fresh_db_url;
+use crate::scheduler_storage::test_harness::utils::worker;
+use crate::scheduler_storage::{SchedulerStorage, StorageError};
+
+/// The advisory lock is admission control only: a second leader is refused while the first's
+/// connection lives, regardless of the epoch.
+#[test]
+fn a_second_leader_is_refused_while_the_first_connection_lives() {
+    let (url, _db) = fresh_db_url("locks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+    let (leader, _) =
+        PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+            .expect("leader connects");
+    assert!(
+        matches!(
+            PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE),
+            Err(StorageError::AlreadyRunning)
+        ),
+        "a second leader must be refused while the first lives"
+    );
+
+    drop(leader);
+    PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+        .expect("replacement leader once the connection is gone");
+}
+
+/// A follower carries its leader's epoch, so it stops writing the moment a replacement leader claims
+/// the next one — no dependency on the old leader's connections disappearing. Its reads are
+/// unfenced and keep working.
+#[test]
+fn follower_with_a_stale_epoch_is_fenced_out_but_still_reads() {
+    let (url, _db) = fresh_db_url("locks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+    let (leader, epoch) =
+        PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+            .expect("leader connects");
+    let mut follower = PostgresStorage::connect_follower(
+        &url,
+        SessionMemory::ServerDefault,
+        epoch,
+        DEFAULT_BATCH_SIZE,
+    )
+    .expect("follower connects with the leader's epoch");
+    follower
+        .update_worker_set(&[worker(1, None)], 100)
+        .expect("the follower writes under the current epoch");
+
+    // Dropping the leader frees the singleton lock; the replacement claims the next epoch.
+    drop(leader);
+    let (_replacement, next) =
+        PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+            .expect("replacement leader connects");
+    assert_ne!(next, epoch, "the claim must mint a fresh epoch");
+
+    assert!(
+        matches!(
+            follower.update_worker_set(&[worker(2, None)], 200),
+            Err(StorageError::FencedOut)
+        ),
+        "the demoted instance's follower must not commit"
+    );
+    assert_eq!(
+        follower
+            .datasets_with_last_chunk()
+            .expect("reads stay unfenced")
+            .len(),
+        0
+    );
+}
+
+/// Pins the `FOR SHARE` in `begin_fenced`: while a fenced transaction is in flight, a leadership
+/// claim *parks* on the leadership row — observed via `pg_stat_activity`, not timing — and only
+/// succeeds once that transaction commits. Without it a new leader could believe it is exclusive
+/// while the old one's write is still uncommitted.
+#[test]
+fn an_in_flight_fenced_transaction_blocks_a_leadership_claim() {
+    let (url, _db) = fresh_db_url("locks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+    let (mut storage, epoch) =
+        PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+            .expect("leader connects");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("build test runtime");
+    rt.block_on(async {
+        // A fenced write held open on its own thread: the fence read is taken, the row lock is held,
+        // and the commit waits for `release`.
+        let (proceed, release) = std::sync::mpsc::channel::<()>();
+        let write = std::thread::spawn(move || {
+            storage.with_conn(async move |conn| {
+                let mut tx =
+                    super::super::begin_fenced(conn, epoch, super::super::Isolation::ServerDefault)
+                        .await?;
+                sqlx::query("UPDATE sched_workers SET version = NULL")
+                    .execute(&mut *tx)
+                    .await
+                    .expect("write inside the fenced tx");
+                release.recv().expect("wait for the observer");
+                tx.commit().await.expect("commit the fenced tx");
+                Ok::<_, StorageError>(())
+            })
+        });
+
+        // The competing claim, raw SQL: a second `connect` would fast-fail on the advisory lock long
+        // before reaching the claim.
+        let claim = {
+            let url = url.clone();
+            tokio::spawn(async move {
+                let mut conn = sqlx::postgres::PgConnection::connect(&url)
+                    .await
+                    .expect("claiming connection");
+                sqlx::query_scalar::<_, i64>(
+                    "UPDATE sched_leadership SET epoch = epoch + 1, leader_pid = pg_backend_pid() \
+                     WHERE only_row RETURNING epoch",
+                )
+                .fetch_one(&mut conn)
+                .await
+                .expect("claim leadership")
+            })
+        };
+
+        // Provably parked on the leadership row's lock (each test runs in its own database, so the
+        // filter can't pick up a neighbour's wait).
+        let mut observer = sqlx::postgres::PgConnection::connect(&url)
+            .await
+            .expect("observer connection");
+        let mut polls = 0u32;
+        loop {
+            let waiting: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM pg_stat_activity \
+                 WHERE datname = current_database() AND wait_event_type = 'Lock'",
+            )
+            .fetch_one(&mut observer)
+            .await
+            .expect("poll lock waits");
+            if waiting > 0 {
+                break;
+            }
+            assert!(
+                !claim.is_finished(),
+                "the claim finished without parking on the leadership row"
+            );
+            polls += 1;
+            assert!(polls < 100, "the claim never parked on the leadership row");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        proceed.send(()).expect("release the fenced write");
+        write.join().expect("write thread").expect("fenced write");
+        let claimed = claim.await.expect("claim task");
+        assert_eq!(
+            claimed,
+            epoch.0 + 1,
+            "the claim lands the next epoch, once the fenced write let it through"
+        );
+    });
+}
+
+/// The 40001 the fence can raise: under REPEATABLE READ the fence read parks on an uncommitted
+/// claim's row lock, and once that claim commits Postgres refuses the now-outdated snapshot. That is
+/// the same event as a plain epoch mismatch, so it must surface as `FencedOut`, not `Serialization`.
+#[test]
+fn a_repeatable_read_fence_check_maps_40001_to_fenced_out() {
+    let (url, _db) = fresh_db_url("locks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+    let (mut storage, epoch) =
+        PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+            .expect("leader connects");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("build test runtime");
+    rt.block_on(async {
+        // An uncommitted claim holding the leadership row.
+        let mut claimer = sqlx::postgres::PgConnection::connect(&url)
+            .await
+            .expect("claiming connection");
+        let mut claim_tx = claimer.begin().await.expect("begin claim");
+        sqlx::query(
+            "UPDATE sched_leadership SET epoch = epoch + 1, leader_pid = pg_backend_pid() \
+             WHERE only_row",
+        )
+        .execute(&mut *claim_tx)
+        .await
+        .expect("claim leadership (uncommitted)");
+
+        // A REPEATABLE READ fenced transaction on its own thread: its fence read must park.
+        let cycle = std::thread::spawn(move || {
+            storage.with_conn(async move |conn| {
+                super::super::begin_fenced(conn, epoch, super::super::Isolation::RepeatableRead)
+                    .await
+                    .map(|_| ())
+            })
+        });
+
+        let mut observer = sqlx::postgres::PgConnection::connect(&url)
+            .await
+            .expect("observer connection");
+        let mut polls = 0u32;
+        loop {
+            let waiting: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM pg_stat_activity \
+                 WHERE datname = current_database() AND wait_event_type = 'Lock'",
+            )
+            .fetch_one(&mut observer)
+            .await
+            .expect("poll lock waits");
+            if waiting > 0 {
+                break;
+            }
+            assert!(
+                !cycle.is_finished(),
+                "the fence read finished without parking on the claim"
+            );
+            polls += 1;
+            assert!(polls < 100, "the fence read never parked on the claim");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        claim_tx.commit().await.expect("commit the claim");
+        assert!(
+            matches!(
+                cycle.join().expect("cycle thread"),
+                Err(StorageError::FencedOut)
+            ),
+            "40001 on the fence read is a lost-leadership event"
+        );
+    });
+}
+
+/// Pins the designed resolution of the GC-vs-reactivation race (no advisory lock, no 40001):
+/// `gc_inactive_workers`'s READ COMMITTED DELETE matches the inactive row version, *parks* on
+/// the row lock of an uncommitted reactivating UPDATE — observed via `pg_stat_activity`'s lock
+/// wait, not timing — and on commit re-evaluates its predicate against the new row version
+/// (EvalPlanQual), skipping the returning worker. Deterministically red if the DELETE stops
+/// re-checking: the worker row would vanish despite the committed reactivation.
+#[test]
+fn worker_gc_spares_a_concurrently_reactivated_worker() {
+    let (url, _db) = fresh_db_url("locks", TEST_ID.fetch_add(1, Ordering::Relaxed));
+    let (mut storage, _) =
+        PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+            .expect("connect");
+    storage
+        .update_worker_set(&[worker(1, None)], 100)
+        .expect("register the worker");
+    storage
+        .update_worker_set(&[], 200)
+        .expect("mark it inactive at 200");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("build test runtime");
+    rt.block_on(async {
+        // The reactivation: an open transaction holding the worker's row lock.
+        let mut reactivate = sqlx::postgres::PgConnection::connect(&url)
+            .await
+            .expect("reactivating connection");
+        let mut tx = reactivate.begin().await.expect("begin reactivation");
+        sqlx::query("UPDATE sched_workers SET inactive_since = NULL")
+            .execute(&mut *tx)
+            .await
+            .expect("reactivate the worker (uncommitted)");
+
+        // GC on its own thread (`PostgresStorage` is sync): its DELETE matches the committed
+        // inactive version (200 < 1000 - 60) and must park on the row lock.
+        let gc = std::thread::spawn(move || storage.gc_inactive_workers(1000, 60));
+
+        // Provably parked on the row lock (each test runs in its own database, so the filter
+        // can't pick up a neighbour's wait).
+        let mut observer = sqlx::postgres::PgConnection::connect(&url)
+            .await
+            .expect("observer connection");
+        let mut polls = 0u32;
+        loop {
+            let waiting: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM pg_stat_activity \
+                 WHERE datname = current_database() AND wait_event_type = 'Lock'",
+            )
+            .fetch_one(&mut observer)
+            .await
+            .expect("poll lock waits");
+            if waiting > 0 {
+                break;
+            }
+            assert!(
+                !gc.is_finished(),
+                "gc finished without parking on the reactivated row's lock"
+            );
+            polls += 1;
+            assert!(polls < 100, "gc never parked on the row lock");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        tx.commit().await.expect("commit the reactivation");
+        gc.join()
+            .expect("gc thread")
+            .expect("gc completes once the reactivation commits");
+
+        let (total, active): (i64, i64) = sqlx::query_as(
+            "SELECT count(*), count(*) FILTER (WHERE inactive_since IS NULL) \
+             FROM sched_workers",
+        )
+        .fetch_one(&mut observer)
+        .await
+        .expect("read the worker row back");
+        assert_eq!(
+            (total, active),
+            (1, 1),
+            "the DELETE must re-evaluate its predicate and spare the reactivated worker"
+        );
+    });
+}

--- a/src/scheduler_storage/postgres/tests/mod.rs
+++ b/src/scheduler_storage/postgres/tests/mod.rs
@@ -5,6 +5,7 @@ mod correction_tests;
 mod drain_tests;
 mod ingest_tests;
 mod inspect;
+mod locks;
 mod registration_tests;
 mod schema;
 mod worker_tests;

--- a/src/scheduler_storage/postgres/tests/registration_tests.rs
+++ b/src/scheduler_storage/postgres/tests/registration_tests.rs
@@ -53,7 +53,9 @@ fn concurrent_multi_dataset_inserts_do_not_deadlock() {
     use crate::scheduler_storage::{NewChunk, SchemaId};
     use sqlx::Connection;
 
-    use crate::scheduler_storage::postgres::PostgresStorage;
+    use crate::scheduler_storage::postgres::{
+        DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT, PostgresStorage,
+    };
     use crate::scheduler_storage::test_harness::pg_harness::fresh_db_url;
 
     fn nc(ds: &str, id: String, schema_id: SchemaId) -> NewChunk {
@@ -78,7 +80,9 @@ fn concurrent_multi_dataset_inserts_do_not_deadlock() {
     // dataset's current schema id (chunks must pin one), then drop the storage so its scheduler
     // session lock is released before the raw writers connect.
     let (schema_a, schema_b) = {
-        let mut seed = PostgresStorage::connect(&url).expect("connect seed");
+        let (mut seed, _) =
+            PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+                .expect("connect seed");
         seed.insert_new_datasets(vec![
             new_dataset("a", DatasetSchema::default()),
             new_dataset("b", DatasetSchema::default()),

--- a/src/scheduler_storage/postgres/tests/schema.rs
+++ b/src/scheduler_storage/postgres/tests/schema.rs
@@ -118,7 +118,7 @@ fn schedule_with_bundle(
 
 fn one_worker(storage: &mut PostgresStorage) -> Vec<WorkerPk> {
     storage
-        .update_worker_set(&[worker(1, None)], 0, 10_000)
+        .update_worker_set(&[worker(1, None)], 0)
         .expect("upsert workers");
     storage
         .get_workers(|_| true)

--- a/src/scheduler_storage/postgres/tests/worker_tests.rs
+++ b/src/scheduler_storage/postgres/tests/worker_tests.rs
@@ -29,16 +29,12 @@ fn resyncing_an_unchanged_worker_set_consumes_no_ids() {
     let mut storage = fresh_storage("worker_seq");
     let active: Vec<Worker> = (1..=8).map(|seed| worker(seed, Some("2.8.0"))).collect();
 
-    storage
-        .update_worker_set(&active, 1, 100)
-        .expect("first sync");
+    storage.update_worker_set(&active, 1).expect("first sync");
     let after_first = ids_consumed(&mut storage);
     assert_eq!(after_first, 8, "one id per worker on first registration");
 
     for tick in 2..=10 {
-        storage
-            .update_worker_set(&active, tick, 100)
-            .expect("re-sync");
+        storage.update_worker_set(&active, tick).expect("re-sync");
     }
     assert_eq!(
         ids_consumed(&mut storage),

--- a/src/scheduler_storage/postgres/workers.rs
+++ b/src/scheduler_storage/postgres/workers.rs
@@ -1,11 +1,12 @@
-//! Phase helpers for [`PostgresStorage::update_worker_set`], run inside the
-//! update's transaction.
+//! Worker-row helpers, split across their callers: [`PostgresStorage::update_worker_set`] (status
+//! columns only), the scheduling cycle's phase A ([`delete_inactive_stale_mappings`],
+//! [`promote_orphaned_drains`] — keyed on `sched_workers.inactive_since`), and
+//! [`PostgresStorage::gc_inactive_workers`].
 
 use anyhow::{Context, Result};
-use sqlx::{Postgres, Row, Transaction};
+use sqlx::{Postgres, Transaction};
 
 use crate::metrics::PhaseTimer;
-use crate::scheduler_storage::WorkerPk;
 
 use super::rows::tick_to_i64;
 
@@ -60,50 +61,49 @@ pub(super) async fn upsert_active(
     Ok(())
 }
 
-/// Stamp `inactive_since` on workers no longer in the active set, returning the ones newly departed.
-/// `inactive_since IS NULL` keeps the original timestamp and stops already-inactive workers from
-/// being re-reported as departed.
+/// Stamp `inactive_since` on workers no longer in the active set.
+/// `inactive_since IS NULL` keeps the original timestamp on already-inactive workers, so a
+/// departure's clock starts once. Departed workers' mapping-table state is settled later, by the
+/// scheduling cycle's state-based cleanup.
 pub(super) async fn mark_departed(
     tx: &mut Transaction<'_, Postgres>,
     peer_ids: &[String],
     now: u64,
-) -> Result<Vec<WorkerPk>> {
+) -> Result<()> {
     let mut timer = PhaseTimer::new("update_worker_set:mark_departed");
-    let rows = sqlx::query(
+    let res = sqlx::query(
         r#"
         UPDATE sched_workers
         SET inactive_since = $2
         WHERE NOT (peer_id = ANY($1))
           AND inactive_since IS NULL
-        RETURNING id
         "#,
     )
     .bind(peer_ids)
     .bind(tick_to_i64(now))
-    .fetch_all(&mut **tx)
+    .execute(&mut **tx)
     .await
     .context("update_worker_set: mark departed")?;
-    timer.stmt(rows.len() as u64);
-    Ok(rows
-        .iter()
-        .map(|row| row.get::<WorkerPk, _>("id"))
-        .collect())
+    timer.stmt(res.rows_affected());
+    Ok(())
 }
 
-/// Drop stale mappings held by workers that just departed.
-pub(super) async fn delete_stale_mappings(
+/// Drop stale mappings held by inactive workers. State-based: any departure detected by an earlier
+/// `update_worker_set` is settled here, whether it happened one tick or several cycles ago.
+pub(super) async fn delete_inactive_stale_mappings(
     tx: &mut Transaction<'_, Postgres>,
-    departed: &[WorkerPk],
 ) -> Result<()> {
-    if departed.is_empty() {
-        return Ok(());
-    }
-    let mut timer = PhaseTimer::new("update_worker_set:delete_stale_mappings");
-    let res = sqlx::query("DELETE FROM sched_stale_mappings WHERE worker_id = ANY($1)")
-        .bind(departed)
-        .execute(&mut **tx)
-        .await
-        .context("update_worker_set: delete stale mappings")?;
+    let mut timer = PhaseTimer::new("run_scheduling_cycle:delete_inactive_stale_mappings");
+    let res = sqlx::query(
+        r#"
+        DELETE FROM sched_stale_mappings st
+        USING sched_workers w
+        WHERE w.id = st.worker_id AND w.inactive_since IS NOT NULL
+        "#,
+    )
+    .execute(&mut **tx)
+    .await
+    .context("run_scheduling_cycle: delete inactive stale mappings")?;
     timer.stmt(res.rows_affected());
     Ok(())
 }
@@ -119,23 +119,18 @@ pub(super) async fn delete_stale_mappings(
 /// No follow-up needed: leftover copies become ordinary drains next cycle, and the departed workers'
 /// ideal rows drop out with the next diff.
 ///
-/// Run after [`mark_departed`] (departures now visible) and [`delete_stale_mappings`] (every leftover
-/// stale row belongs to an active worker).
-pub(super) async fn promote_orphaned_drains(
-    tx: &mut Transaction<'_, Postgres>,
-    departed: &[WorkerPk],
-) -> Result<()> {
-    if departed.is_empty() {
-        return Ok(());
-    }
-    let mut timer = PhaseTimer::new("update_worker_set:promote_orphaned_drains");
+/// Runs in phase A of every cycle, after [`delete_inactive_stale_mappings`] (every leftover stale
+/// row belongs to an active worker, which the promoted CTE also enforces) and structurally before
+/// [`expire_drained_stale_mappings`](super::scheduling_cycle::expire_drained_stale_mappings) — the
+/// rescue precedes the reaper.
+pub(super) async fn promote_orphaned_drains(tx: &mut Transaction<'_, Postgres>) -> Result<()> {
+    let mut timer = PhaseTimer::new("run_scheduling_cycle:promote_orphaned_drains");
     let res = sqlx::query(
         r#"
         WITH orphaned AS (
             SELECT i.chunk_pk
             FROM sched_ideal_chunk_workers i
-            WHERE i.worker_ids && $1
-              AND cardinality(i.worker_ids) > 0
+            WHERE cardinality(i.worker_ids) > 0
               AND NOT EXISTS (
                   SELECT 1 FROM sched_workers w
                   WHERE w.id = ANY(i.worker_ids) AND w.inactive_since IS NULL
@@ -162,27 +157,29 @@ pub(super) async fn promote_orphaned_drains(
         WHERE i.chunk_pk = p.chunk_pk
         "#,
     )
-    .bind(departed)
     .execute(&mut **tx)
     .await
-    .context("update_worker_set: promote orphaned drains")?;
+    .context("run_scheduling_cycle: promote orphaned drains")?;
     timer.stmt(res.rows_affected());
     Ok(())
 }
 
-/// Delete workers inactive for longer than `gc_ticks`.
-pub(super) async fn gc_inactive(
+/// Delete workers inactive for longer than `gc_ticks`; the FK cascade takes their stale mappings
+/// along. Deliberately a single READ COMMITTED statement, never REPEATABLE READ: a concurrent
+/// reactivation then resolves via the row lock — the DELETE waits, re-checks `inactive_since`
+/// against the new row version, and skips the returning worker.
+pub(super) async fn gc_inactive_workers(
     tx: &mut Transaction<'_, Postgres>,
     now: u64,
     gc_ticks: u64,
 ) -> Result<()> {
-    let mut timer = PhaseTimer::new("update_worker_set:gc_inactive");
+    let mut timer = PhaseTimer::new("gc_inactive_workers");
     let res = sqlx::query("DELETE FROM sched_workers WHERE inactive_since < $1 - $2")
         .bind(tick_to_i64(now))
         .bind(tick_to_i64(gc_ticks))
         .execute(&mut **tx)
         .await
-        .context("update_worker_set: gc workers")?;
+        .context("gc_inactive_workers")?;
     timer.stmt(res.rows_affected());
     Ok(())
 }

--- a/src/scheduler_storage/test_harness/pg_harness.rs
+++ b/src/scheduler_storage/test_harness/pg_harness.rs
@@ -6,7 +6,9 @@
 
 pub use pg_testkit::{CaseDb, PgData};
 
-use crate::scheduler_storage::postgres::PostgresStorage;
+use crate::scheduler_storage::postgres::{
+    DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT, PostgresStorage,
+};
 
 /// Backing the test suite uses: tiny per-case DBs in RAM.
 #[cfg(test)]
@@ -33,9 +35,10 @@ pub(crate) fn fresh_db_url(prefix: &str, id: u64) -> (String, CaseDb) {
 /// backing for the shared container; later calls reuse it.
 pub fn fresh_db_with(pgdata: PgData, prefix: &str, id: u64) -> PostgresStorage {
     let (url, db) = pg_testkit::fresh_db_url(pgdata, prefix, id);
-    PostgresStorage::connect(&url)
-        .expect("connect fresh db")
-        .owning(db)
+    let (storage, _epoch) =
+        PostgresStorage::connect(&url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)
+            .expect("connect fresh db");
+    storage.owning(db)
 }
 
 #[cfg(test)]

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -18,13 +18,7 @@ use crate::{
 /// Chunk indices assigned to each worker.
 type WorkerChunks = BTreeMap<PeerId, Vec<ChunkIndex>>;
 
-#[derive(Debug, Clone)]
-pub struct SchedulingConfig {
-    pub worker_capacity: u64,
-    pub saturation: f64,
-    pub min_replication: ReplicationFactor,
-    pub ignore_reliability: bool,
-}
+pub use crate::types::SchedulingConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScheduledChunk<'a> {

--- a/src/types/assignment.rs
+++ b/src/types/assignment.rs
@@ -216,11 +216,13 @@ mod tests {
         cli::Config {
             datasets: BTreeMap::new(),
             worker_inactive_timeout: Duration::from_secs(600),
-            ignore_reliability: false,
-            worker_storage_bytes: 0,
+            scheduling: crate::types::SchedulingConfig {
+                worker_capacity: 0,
+                saturation: 0.99,
+                min_replication: 1,
+                ignore_reliability: false,
+            },
             worker_stale_bytes: 0,
-            min_replication: 1,
-            saturation: 0.99,
             network: "test".to_string(),
             storage_domain: "test.io".to_string(),
             network_state_name: "test.json".to_string(),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -13,6 +13,23 @@ pub type ChunkWeight = u16;
 pub type ReplicationFactor = u16;
 pub type BlockNumber = u64;
 
+/// Scheduling knobs shared by the legacy and multistep schedulers, embedded verbatim in the
+/// config file (flattened into `cli::Config`) — the serde attrs pin the deployed key names.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SchedulingConfig {
+    /// Per-worker capacity budget; the config-file key predates the field name.
+    #[serde(rename = "worker_storage_bytes")]
+    pub worker_capacity: u64,
+    /// The fraction of the worker storage that is actually filled (on average).
+    /// The closer it gets to 1, the less consistent the distribution is.
+    /// Corresponds to `1 / (1 + epsilon)` from this paper:
+    /// https://research.google/blog/consistent-hashing-with-bounded-loads/
+    pub saturation: f64,
+    pub min_replication: ReplicationFactor,
+    #[serde(default)]
+    pub ignore_reliability: bool,
+}
+
 /// A dataset's id, e.g. `s3://ethereum-mainnet-1`. Shared (`Arc`) — the same id rides along with
 /// every chunk of the dataset.
 pub type DatasetId = Arc<String>;

--- a/tools/reshuffle_sim/src/main.rs
+++ b/tools/reshuffle_sim/src/main.rs
@@ -23,7 +23,7 @@ mod util;
 
 use anyhow::Context;
 use clap::Parser;
-use network_scheduler::{cli::Config, scheduling::SchedulingConfig};
+use network_scheduler::cli::Config;
 use rand::prelude::*;
 
 use crate::profile::Scheduler;
@@ -65,12 +65,7 @@ fn main() -> anyhow::Result<()> {
         simulation::register_copy_dataset(plan, &baseline, &mut config.datasets)?;
     }
 
-    let scheduling_config = SchedulingConfig {
-        worker_capacity: config.worker_storage_bytes,
-        saturation: config.saturation,
-        min_replication: config.min_replication,
-        ignore_reliability: config.ignore_reliability,
-    };
+    let scheduling_config = config.scheduling.clone();
 
     // Copies are scheduler-specific: multistep clones them from Postgres, stateless replays them.
     let mut sim_copies = Vec::new();

--- a/tools/reshuffle_sim/src/multistep.rs
+++ b/tools/reshuffle_sim/src/multistep.rs
@@ -18,7 +18,7 @@ use network_scheduler::{
         WorkerAssignment, WorkerAssignmentChunk, WorkerPk,
         algorithm::MultistepAlgorithm,
         discovered_chunk,
-        postgres::PostgresStorage,
+        postgres::{DEFAULT_BATCH_SIZE, DEFAULT_CLAIM_LOCK_TIMEOUT, PostgresStorage},
         test_harness::pg_harness::{self, PgData},
     },
     types::{Chunk, DatasetSchema},
@@ -66,9 +66,10 @@ struct Backend {
 
 fn existing_database(url: &str) -> anyhow::Result<Backend> {
     tracing::info!("Connecting to Postgres at {url}");
-    Ok(Backend {
-        storage: connect_migrated(url)?,
-    })
+    // Its own leader; the sim is the only writer of the database it is pointed at.
+    let (storage, _epoch) =
+        PostgresStorage::connect(url, DEFAULT_CLAIM_LOCK_TIMEOUT, DEFAULT_BATCH_SIZE)?;
+    Ok(Backend { storage })
 }
 
 /// Disk-backed because the mainnet DB overflows the harness tmpfs.
@@ -77,12 +78,6 @@ fn ephemeral_database() -> Backend {
     Backend {
         storage: pg_harness::fresh_db_with(PgData::Disk, "reshuffle_sim", 0),
     }
-}
-
-fn connect_migrated(url: &str) -> anyhow::Result<PostgresStorage> {
-    let mut storage = PostgresStorage::connect(url)?;
-    storage.migrate()?;
-    Ok(storage)
 }
 
 /// What [`MultistepScheduler::build`] does with the baseline data before scheduling.
@@ -169,10 +164,8 @@ impl MultistepScheduler {
             backend,
             algo: MultistepAlgorithm::new(config.datasets.clone()),
             config: MultistepConfig {
-                worker_capacity: config.worker_storage_bytes,
-                saturation: config.saturation,
-                min_replication: config.min_replication,
                 ignore_reliability: true,
+                ..config.scheduling.clone()
             },
             clock: 0,
             ingested_chunks,
@@ -378,9 +371,14 @@ impl StepScheduler for MultistepScheduler {
 
     fn step(&mut self, ctx: StepContext) -> anyhow::Result<StepOutcome> {
         self.algo.set_weight_strategy(ctx.datasets_config.clone());
+        // Like the one-shot controller path: status update, then GC (rows stamped inactive at an
+        // earlier clock are collected; this step's departures survive until the next step).
         self.backend
             .storage
-            .update_worker_set(ctx.workers, self.clock, GC_TICKS)?;
+            .update_worker_set(ctx.workers, self.clock)?;
+        self.backend
+            .storage
+            .gc_inactive_workers(self.clock, GC_TICKS)?;
 
         self.current_step += 1;
 
@@ -501,9 +499,7 @@ fn seed_baseline(
             .map(|name| NewDataset::with_name(name.clone(), name, DatasetSchema::default()))
             .collect(),
     )?;
-    backend
-        .storage
-        .update_worker_set(&baseline.workers, 0, GC_TICKS)?;
+    backend.storage.update_worker_set(&baseline.workers, 0)?;
     tracing::info!(
         "Seeded {dataset_count} datasets and {} workers",
         baseline.workers.len()


### PR DESCRIPTION
## What this PR is?

`RunMode::Service`: three periodic tasks — scheduling, worker-status and chunk-discovery — each owning its own Postgres connection, with a leadership epoch fencing every write so a displaced scheduler cannot write behind its successor.

- **Scheduling task** holds the leader connection (advisory lock, migrations, epoch claim). Each tick runs the scheduling cycle, regenerates the schema bundle, GCs inactive workers, then runs the visibility cycle.
- **Worker-status task** refreshes the worker set and advances the confirmation watermark from worker-echoed assignment ids.
- **Chunk-discovery task** does S3 discovery and chunk registration.
- **Ops surface**: `/metrics`, `/health`, `/ready` backed by per-task heartbeats; SIGTERM drains, SIGINT exits immediately.
- **Storage**: lock-free worker/cycle split so every table has exactly one writing connection, plus connection probing while a task waits for its next tick.
- **CLI** secrets are no longer held as plain `String`